### PR TITLE
Format Springmvc & Tomcat EntrySpan operation name to `METHOD:URI`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,8 @@ Release Notes.
 * Implement Kafka Log Reporter. Add config item of `agnt.conf`, `plugin.kafka.topic_logging`.
 * Upgrade byte-buddy to 1.11.18
 * Add plugin to support Apache HttpClient 5.
-* Format SpringMVC & Tomcat EntrySpan operation name to `METHOD:URI`
+* Format SpringMVC & Tomcat EntrySpan operation name to `METHOD:URI`.
+* Make `HTTP method` in the operation name according to runtime, rather than previous code-level definition, which used to have possibilities including multiple HTTP methods.
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Release Notes.
 * Implement Kafka Log Reporter. Add config item of `agnt.conf`, `plugin.kafka.topic_logging`.
 * Upgrade byte-buddy to 1.11.18
 * Add plugin to support Apache HttpClient 5.
+* Format Springmvc & Tomcat EntrySpan operation name to `METHOD:URI`
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@ Release Notes.
 * Implement Kafka Log Reporter. Add config item of `agnt.conf`, `plugin.kafka.topic_logging`.
 * Upgrade byte-buddy to 1.11.18
 * Add plugin to support Apache HttpClient 5.
-* Format Springmvc & Tomcat EntrySpan operation name to `METHOD:URI`
+* Format SpringMVC & Tomcat EntrySpan operation name to `METHOD:URI`
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/spring/mvc/v4/RequestMappingMethodInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/spring/mvc/v4/RequestMappingMethodInterceptorTest.java
@@ -101,6 +101,7 @@ public class RequestMappingMethodInterceptorTest {
         when(request.getServerPort()).thenReturn(8080);
         when(request.getRequestURI()).thenReturn("/test/testRequestURL");
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/testRequestURL"));
+        when(request.getMethod()).thenReturn("GET");
         when(response.getStatus()).thenReturn(200);
 
         arguments = new Object[] {
@@ -168,7 +169,7 @@ public class RequestMappingMethodInterceptorTest {
     }
 
     private void assertHttpSpan(AbstractTracingSpan span) {
-        assertThat(span.getOperationName(), is("/test/testRequestURL"));
+        assertThat(span.getOperationName(), is("GET:/test/testRequestURL"));
         assertComponent(span, ComponentsDefine.SPRING_MVC_ANNOTATION);
         SpanAssert.assertTag(span, 0, "http://localhost:8080/test/testRequestURL");
         assertThat(span.isEntry(), is(true));

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/spring/mvc/v4/RestMappingMethodInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/spring/mvc/v4/RestMappingMethodInterceptorTest.java
@@ -135,6 +135,7 @@ public class RestMappingMethodInterceptorTest {
                 Method m = mappingClass1.getClass().getMethod("getRequestURL");
                 when(request.getRequestURI()).thenReturn("/test/testRequestURL");
                 when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/getRequestURL"));
+                when(request.getMethod()).thenReturn("GET");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -147,7 +148,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{GET}", "/getRequestURL");
+        assertHttpSpan(spans.get(0), "GET:", "/getRequestURL");
     }
 
     @Test
@@ -160,6 +161,7 @@ public class RestMappingMethodInterceptorTest {
                 Method m = mappingClass1.getClass().getMethod("postRequestURL");
                 when(request.getRequestURI()).thenReturn("/test/testRequestURL");
                 when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/postRequestURL"));
+                when(request.getMethod()).thenReturn("POST");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -173,7 +175,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{POST}", "/postRequestURL");
+        assertHttpSpan(spans.get(0), "POST:", "/postRequestURL");
     }
 
     @Test
@@ -186,6 +188,7 @@ public class RestMappingMethodInterceptorTest {
                 Method m = mappingClass1.getClass().getMethod("putRequestURL");
                 when(request.getRequestURI()).thenReturn("/test/testRequestURL");
                 when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/putRequestURL"));
+                when(request.getMethod()).thenReturn("PUT");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -199,7 +202,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{PUT}", "/putRequestURL");
+        assertHttpSpan(spans.get(0), "PUT:", "/putRequestURL");
     }
 
     @Test
@@ -213,6 +216,7 @@ public class RestMappingMethodInterceptorTest {
                 when(request.getRequestURI()).thenReturn("/test/testRequestURL");
                 when(request.getRequestURL()).thenReturn(
                     new StringBuffer("http://localhost:8080/test/deleteRequestURL"));
+                when(request.getMethod()).thenReturn("DELETE");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -226,7 +230,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{DELETE}", "/deleteRequestURL");
+        assertHttpSpan(spans.get(0), "DELETE:", "/deleteRequestURL");
     }
 
     @Test
@@ -240,6 +244,7 @@ public class RestMappingMethodInterceptorTest {
                 when(request.getRequestURI()).thenReturn("/test/testRequestURL");
                 when(request.getRequestURL()).thenReturn(
                     new StringBuffer("http://localhost:8080/test/patchRequestURL"));
+                when(request.getMethod()).thenReturn("PATCH");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -252,7 +257,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{PATCH}", "/patchRequestURL");
+        assertHttpSpan(spans.get(0), "PATCH:", "/patchRequestURL");
     }
 
     @Test
@@ -265,6 +270,7 @@ public class RestMappingMethodInterceptorTest {
                 Method m = mappingClass1.getClass().getMethod("dummy");
                 when(request.getRequestURI()).thenReturn("/test");
                 when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test"));
+                when(request.getMethod()).thenReturn("GET");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -278,7 +284,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "", "");
+        assertHttpSpan(spans.get(0), "GET:", "");
     }
 
     @Test
@@ -291,6 +297,7 @@ public class RestMappingMethodInterceptorTest {
                 Method m = mappingClass1.getClass().getMethod("getRequestURL");
                 when(request.getRequestURI()).thenReturn("/test/testRequestURL");
                 when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/getRequestURL"));
+                when(request.getMethod()).thenReturn("GET");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -304,7 +311,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{GET}", "/getRequestURL");
+        assertHttpSpan(spans.get(0), "GET:", "/getRequestURL");
         List<LogDataEntity> logDataEntities = SpanHelper.getLogs(spans.get(0));
         assertThat(logDataEntities.size(), is(1));
         SpanAssert.assertException(logDataEntities.get(0), RuntimeException.class);
@@ -323,6 +330,7 @@ public class RestMappingMethodInterceptorTest {
                 when(request.getHeaderNames()).thenReturn(new Vector(Arrays.asList("Connection", "Cookie")).elements());
                 when(request.getHeaders("connection")).thenReturn(new Vector(Arrays.asList("keep-alive")).elements());
                 when(request.getHeaders("cookie")).thenReturn(new Vector(Arrays.asList("dummy cookies")).elements());
+                when(request.getMethod()).thenReturn("GET");
                 ServletRequestAttributes servletRequestAttributes = new ServletRequestAttributes(request, response);
                 RequestContextHolder.setRequestAttributes(servletRequestAttributes);
 
@@ -335,7 +343,7 @@ public class RestMappingMethodInterceptorTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
 
-        assertHttpSpan(spans.get(0), "{GET}", "/getRequestURL");
+        assertHttpSpan(spans.get(0), "GET:", "/getRequestURL");
         SpanAssert.assertTag(spans.get(0), 2, "connection=[keep-alive]");
     }
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/commons/interceptor/RequestMappingMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/commons/interceptor/RequestMappingMethodInterceptor.java
@@ -40,24 +40,4 @@ public class RequestMappingMethodInterceptor extends AbstractMethodInterceptor {
             return requestURL;
         });
     }
-
-    @Override
-    public String getAcceptedMethodTypes(Method method) {
-        return ParsePathUtil.recursiveParseMethodAnnotation(method, m -> {
-            RequestMapping methodRequestMapping = AnnotationUtils.getAnnotation(m, RequestMapping.class);
-            if (methodRequestMapping == null || methodRequestMapping.method().length == 0) {
-                return null;
-            }
-            StringBuilder methodTypes = new StringBuilder();
-            methodTypes.append("{");
-            for (int i = 0; i < methodRequestMapping.method().length; i++) {
-                methodTypes.append(methodRequestMapping.method()[i].toString());
-                if (methodRequestMapping.method().length > (i + 1)) {
-                    methodTypes.append(",");
-                }
-            }
-            methodTypes.append("}");
-            return methodTypes.toString();
-        });
-    }
 }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/commons/interceptor/RestMappingMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/commons/interceptor/RestMappingMethodInterceptor.java
@@ -77,23 +77,4 @@ public class RestMappingMethodInterceptor extends AbstractMethodInterceptor {
             return requestURL;
         });
     }
-
-    @Override
-    public String getAcceptedMethodTypes(Method method) {
-        return ParsePathUtil.recursiveParseMethodAnnotation(method, m -> {
-            if (AnnotationUtils.getAnnotation(m, GetMapping.class) != null) {
-                return "{GET}";
-            } else if (AnnotationUtils.getAnnotation(m, PostMapping.class) != null) {
-                return "{POST}";
-            } else if (AnnotationUtils.getAnnotation(m, PutMapping.class) != null) {
-                return "{PUT}";
-            } else if (AnnotationUtils.getAnnotation(m, DeleteMapping.class) != null) {
-                return "{DELETE}";
-            } else if (AnnotationUtils.getAnnotation(m, PatchMapping.class) != null) {
-                return "{PATCH}";
-            } else {
-                return null;
-            }
-        });
-    }
 }

--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/tomcat78x/TomcatInvokeInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/tomcat78x/TomcatInvokeInterceptor.java
@@ -74,8 +74,8 @@ public class TomcatInvokeInterceptor implements InstanceMethodsAroundInterceptor
             next = next.next();
             next.setHeadValue(request.getHeader(next.getHeadKey()));
         }
-
-        AbstractSpan span = ContextManager.createEntrySpan(request.getRequestURI(), contextCarrier);
+        String operationName =  String.join(":", request.getMethod(), request.getRequestURI());
+        AbstractSpan span = ContextManager.createEntrySpan(operationName, contextCarrier);
         Tags.URL.set(span, request.getRequestURL().toString());
         Tags.HTTP.METHOD.set(span, request.getMethod());
         span.setComponent(ComponentsDefine.TOMCAT);

--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/tomcat78x/TomcatInvokeInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/tomcat78x/TomcatInvokeInterceptorTest.java
@@ -87,6 +87,7 @@ public class TomcatInvokeInterceptorTest {
         when(request.getRequestURI()).thenReturn("/test/testRequestURL");
         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost:8080/test/testRequestURL"));
         when(response.getStatus()).thenReturn(200);
+        when(request.getMethod()).thenReturn("GET");
         arguments = new Object[] {
             request,
             response
@@ -174,7 +175,7 @@ public class TomcatInvokeInterceptorTest {
     }
 
     private void assertHttpSpan(AbstractTracingSpan span) {
-        assertThat(span.getOperationName(), is("/test/testRequestURL"));
+        assertThat(span.getOperationName(), is("GET:/test/testRequestURL"));
         assertComponent(span, ComponentsDefine.TOMCAT);
         SpanAssert.assertTag(span, 0, "http://localhost:8080/test/testRequestURL");
         assertThat(span.isEntry(), is(true));

--- a/test/e2e/case/base/e2e.yaml
+++ b/test/e2e/case/base/e2e.yaml
@@ -73,7 +73,7 @@ verify:
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql endpoint list --keyword=info --service-id=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql service ls|grep -B 1 'provider'|yq e '.[0].id' -)
       expected: expected/service-endpoint.yml
     # basic check: service endpoint metrics
-    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name endpoint_cpm --endpoint=/info --service=e2e-service-provider |yq e 'to_entries' -
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql metrics linear --name endpoint_cpm --endpoint=POST:/info --service=e2e-service-provider |yq e 'to_entries' -
       expected: expected/metrics-has-value.yml
 
     # native management: service instance list
@@ -88,7 +88,7 @@ verify:
     - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls
       expected: expected/traces-list.yml
     # native tracing: trace detail
-    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls|grep -A 5 '/info'|tail -n1|awk -F ' ' '{print $2}')
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace $(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls|grep -A 5 'POST:/info'|tail -n1|awk -F ' ' '{print $2}')
       expected: expected/trace-info-detail.yml
 
     # native event: event list
@@ -96,5 +96,5 @@ verify:
       expected: expected/event-list.yml
 
     # native log: logs list
-    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql logs list --service-id=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql service ls|grep -B 1 'provider'|yq e '.[0].id' -) --trace-id=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls|grep -A 5 '/info'|tail -n1|awk -F ' ' '{print $2}')
+    - query: swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql logs list --service-id=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql service ls|grep -B 1 'provider'|yq e '.[0].id' -) --trace-id=$(swctl --display yaml --base-url=http://${oap_host}:${oap_12800}/graphql trace ls|grep -A 5 'POST:/info'|tail -n1|awk -F ' ' '{print $2}')
       expected: expected/logs-list.yml

--- a/test/e2e/case/base/expected/service-endpoint.yml
+++ b/test/e2e/case/base/expected/service-endpoint.yml
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 {{- range .}}
-{{- if eq .name "/info" }}
-- id: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "/info" }}
-  name: /info
+{{- if eq .name "POST:/info" }}
+- id: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "POST:/info" }}
+  name: POST:/info
 {{- end}}
 {{- end}}

--- a/test/e2e/case/base/expected/trace-info-detail.yml
+++ b/test/e2e/case/base/expected/trace-info-detail.yml
@@ -35,7 +35,13 @@ spans:
     serviceinstancename: {{ notEmpty .serviceinstancename }}
     starttime: {{ gt .starttime 0 }}
     endtime: {{ gt .endtime 0 }}
-    endpointname: POST:/info
+    endpointname:
+    {{- if eq .type "Exit" }}
+      /info
+    {{- end }}
+    {{- if eq .type "Entry" }}
+      POST:/info
+    {{- end }}
     type: {{ notEmpty .type }}
     peer:
     {{- if eq .type "Exit" }}

--- a/test/e2e/case/base/expected/trace-info-detail.yml
+++ b/test/e2e/case/base/expected/trace-info-detail.yml
@@ -35,7 +35,7 @@ spans:
     serviceinstancename: {{ notEmpty .serviceinstancename }}
     starttime: {{ gt .starttime 0 }}
     endtime: {{ gt .endtime 0 }}
-    endpointname: /info
+    endpointname: POST:/info
     type: {{ notEmpty .type }}
     peer:
     {{- if eq .type "Exit" }}

--- a/test/e2e/case/base/expected/trace-users-detail.yml
+++ b/test/e2e/case/base/expected/trace-users-detail.yml
@@ -24,7 +24,7 @@ spans:
     serviceinstancename: {{ notEmpty .serviceinstancename }}
     starttime: {{ gt .starttime 0 }}
     endtime: {{ gt .endtime 0 }}
-    endpointname: /users
+    endpointname: POST:/users
     type: Entry
     peer: ""
     component: Tomcat

--- a/test/e2e/case/base/expected/traces-list.yml
+++ b/test/e2e/case/base/expected/traces-list.yml
@@ -32,11 +32,11 @@ traces:
   {{- if eq (index .endpointnames 0) "H2/JDBI/PreparedStatement/executeQuery" }}
     - H2/JDBI/PreparedStatement/executeQuery
   {{- end }}
-  {{- if eq (index .endpointnames 0) "/info" }}
-    - /info
+  {{- if eq (index .endpointnames 0) "POST:/info" }}
+    - POST:/info
   {{- end }}
-  {{- if eq (index .endpointnames 0) "/users" }}
-    - /users
+  {{- if eq (index .endpointnames 0) "POST:/users" }}
+    - POST:/users
   {{- end }}
   duration: {{ ge .duration 0 }}
   start: "{{ notEmpty .start}}"

--- a/test/plugin/scenarios/activemq-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/activemq-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: ActiveMQ/Queue/test/Producer
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: MQ
@@ -34,8 +33,7 @@ segmentItems:
       - {key: mq.broker, value: not null}
       - {key: mq.queue, value: test}
       skipAnalysis: 'false'
-    - operationName: /activemq-scenario/case/activemq
-      operationId: 0
+    - operationName: GET:/activemq-scenario/case/activemq
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -52,7 +50,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: ActiveMQ/Queue/test/Consumer
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: MQ
@@ -67,7 +64,7 @@ segmentItems:
       - {key: mq.queue, value: test}
       - {key: transmission.latency, value: not null}
       refs:
-      - {parentEndpoint: /activemq-scenario/case/activemq, networkAddress: not null,
+      - {parentEndpoint: GET:/activemq-scenario/case/activemq, networkAddress: not null,
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
         parentServiceInstance: not null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/apm-toolkit-trace-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/apm-toolkit-trace-scenario/config/expectedData.yaml
@@ -19,9 +19,17 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - {operationName: tool-kit-set-operation-name, parentSpanId: 0,
-      spanId: 1, spanLayer: Unknown, startTime: nq 0, endTime: nq 0,
-      componentId: 0, isError: false, spanType: Local, peer: '', skipAnalysis: true}
+    - operationName: tool-kit-set-operation-name
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: Unknown
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 0
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: true
     - operationName: test.apache.skywalking.apm.testcase.toolkit.controller.TestService.testTag()
       parentSpanId: 0
       spanId: 2
@@ -145,7 +153,7 @@ segmentItems:
       - {key: p2, value: '16'}
       - {key: username, value: lisi}
       skipAnalysis: 'true'
-    - operationName: /case/tool-kit
+    - operationName: GET:/case/tool-kit
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -169,7 +177,7 @@ segmentItems:
 
   - segmentId: not null
     spans:
-    - operationName: /case/asyncVisit/callable
+    - operationName: GET:/case/asyncVisit/callable
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -216,7 +224,7 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /case/tool-kit, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/case/tool-kit, networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: apm-toolkit-trace-scenario, traceId: not null}
       skipAnalysis: 'true'
@@ -237,7 +245,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'true'
     - operationName: Thread/org.apache.skywalking.apm.toolkit.trace.CallableWrapper/call
-
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -248,13 +255,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /case/tool-kit, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/case/tool-kit, networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: apm-toolkit-trace-scenario, traceId: not null}
       skipAnalysis: 'true'
   - segmentId: not null
     spans:
-    - operationName: /case/asyncVisit/runnable
+    - operationName: GET:/case/asyncVisit/runnable
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -301,13 +308,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /case/tool-kit, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/case/tool-kit, networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: apm-toolkit-trace-scenario, traceId: not null}
       skipAnalysis: 'true'
   - segmentId: not null
     spans:
-    - operationName: /case/asyncVisit/supplier
+    - operationName: GET:/case/asyncVisit/supplier
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/armeria-0.96minus-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/armeria-0.96minus-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /greet/skywalking
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -34,14 +33,13 @@ segmentItems:
       - {key: url, value: /greet/skywalking}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /greet/skywalking, networkAddress: '127.0.0.1:8085', refType: CrossProcess,
+      - {parentEndpoint: GET:/greet/skywalking, networkAddress: '127.0.0.1:8085', refType: CrossProcess,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /greet/skywalking
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -54,8 +52,7 @@ segmentItems:
       tags:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
-    - operationName: /greet/skywalking
-      operationId: 0
+    - operationName: GET:/greet/skywalking
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/armeria-0.96plus-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/armeria-0.96plus-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /greet/skywalking
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -34,14 +33,13 @@ segmentItems:
       - {key: url, value: /greet/skywalking}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /greet/skywalking, networkAddress: '127.0.0.1:8085', refType: CrossProcess,
+      - {parentEndpoint: GET:/greet/skywalking, networkAddress: '127.0.0.1:8085', refType: CrossProcess,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /greet/skywalking
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -54,8 +52,7 @@ segmentItems:
       tags:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
-    - operationName: /greet/skywalking
-      operationId: 0
+    - operationName: GET:/greet/skywalking
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/asynchttpclient-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/asynchttpclient-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: AsyncHttpClient/asynchttpclient/back
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -35,14 +34,13 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/asynchttpclient/back'}
               - {key: http.status_code, value: '200'}
-          - operationName: /asynchttpclient/case
-            operationId: 0
+          - operationName: GET:/asynchttpclient/case
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -52,14 +50,13 @@ segmentItems:
               - {key: http.method, value: GET}
       - segmentId: not null
         spans:
-          - operationName: /asynchttpclient/back
-            operationId: 0
+          - operationName: GET:/asynchttpclient/back
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -68,6 +65,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/asynchttpclient/back'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /asynchttpclient/case, networkAddress: 'localhost:8080',
+              - {parentEndpoint: GET:/asynchttpclient/case, networkAddress: 'localhost:8080',
                  refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not null,
                  parentService: asynchttpclient-scenario, traceId: not null}

--- a/test/plugin/scenarios/avro-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/avro-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: example.proto.Greeter.hello
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -40,11 +39,18 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - {operationName: example.proto.Greeter.hello, operationId: 0, parentSpanId: 0,
-      spanId: 1, spanLayer: RPCFramework, startTime: gt 0, endTime: gt 0, componentId: 83,
-      isError: false, spanType: Exit, peer: 'localhost/127.0.0.1:9018', skipAnalysis: 'false'}
-    - operationName: /avro-scenario/case/avro-scenario
-      operationId: 0
+    - operationName: example.proto.Greeter.hello
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: RPCFramework
+      startTime: gt 0
+      endTime: gt 0
+      componentId: 83
+      isError: false
+      spanType: Exit
+      peer: 'localhost/127.0.0.1:9018'
+      skipAnalysis: 'false'
+    - operationName: GET:/avro-scenario/case/avro-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/avro-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/avro-scenario/config/expectedData.yaml
@@ -30,7 +30,7 @@ segmentItems:
       spanType: Entry
       peer: ''
       refs:
-      - {parentEndpoint: /avro-scenario/case/avro-scenario, networkAddress: 'localhost/127.0.0.1:9018',
+      - {parentEndpoint: GET:/avro-scenario/case/avro-scenario, networkAddress: 'localhost/127.0.0.1:9018',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: avro-client, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/baidu-brpc-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/baidu-brpc-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: example.EchoService.Echo
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -38,7 +37,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: example.EchoService.Echo
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: RPCFramework
@@ -49,8 +47,7 @@ segmentItems:
       spanType: Exit
       peer: 127.0.0.1:1118
       skipAnalysis: 'false'
-    - operationName: /baidu-brpc-scenario/case/brpc
-      operationId: 0
+    - operationName: GET:/baidu-brpc-scenario/case/brpc
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/baidu-brpc-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/baidu-brpc-scenario/config/expectedData.yaml
@@ -30,7 +30,7 @@ segmentItems:
       spanType: Entry
       peer: ''
       refs:
-      - {parentEndpoint: /baidu-brpc-scenario/case/brpc, networkAddress: '127.0.0.1:1118',
+      - {parentEndpoint: GET:/baidu-brpc-scenario/case/brpc, networkAddress: '127.0.0.1:1118',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: baidu-brpc-scenario, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/canal-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/canal-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Canal/example
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -34,8 +33,7 @@ segmentItems:
       - {key: batchSize, value: '1000'}
       - {key: destination, value: example}
       skipAnalysis: 'false'
-    - operationName: /canal-scenario/case/canal-case
-      operationId: 0
+    - operationName: GET:/canal-scenario/case/canal-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/cassandra-java-driver-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/cassandra-java-driver-3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 1
       spanId: 2
       spanLayer: Database
@@ -34,7 +33,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -51,7 +49,6 @@ segmentItems:
           = {''class'': ''SimpleStrategy'', ''replication_factor'': 1}'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 3
       spanId: 4
       spanLayer: Database
@@ -65,7 +62,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -82,7 +78,6 @@ segmentItems:
           KEY, value TEXT)'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 5
       spanId: 6
       spanLayer: Database
@@ -96,7 +91,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -112,7 +106,6 @@ segmentItems:
       - {key: db.statement, value: 'INSERT INTO demo.test(id, value) VALUES(?,?)'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 7
       spanId: 8
       spanLayer: Database
@@ -126,7 +119,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Database
@@ -142,7 +134,6 @@ segmentItems:
       - {key: db.statement, value: 'SELECT * FROM demo.test WHERE id = ?'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 9
       spanId: 10
       spanLayer: Database
@@ -156,7 +147,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 9
       spanLayer: Database
@@ -172,7 +162,6 @@ segmentItems:
       - {key: db.statement, value: 'DELETE FROM demo.test WHERE id = ?'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 11
       spanId: 12
       spanLayer: Database
@@ -186,7 +175,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 11
       spanLayer: Database
@@ -202,7 +190,6 @@ segmentItems:
       - {key: db.statement, value: DROP TABLE IF EXISTS demo.test}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 13
       spanId: 14
       spanLayer: Database
@@ -216,7 +203,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 13
       spanLayer: Database
@@ -232,7 +218,6 @@ segmentItems:
       - {key: db.statement, value: DROP KEYSPACE IF EXISTS demo}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 15
       spanLayer: Database
@@ -249,7 +234,6 @@ segmentItems:
           = {''class'': ''SimpleStrategy'', ''replication_factor'': 1}'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 16
       spanLayer: Database
@@ -263,7 +247,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 17
       spanLayer: Database
@@ -280,7 +263,6 @@ segmentItems:
           KEY, value TEXT)'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 18
       spanLayer: Database
@@ -294,7 +276,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 19
       spanLayer: Database
@@ -310,7 +291,6 @@ segmentItems:
       - {key: db.statement, value: 'INSERT INTO demo.test(id, value) VALUES(?,?)'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 20
       spanLayer: Database
@@ -324,7 +304,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 21
       spanLayer: Database
@@ -340,7 +319,6 @@ segmentItems:
       - {key: db.statement, value: 'SELECT * FROM demo.test WHERE id = ?'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 22
       spanLayer: Database
@@ -354,7 +332,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 23
       spanLayer: Database
@@ -370,7 +347,6 @@ segmentItems:
       - {key: db.statement, value: 'DELETE FROM demo.test WHERE id = ?'}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 24
       spanLayer: Database
@@ -384,7 +360,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 25
       spanLayer: Database
@@ -400,7 +375,6 @@ segmentItems:
       - {key: db.statement, value: DROP TABLE IF EXISTS demo.test}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 26
       spanLayer: Database
@@ -414,7 +388,6 @@ segmentItems:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
     - operationName: Cassandra/executeAsync
-      operationId: 0
       parentSpanId: 0
       spanId: 27
       spanLayer: Database
@@ -430,7 +403,6 @@ segmentItems:
       - {key: db.statement, value: DROP KEYSPACE IF EXISTS demo}
       skipAnalysis: 'false'
     - operationName: Cassandra/getUninterruptibly
-      operationId: 0
       parentSpanId: 0
       spanId: 28
       spanLayer: Database
@@ -443,8 +415,7 @@ segmentItems:
       tags:
       - {key: db.type, value: cassandra}
       skipAnalysis: 'false'
-    - operationName: /cassandra-java-driver-3.x-scenario/case/cassandra
-      operationId: 0
+    - operationName: GET:/cassandra-java-driver-3.x-scenario/case/cassandra
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/correlation-autotag-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/correlation-autotag-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /correlation-autotag-scenario/case/healthCheck
-            operationId: 0
+          - operationName: HEAD:/correlation-autotag-scenario/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -36,11 +35,18 @@ segmentItems:
               - {key: http.method, value: HEAD}
       - segmentId: 78a0cdef42a74b4ba80b48bf72b8558d.37.16042096947740000
         spans:
-          - {operationName: Greeter.sayHello, operationId: 0, parentSpanId: 0, spanId: 1,
-             spanLayer: RPCFramework, startTime: gt 0, endTime: gt 0, componentId: 23,
-             isError: false, spanType: Exit, peer: '127.0.0.1:18080', skipAnalysis: false}
-          - operationName: /correlation-autotag-scenario/case/correlation-autotag-scenario
-            operationId: 0
+          - operationName: Greeter.sayHello
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: RPCFramework
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 23
+            isError: false
+            spanType: Exit
+            peer: '127.0.0.1:18080'
+            skipAnalysis: false
+          - operationName: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -59,7 +65,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -74,7 +79,7 @@ segmentItems:
               - {key: autotag1, value: '1'}
               - {key: autotag2, value: '1'}
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '127.0.0.1:18080', refType: CrossProcess, parentSpanId: 1,
                  parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
@@ -82,7 +87,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Request/onComplete
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -94,14 +98,13 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '', refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -113,14 +116,13 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '', refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -132,14 +134,13 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '', refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/server/Response/onMessage
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -151,7 +152,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: Greeter.sayHello/server/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -170,7 +170,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/server/Response/onMessage
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -182,7 +181,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: Greeter.sayHello/server/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -201,7 +199,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/server/Response/onClose
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -215,7 +212,6 @@ segmentItems:
             tags:
               - {key: rpc.status_code, value: OK}
           - operationName: Greeter.sayHello/server/Request/onComplete
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -234,7 +230,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Response/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -246,14 +241,13 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '', refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Response/onClose
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -265,14 +259,13 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '', refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Response/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -284,7 +277,7 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: /correlation-autotag-scenario/case/correlation-autotag-scenario,
+              - {parentEndpoint: GET:/correlation-autotag-scenario/case/correlation-autotag-scenario,
                  networkAddress: '', refType: CrossThread, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: correlation-autotag-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/customize-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/customize-scenario/config/expectedData.yaml
@@ -19,10 +19,15 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - {operationName: /is_static_method, operationId: 0, parentSpanId: 0, spanId: 1,
-      startTime: nq 0, endTime: nq 0, isError: false, spanType: Local, skipAnalysis: 'false'}
+    - operationName: /is_static_method
+      parentSpanId: 0
+      spanId: 1
+      startTime: nq 0
+      endTime: nq 0
+      isError: false
+      spanType: Local
+      skipAnalysis: 'false'
     - operationName: /is_static_method_args/id/123/a
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       startTime: nq 0
@@ -36,12 +41,15 @@ segmentItems:
       - logEvent:
         - {key: log_1, value: '3'}
       skipAnalysis: 'false'
-    - {operationName: test.apache.skywalking.apm.testcase.customize.service.TestService1.method(),
-      operationId: 0, parentSpanId: 0, spanId: 3, startTime: nq 0, endTime: nq 0,
-      isError: false, spanType: Local, skipAnalysis: 'false'}
-    - operationName: /method_2/str0
-      operationId: 0
+    - operationName: test.apache.skywalking.apm.testcase.customize.service.TestService1.method()
       parentSpanId: 0
+      spanId: 3
+      startTime: nq 0
+      endTime: nq 0
+      isError: false
+      spanType: Local
+      skipAnalysis: 'false'
+    - operationName: /method_2/str0
       spanId: 4
       startTime: nq 0
       endTime: nq 0
@@ -54,7 +62,6 @@ segmentItems:
         - {key: log_1, value: '123'}
       skipAnalysis: 'false'
     - operationName: /method_3/id/name/100
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       startTime: nq 0
@@ -68,7 +75,6 @@ segmentItems:
         - {key: log_map, value: v1}
       skipAnalysis: 'false'
     - operationName: /is_2_static_method
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       startTime: nq 0
@@ -82,7 +88,6 @@ segmentItems:
         - {key: log_1_1, value: '123'}
       skipAnalysis: 'false'
     - operationName: /method_4
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       startTime: nq 0
@@ -93,7 +98,6 @@ segmentItems:
       - {key: tag_4_1, value: '1'}
       skipAnalysis: 'false'
     - operationName: /method_5
-      operationId: 0
       parentSpanId: 0
       spanId: 8
       startTime: nq 0
@@ -106,8 +110,7 @@ segmentItems:
       - logEvent:
         - {key: log_5_1, value: '123'}
       skipAnalysis: 'false'
-    - operationName: /case/customize
-      operationId: 0
+    - operationName: GET:/case/customize
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/cxf-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/cxf-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: GET:/cxf-scenario/soap/user
+          - operationName: POST:/cxf-scenario/soap/user
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -34,7 +34,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/cxf-scenario/soap/user'}
               - {key: http.method, value: POST}
             refs:
-              - {parentEndpoint: /cxf-scenario/case/cxf-scenario, networkAddress: 'localhost:8080',
+              - {parentEndpoint: GET:/cxf-scenario/case/cxf-scenario, networkAddress: 'localhost:8080',
                  refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: cxf-scenario, traceId: not null}
       - segmentId: not null
@@ -51,7 +51,7 @@ segmentItems:
             peer: ''
             skipAnalysis: 'false'
             refs:
-              - {parentEndpoint: /cxf-scenario/soap/user, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: POST:/cxf-scenario/soap/user, networkAddress: '', refType: CrossThread,
                  parentSpanId: 0, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: cxf-scenario, traceId: not null}
       - segmentId: not null

--- a/test/plugin/scenarios/cxf-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/cxf-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /cxf-scenario/soap/user
-            operationId: 0
+          - operationName: GET:/cxf-scenario/soap/user
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -41,7 +40,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /CXF/AsyncInvoke
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -59,7 +57,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /cxf-scenario/soap/user/getUser
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -73,8 +70,7 @@ segmentItems:
             tags:
               - {key: http.method, value: POST}
               - {key: url, value: 'http://localhost:8080/cxf-scenario/soap/user/getUser'}
-          - operationName: /cxf-scenario/case/cxf-scenario
-            operationId: 0
+          - operationName: GET:/cxf-scenario/case/cxf-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/dbcp-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/dbcp-2.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Mysql/JDBI/Connection/close
-      operationId: eq 0
       parentSpanId: 1
       spanId: 2
       componentId: 33
@@ -33,7 +32,6 @@ segmentItems:
         - {key: db.instance, value: test}
         - {key: db.statement, value: ''}
     - operationName: DBCP/Connection/getConnection
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       startTime: gt 0
@@ -44,7 +42,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       startTime: gt 0
@@ -61,7 +58,6 @@ segmentItems:
           value: "CREATE TABLE test_DBCP(\nid VARCHAR(1) PRIMARY KEY, \nvalue VARCHAR(1)\
           \ NOT NULL)"
     - operationName: DBCP/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       startTime: gt 0
@@ -72,7 +68,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: DBCP/Connection/getConnection
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       startTime: gt 0
@@ -83,7 +78,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       startTime: gt 0
@@ -99,7 +93,6 @@ segmentItems:
         - key: db.statement
           value: 'INSERT INTO test_DBCP(id, value) VALUES(1,1)'
     - operationName: DBCP/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       startTime: gt 0
@@ -110,7 +103,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: DBCP/Connection/getConnection
-      operationId: 0
       parentSpanId: 0
       spanId: 8
       startTime: gt 0
@@ -121,7 +113,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 9
       startTime: gt 0
@@ -137,7 +128,6 @@ segmentItems:
         - key: db.statement
           value: 'SELECT id, value FROM test_DBCP WHERE id=1'
     - operationName: DBCP/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 10
       startTime: gt 0
@@ -148,7 +138,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: DBCP/Connection/getConnection
-      operationId: 0
       parentSpanId: 0
       spanId: 11
       startTime: gt 0
@@ -159,7 +148,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 12
       startTime: gt 0
@@ -175,7 +163,6 @@ segmentItems:
         - key: db.statement
           value: "DELETE FROM test_DBCP WHERE id=1"
     - operationName: DBCP/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 13
       startTime: gt 0
@@ -186,7 +173,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: DBCP/Connection/getConnection
-      operationId: 0
       parentSpanId: 0
       spanId: 14
       startTime: gt 0
@@ -197,7 +183,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 15
       startTime: gt 0
@@ -213,7 +198,6 @@ segmentItems:
         - key: db.statement
           value: "DROP table test_DBCP"
     - operationName: DBCP/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 16
       startTime: gt 0
@@ -223,8 +207,7 @@ segmentItems:
       spanType: Local
       peer: ''
       skipAnalysis: false
-    - operationName: /dbcp-2.x-scenario/case/dbcp-2.x-scenario
-      operationId: 0
+    - operationName: GET:/dbcp-2.x-scenario/case/dbcp-2.x-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/druid-1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/druid-1.x-scenario/config/expectedData.yaml
@@ -190,7 +190,7 @@ segmentItems:
       isError: false
       spanType: Local
       peer: ''
-    - operationName: /druid-1.x-scenario/case/druid-1.x-scenario
+    - operationName: GET:/druid-1.x-scenario/case/druid-1.x-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/dubbo-2.5.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/dubbo-2.5.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -33,14 +32,13 @@ segmentItems:
       tags:
       - {key: url, value: not null}
       refs:
-      - {parentEndpoint: /dubbo-2.5.x-scenario/case/dubbo, networkAddress: 'localhost:20080',
+      - {parentEndpoint: GET:/dubbo-2.5.x-scenario/case/dubbo, networkAddress: 'localhost:20080',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: dubbo-2.5.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: RPCFramework
@@ -53,8 +51,7 @@ segmentItems:
       tags:
       - {key: url, value: 'dubbo://localhost:20080/org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness()'}
       skipAnalysis: 'false'
-    - operationName: /dubbo-2.5.x-scenario/case/dubbo
-      operationId: 0
+    - operationName: GET:/dubbo-2.5.x-scenario/case/dubbo
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/dubbo-2.7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/dubbo-2.7.x-scenario/config/expectedData.yaml
@@ -21,7 +21,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness(String)
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -35,14 +34,13 @@ segmentItems:
               - {key: url, value: not null}
               - {key: arguments, value: helloWorld}
             refs:
-              - {parentEndpoint: /dubbo-2.7.x-scenario/case/dubbo, networkAddress: 'localhost:20080',
+              - {parentEndpoint: GET:/dubbo-2.7.x-scenario/case/dubbo, networkAddress: 'localhost:20080',
                  refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: dubbo-2.7.x-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness(String)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -56,8 +54,7 @@ segmentItems:
               - {key: url, value: 'dubbo://localhost:20080/org.apache.skywalking.apm.testcase.dubbo.services.GreetService.doBusiness(String)'}
               - {key: arguments, value: helloWorld}
             skipAnalysis: 'false'
-          - operationName: /dubbo-2.7.x-scenario/case/dubbo
-            operationId: 0
+          - operationName: GET:/dubbo-2.7.x-scenario/case/dubbo
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/ehcache-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/ehcache-2.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Ehcache/put/testCache
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Cache
@@ -34,7 +33,6 @@ segmentItems:
       - {key: db.statement, value: dataKey}
       skipAnalysis: 'false'
     - operationName: Ehcache/get/testCache
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Cache
@@ -47,11 +45,18 @@ segmentItems:
       tags:
       - {key: db.statement, value: dataKey}
       skipAnalysis: 'false'
-    - {operationName: Ehcache/putAll/testCache, operationId: 0, parentSpanId: 0, panId: 3,
-      spanLayer: Cache, startTime: nq 0, endTime: nq 0, componentId: 75, isError: false,
-      spanType: Local, peer: '', skipAnalysis: 'false'}
+    - operationName: Ehcache/putAll/testCache
+      parentSpanId: 0
+      panId: 3
+      spanLayer: Cache
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 75
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
     - operationName: Ehcache/tryRead/testCache
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Cache
@@ -65,7 +70,6 @@ segmentItems:
       - {key: db.statement, value: dataKey}
       skipAnalysis: 'false'
     - operationName: Ehcache/releaseRead/testCache
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Cache
@@ -79,7 +83,6 @@ segmentItems:
       - {key: db.statement, value: dataKey}
       skipAnalysis: 'false'
     - operationName: Ehcache/put/testCache2
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Cache
@@ -92,8 +95,7 @@ segmentItems:
       tags:
       - {key: db.statement, value: dataKey}
       skipAnalysis: 'false'
-    - operationName: /ehcache-2.x-scenario/case/ehcache
-      operationId: 0
+    - operationName: GET:/ehcache-2.x-scenario/case/ehcache
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/elasticjob-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticjob-2.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /elasticjob-2.x-scenario/case/call
-      operationId: 0
+    - operationName: GET:/elasticjob-2.x-scenario/case/call
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -39,7 +38,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /elasticjob-2.x-scenario/case/call
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -54,7 +52,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/elasticjob-2.x-scenario/case/call'}
     - operationName: ElasticJob/org.apache.skywalking.apm.testcase.elasticjob.job.DemoSimpleJob
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown

--- a/test/plugin/scenarios/elasticjob-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticjob-3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /elasticjob-3.x-scenario/case/ping
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -35,7 +34,6 @@ segmentItems:
         - {key: http.method, value: GET}
         - {key: url, value: 'http://localhost:8080/elasticjob-3.x-scenario/case/ping'}
     - operationName: ElasticJob/simpleJob
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown

--- a/test/plugin/scenarios/elasticsearch-5.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-5.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Elasticsearch/IndexRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -38,7 +37,6 @@ segmentItems:
       - {key: es.types, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/actionGet
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       startTime: nq 0
@@ -50,7 +48,6 @@ segmentItems:
       - {key: db.type, value: Elasticsearch}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/GetRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -68,7 +65,6 @@ segmentItems:
       - {key: es.types, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -86,7 +82,6 @@ segmentItems:
       - {key: es.types, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/UpdateRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -104,7 +99,6 @@ segmentItems:
       - {key: es.types, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Database
@@ -122,7 +116,6 @@ segmentItems:
       - {key: es.types, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteIndexRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Database
@@ -139,8 +132,7 @@ segmentItems:
       - {key: es.indices, value: ''}
       - {key: es.types, value: ''}
       skipAnalysis: 'false'
-    - operationName: '{GET}/case/elasticsearch'
-      operationId: 0
+    - operationName: 'GET:/case/elasticsearch'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/elasticsearch-6.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-6.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Elasticsearch/CreateRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/IndexRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -52,7 +50,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/GetRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -68,7 +65,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -83,7 +79,6 @@ segmentItems:
       - {key: db.instance, value: not null}
       - {key: db.statement, value: not null}
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -98,7 +93,6 @@ segmentItems:
         - {key: db.instance, value: not null}
         - {key: db.statement, value: not null}
     - operationName: Elasticsearch/SearchScrollRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Database
@@ -113,7 +107,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Database
@@ -128,7 +121,6 @@ segmentItems:
         - {key: db.instance, value: not null}
         - {key: db.statement, value: not null}
     - operationName: Elasticsearch/SearchScrollRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 8
       spanLayer: Database
@@ -143,7 +135,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 9
       spanLayer: Database
@@ -158,7 +149,6 @@ segmentItems:
         - {key: db.instance, value: not null}
         - {key: db.statement, value: not null}
     - operationName: Elasticsearch/ClearScrollRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 10
       spanLayer: Database
@@ -173,7 +163,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 11
       spanLayer: Database
@@ -188,7 +177,6 @@ segmentItems:
         - {key: db.instance, value: not null}
         - {key: db.statement, value: not null}
     - operationName: Elasticsearch/ClearScrollRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 12
       spanLayer: Database
@@ -203,7 +191,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchTemplateRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 13
       spanLayer: Database
@@ -218,7 +205,6 @@ segmentItems:
         - {key: db.instance, value: not null}
         - {key: db.statement, value: not null}
     - operationName: Elasticsearch/SearchTemplateRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 14
       spanLayer: Database
@@ -233,7 +219,6 @@ segmentItems:
         - {key: db.instance, value: not null}
         - {key: db.statement, value: not null}
     - operationName: Elasticsearch/UpdateRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 15
       spanLayer: Database
@@ -249,7 +234,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/AnalyzeRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 16
       spanLayer: Database
@@ -265,7 +249,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/AnalyzeRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 17
       spanLayer: Database
@@ -281,7 +264,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteByQueryRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 18
       spanLayer: Database
@@ -297,7 +279,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteByQueryRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 19
       spanLayer: Database
@@ -313,7 +294,6 @@ segmentItems:
         - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 20
       spanLayer: Database
@@ -328,7 +308,6 @@ segmentItems:
       - {key: db.instance, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/IndexRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 21
       spanLayer: Database
@@ -347,7 +326,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/actionGet
-      operationId: 0
       parentSpanId: 0
       spanId: 22
       startTime: nq 0
@@ -360,7 +338,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/GetRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 23
       spanLayer: Database
@@ -379,7 +356,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/SearchRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 24
       spanLayer: Database
@@ -398,7 +374,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/UpdateRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 25
       spanLayer: Database
@@ -417,7 +392,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 26
       spanLayer: Database
@@ -436,7 +410,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: Elasticsearch/DeleteIndexRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 27
       spanLayer: Database
@@ -452,8 +425,7 @@ segmentItems:
       - {key: node.address, value: not null}
       - {key: es.indices, value: not null}
       skipAnalysis: 'false'
-    - operationName: /elasticsearch-case/case/elasticsearch
-      operationId: 0
+    - operationName: GET:/elasticsearch-case/case/elasticsearch
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Elasticsearch/Health
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Database
@@ -34,7 +33,6 @@ segmentItems:
               - { key: db.type, value: Elasticsearch }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/GetSettings
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Database
@@ -48,7 +46,6 @@ segmentItems:
               - { key: db.type, value: Elasticsearch }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/PutSettings
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Database
@@ -63,7 +60,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/CreateRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Database
@@ -79,7 +75,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/IndexRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Database
@@ -95,7 +90,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/GetRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 6
             spanLayer: Database
@@ -111,7 +105,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/SearchRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 7
             spanLayer: Database
@@ -127,7 +120,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/UpdateRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 8
             spanLayer: Database
@@ -143,7 +135,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/DeleteRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 9
             spanLayer: Database
@@ -158,7 +149,6 @@ segmentItems:
               - { key: db.instance, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/IndexRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 10
             spanLayer: Database
@@ -177,7 +167,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/actionGet
-            operationId: 0
             parentSpanId: 0
             spanId: 11
             startTime: nq 0
@@ -190,7 +179,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/GetRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 12
             spanLayer: Database
@@ -209,7 +197,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/SearchRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 13
             spanLayer: Database
@@ -228,7 +215,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/actionGet
-            operationId: 0
             parentSpanId: 0
             spanId: 14
             startTime: nq 0
@@ -243,7 +229,6 @@ segmentItems:
               - {key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/UpdateRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 15
             spanLayer: Database
@@ -262,7 +247,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/DeleteRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 16
             spanLayer: Database
@@ -281,7 +265,6 @@ segmentItems:
               - { key: db.statement, value: not null }
             skipAnalysis: 'false'
           - operationName: Elasticsearch/DeleteIndexRequest
-            operationId: 0
             parentSpanId: 0
             spanId: 17
             spanLayer: Database
@@ -297,8 +280,7 @@ segmentItems:
               - { key: node.address, value: not null }
               - { key: es.indices, value: not null }
             skipAnalysis: 'false'
-          - operationName: /elasticsearch-case/case/elasticsearch
-            operationId: 0
+          - operationName: GET:/elasticsearch-case/case/elasticsearch
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/exception-checker-spring-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/exception-checker-spring-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /case/healthCheck
-            operationId: 0
+          - operationName: HEAD:/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -37,7 +36,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testAnnotatedException
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Unknown
@@ -56,7 +54,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testListedException
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Unknown
@@ -75,7 +72,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testHierarchyListedException
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Unknown
@@ -94,7 +90,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testException
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Unknown
@@ -113,7 +108,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testRecursiveException
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Unknown
@@ -131,8 +125,7 @@ segmentItems:
                   - {key: message, value: test.apache.skywalking.apm.testcase.exceptionchecker.exception.TestListedException}
                   - key: stack
                     value: not null
-          - operationName: /case/exceptionchecker
-            operationId: 0
+          - operationName: GET:/case/exceptionchecker
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/exception-checker-tomcat-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/exception-checker-tomcat-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testAnnotatedException
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Unknown
@@ -39,7 +38,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testListedException
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Unknown
@@ -58,7 +56,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testHierarchyListedException
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Unknown
@@ -77,7 +74,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testException
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Unknown
@@ -96,7 +92,6 @@ segmentItems:
                   - key: stack
                     value: not null
           - operationName: test.apache.skywalking.apm.testcase.exceptionchecker.service.TestService.testRecursiveException
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Unknown
@@ -114,8 +109,7 @@ segmentItems:
                   - {key: message, value: test.apache.skywalking.apm.testcase.exceptionchecker.exception.TestListedException}
                   - key: stack
                     value: not null
-          - operationName: /case/exceptionchecker
-            operationId: 0
+          - operationName: GET:/case/exceptionchecker
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/fastjson-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/fastjson-scenario/config/expectedData.yaml
@@ -115,7 +115,7 @@ segmentItems:
       peer: ''
       tags:
         - {key: length, value: '24'}
-    - operationName: /fastjson-scenario/case/fastjson-scenario
+    - operationName: GET:/fastjson-scenario/case/fastjson-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/feign-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/feign-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /feign-scenario/create/
-      operationId: 0
+    - operationName: POST:/feign-scenario/create/
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -34,14 +33,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/feign-scenario/create/'}
       - {key: http.method, value: POST}
       refs:
-      - {parentEndpoint: /feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: feign-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /feign-scenario/get/1
-      operationId: 0
+    - operationName: GET:/feign-scenario/get/1
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -55,14 +53,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/feign-scenario/get/1'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: feign-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /feign-scenario/update/1
-      operationId: 0
+    - operationName: PUT:/feign-scenario/update/1
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -76,14 +73,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/feign-scenario/update/1'}
       - {key: http.method, value: PUT}
       refs:
-      - {parentEndpoint: /feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: feign-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-      - operationName: /feign-scenario/modify/1
-        operationId: 0
+      - operationName: PUT:/feign-scenario/modify/1
         parentSpanId: -1
         spanId: 0
         spanLayer: Http
@@ -97,14 +93,13 @@ segmentItems:
           - {key: url, value: 'http://localhost:8080/feign-scenario/modify/1'}
           - {key: http.method, value: PUT}
         refs:
-          - {parentEndpoint: /feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
+          - {parentEndpoint: GET:/feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
              refType: CrossProcess, parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                                        null, parentService: feign-scenario, traceId: not null}
         skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /feign-scenario/delete/1
-      operationId: 0
+    - operationName: DELETE:/feign-scenario/delete/1
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -118,14 +113,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/feign-scenario/delete/1'}
       - {key: http.method, value: DELETE}
       refs:
-      - {parentEndpoint: /feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/feign-scenario/case/feign-scenario, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 5, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: feign-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /feign-scenario/create/
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -141,7 +135,6 @@ segmentItems:
       - {key: http.body, value: '{"id": "1", "userName": "test"}'}
       skipAnalysis: 'false'
     - operationName: /feign-scenario/get/{id}
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Http
@@ -156,7 +149,6 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/feign-scenario/get/1'}
       skipAnalysis: 'false'
     - operationName: /feign-scenario/update/{id}
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Http
@@ -172,7 +164,6 @@ segmentItems:
       - {key: http.body, value: '{"id": "1", "userName": "testA"}'}
       skipAnalysis: 'false'
     - operationName: /feign-scenario/modify/{id}
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Http
@@ -188,7 +179,6 @@ segmentItems:
         - {key: http.body, value: testA}
       skipAnalysis: 'false'
     - operationName: /feign-scenario/delete/{id}
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Http
@@ -202,8 +192,7 @@ segmentItems:
       - {key: http.method, value: DELETE}
       - {key: url, value: 'http://localhost:8080/feign-scenario/delete/1'}
       skipAnalysis: 'false'
-    - operationName: /feign-scenario/case/feign-scenario
-      operationId: 0
+    - operationName: GET:/feign-scenario/case/feign-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/finagle-17.10.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/finagle-17.10.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: hello
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -31,17 +30,24 @@ segmentItems:
       spanType: Entry
       peer: ''
       refs:
-      - {parentEndpoint: /finagle-17.10.x-scenario/case/finagle, networkAddress: '127.0.0.1:12220',
+      - {parentEndpoint: GET:/finagle-17.10.x-scenario/case/finagle, networkAddress: '127.0.0.1:12220',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: finagle-17.10.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - {operationName: hello, operationId: 0, parentSpanId: 0, spanId: 1, spanLayer: RPCFramework,
-      startTime: nq 0, endTime: nq 0, componentId: 85, isError: false, spanType: Exit,
-      peer: '127.0.0.1:12220', skipAnalysis: 'false'}
-    - operationName: /finagle-17.10.x-scenario/case/finagle
-      operationId: 0
+    - operationName: hello,
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: RPCFramework
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 85
+      isError: false
+      spanType: Exit
+      peer: '127.0.0.1:12220'
+      skipAnalysis: 'false'
+    - operationName: GET:/finagle-17.10.x-scenario/case/finagle
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/finagle-17.10.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/finagle-17.10.x-scenario/config/expectedData.yaml
@@ -36,7 +36,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: hello,
+    - operationName: hello
       parentSpanId: 0
       spanId: 1
       spanLayer: RPCFramework

--- a/test/plugin/scenarios/finagle-6.44.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/finagle-6.44.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: hello
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -31,17 +30,24 @@ segmentItems:
       spanType: Entry
       peer: ''
       refs:
-      - {parentEndpoint: /finagle-6.44.x-scenario/case/finagle, networkAddress: '127.0.0.1:12220',
+      - {parentEndpoint: GET:/finagle-6.44.x-scenario/case/finagle, networkAddress: '127.0.0.1:12220',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: finagle-6.44.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - {operationName: hello, operationId: 0, parentSpanId: 0, spanId: 1, spanLayer: RPCFramework,
-      startTime: nq 0, endTime: nq 0, componentId: 85, isError: false, spanType: Exit,
-      peer: '127.0.0.1:12220', skipAnalysis: 'false'}
-    - operationName: /finagle-6.44.x-scenario/case/finagle
-      operationId: 0
+    - operationName: hello
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: RPCFramework
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 85
+      isError: false
+      spanType: Exit
+      peer: '127.0.0.1:12220'
+      skipAnalysis: 'false'
+    - operationName: GET:/finagle-6.44.x-scenario/case/finagle
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/gateway-2.0.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/gateway-2.0.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /provider/b/testcase
-      operationId: 0
+    - operationName: GET:/provider/b/testcase
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: nq 0
+      componentId: 14
       isError: false
       spanType: Entry
       peer: ''
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /provider/b/testcase
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -62,7 +60,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: SpringCloudGateway/sendRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -77,7 +74,6 @@ segmentItems:
       - {key: http.status_code, value: '200'}
       skipAnalysis: 'false'
     - operationName: SpringCloudGateway/RoutingFilter
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/gateway-2.1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/gateway-2.1.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /provider/b/testcase
-      operationId: 0
+    - operationName: GET:/provider/b/testcase
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: nq 0
+      componentId: 14
       isError: false
       spanType: Entry
       peer: ''
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /provider/b/testcase
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -62,7 +60,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: SpringCloudGateway/sendRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -77,7 +74,6 @@ segmentItems:
       - {key: http.status_code, value: '200'}
       skipAnalysis: 'false'
     - operationName: SpringCloudGateway/RoutingFilter
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/gateway-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/gateway-3.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /provider/b/testcase
-      operationId: 0
+    - operationName: GET:/provider/b/testcase
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: nq 0
+      componentId: 14
       isError: false
       spanType: Entry
       peer: ''
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /provider/b/testcase
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -62,7 +60,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: SpringCloudGateway/sendRequest
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -77,7 +74,6 @@ segmentItems:
       - {key: http.status_code, value: '200'}
       skipAnalysis: 'false'
     - operationName: SpringCloudGateway/RoutingFilter
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/graphql-12.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/graphql-12.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: user
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -34,7 +33,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: users
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Unknown
@@ -48,7 +46,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: user
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Unknown
@@ -62,7 +59,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: users
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Unknown
@@ -75,8 +71,7 @@ segmentItems:
       skipAnalysis: false
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
-    - operationName: /graphql-scenario/case/graphql
-      operationId: 0
+    - operationName: GET:/graphql-scenario/case/graphql
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/graphql-8.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/graphql-8.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: user
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -34,7 +33,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: users
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Unknown
@@ -48,7 +46,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: user
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Unknown
@@ -62,7 +59,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: users
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Unknown
@@ -75,8 +71,7 @@ segmentItems:
       skipAnalysis: false
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
-    - operationName: /graphql-scenario/case/graphql
-      operationId: 0
+    - operationName: GET:/graphql-scenario/case/graphql
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/graphql-9.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/graphql-9.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: user
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -34,7 +33,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: users
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Unknown
@@ -48,7 +46,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: user
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Unknown
@@ -62,7 +59,6 @@ segmentItems:
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
     - operationName: users
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Unknown
@@ -75,8 +71,7 @@ segmentItems:
       skipAnalysis: false
       tags:
       - {key: x-le, value: '{"logic-span":true}'}
-    - operationName: /graphql-scenario/case/graphql
-      operationId: 0
+    - operationName: GET:/graphql-scenario/case/graphql
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/grpc-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/grpc-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: GreeterBlocking.sayHello
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -31,14 +30,13 @@ segmentItems:
             spanType: Entry
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '127.0.0.1:18080',
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '127.0.0.1:18080',
                  refType: CrossProcess, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                                            null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -49,14 +47,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                     null, parentService: not null, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -67,14 +64,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                     null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Request/onComplete
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -85,14 +81,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                     null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -103,14 +98,13 @@ segmentItems:
             spanType: Entry
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '127.0.0.1:18080',
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '127.0.0.1:18080',
                  refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                                            null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/server/Response/onMessage
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -122,7 +116,6 @@ segmentItems:
             peer: ''
             skipAnalysis: 'false'
           - operationName: Greeter.sayHello/server/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -140,7 +133,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Response/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -151,14 +143,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                     null, parentService: not null, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: GreeterBlocking.sayHello/server/Response/onClose
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -172,7 +163,6 @@ segmentItems:
               - {key: rpc.status_code, value: OK}
             skipAnalysis: 'false'
           - operationName: GreeterBlocking.sayHello/server/Request/onComplete
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -190,7 +180,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/server/Response/onMessage
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -202,7 +191,6 @@ segmentItems:
             peer: ''
             skipAnalysis: 'false'
           - operationName: Greeter.sayHello/server/Request/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -220,7 +208,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/server/Response/onClose
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -234,7 +221,6 @@ segmentItems:
               - {key: rpc.status_code, value: OK}
             skipAnalysis: 'false'
           - operationName: Greeter.sayHello/server/Request/onComplete
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -252,7 +238,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Response/onMessage
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -263,14 +248,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                     null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: Greeter.sayHello/client/Response/onClose
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -281,14 +265,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '', refType: CrossThread,
                  parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                     null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: GreeterBlockingError.sayHello
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -299,14 +282,13 @@ segmentItems:
             spanType: Entry
             peer: ''
             refs:
-              - {parentEndpoint: /grpc-scenario/case/grpc-scenario, networkAddress: '127.0.0.1:18080',
+              - {parentEndpoint: GET:/grpc-scenario/case/grpc-scenario, networkAddress: '127.0.0.1:18080',
                  refType: CrossProcess, parentSpanId: 5, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                                            null, parentService: grpc-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
           - operationName: GreeterBlockingError.sayHello/server/Response/onClose
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -326,7 +308,6 @@ segmentItems:
                   - {key: stack, value: not null}
             skipAnalysis: 'false'
           - operationName: GreeterBlockingError.sayHello/server/Request/onComplete
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -343,23 +324,62 @@ segmentItems:
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - {operationName: Greeter.sayHello, operationId: 0, parentSpanId: 0, spanId: 1,
-             spanLayer: RPCFramework, startTime: nq 0, endTime: nq 0, componentId: 23, isError: false,
-             spanType: Exit, peer: '127.0.0.1:18080', skipAnalysis: 'false'}
-          - {operationName: GreeterBlocking.sayHello/client/Request/onComplete, operationId: 0,
-             parentSpanId: 2, spanId: 3, spanLayer: RPCFramework, startTime: nq 0, endTime: nq
-                                                                                     0, componentId: 23, isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-          - {operationName: GreeterBlocking.sayHello/client/Response/onClose, operationId: 0,
-             parentSpanId: 2, spanId: 4, spanLayer: RPCFramework, startTime: nq 0, endTime: nq
-                                                                                     0, componentId: 23, isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-          - {operationName: GreeterBlocking.sayHello, operationId: 0, parentSpanId: 0, spanId: 2,
-             spanLayer: RPCFramework, startTime: nq 0, endTime: nq 0, componentId: 23, isError: false,
-             spanType: Exit, peer: '127.0.0.1:18080', skipAnalysis: 'false'}
-          - {operationName: GreeterBlockingError.sayHello/client/Request/onComplete, operationId: 0,
-             parentSpanId: 5, spanId: 6, spanLayer: RPCFramework, startTime: nq 0, endTime: nq
-                                                                                     0, componentId: 23, isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
+          - operationName: Greeter.sayHello
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 23
+            isError: false
+            spanType: Exit
+            peer: '127.0.0.1:18080'
+            skipAnalysis: 'false'
+          - operationName: GreeterBlocking.sayHello/client/Request/onComplete
+            parentSpanId: 2
+            spanId: 3
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 23
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: 'false'
+          - operationName: GreeterBlocking.sayHello/client/Response/onClose
+            parentSpanId: 2
+            spanId: 4
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 23
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: 'false'
+          - operationName: GreeterBlocking.sayHello
+            parentSpanId: 0
+            panId: 2
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 23
+            isError: false
+            spanType: Exit
+            peer: '127.0.0.1:18080'
+            skipAnalysis: 'false'
+          - operationName: GreeterBlockingError.sayHello/client/Request/onComplete
+            parentSpanId: 5
+            spanId: 6
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 23
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: 'false'
           - operationName: GreeterBlockingError.sayHello/client/Response/onClose
-            operationId: 0
             parentSpanId: 5
             spanId: 7
             spanLayer: RPCFramework
@@ -379,7 +399,6 @@ segmentItems:
                   - {key: stack, value: not null}
             skipAnalysis: 'false'
           - operationName: GreeterBlockingError.sayHello/client/Request/onCancel
-            operationId: 0
             parentSpanId: 5
             spanId: 8
             spanLayer: RPCFramework
@@ -397,7 +416,6 @@ segmentItems:
                   - {key: stack, value: not null}
             skipAnalysis: 'false'
           - operationName: GreeterBlockingError.sayHello
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: RPCFramework
@@ -414,8 +432,7 @@ segmentItems:
                   - {key: message, value: UNKNOWN}
                   - {key: stack, value: not null}
             skipAnalysis: 'false'
-          - operationName: /grpc-scenario/case/grpc-scenario
-            operationId: 0
+          - operationName: GET:/grpc-scenario/case/grpc-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/gson-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/gson-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: nq 0
     spans:
     - operationName: Gson/ToJson
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -34,7 +33,6 @@ segmentItems:
       peer: ' '
       skipAnalysis: 'false'
     - operationName: Gson/FromJson
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Unknown
@@ -47,8 +45,7 @@ segmentItems:
       spanType: Local
       peer: ''
       skipAnalysis: 'false'
-    - operationName: /gson-scenario/case/gson-scenario
-      operationId: 0
+    - operationName: GET:/gson-scenario/case/gson-scenario
       spanId: 0
       spanLayer: Http
       startTime: nq 0

--- a/test/plugin/scenarios/guava-cache-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/guava-cache-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: GuavaCache/put
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Cache
@@ -34,7 +33,6 @@ segmentItems:
       - {key: db.statement, value: testKey1}
       skipAnalysis: 'false'
     - operationName: GuavaCache/invalidate
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Cache
@@ -48,7 +46,6 @@ segmentItems:
       - {key: db.statement, value: testKey1}
       skipAnalysis: 'false'
     - operationName: GuavaCache/get
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Cache
@@ -62,7 +59,6 @@ segmentItems:
       - {key: db.statement, value: testKey1}
       skipAnalysis: 'false'
     - operationName: GuavaCache/getIfPresent
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Cache
@@ -75,17 +71,40 @@ segmentItems:
       tags:
       - {key: db.statement, value: testKey1}
       skipAnalysis: 'false'
-    - {operationName: GuavaCache/putAll, operationId: 0, parentSpanId: 0, spanId: 5, spanLayer: Cache,
-       startTime: nq 0, endTime: nq 0, componentId: 114, isError: false,
-       spanType: Local, peer: '', skipAnalysis: false}
-    - {operationName: GuavaCache/getAllPresent, operationId: 0, parentSpanId: 0, spanId: 6,
-       spanLayer: Cache, startTime: nq 0, endTime: nq 0, componentId: 114,
-       isError: false, spanType: Local, peer: '', skipAnalysis: false}
-    - {operationName: GuavaCache/invalidateAll, operationId: 0, parentSpanId: 0, spanId: 7,
-       spanLayer: Cache, startTime: nq 0, endTime: nq 0, componentId: 114,
-       isError: false, spanType: Local, peer: '', skipAnalysis: false}
-    - operationName: /guava-cache-scenario/case/guava
-      operationId: 0
+    - operationName: GuavaCache/putAll
+      parentSpanId: 0
+      spanId: 5
+      spanLayer: Cache
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 114
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: false
+    - operationName: GuavaCache/getAllPresent
+      parentSpanId: 0
+      spanId: 6
+      spanLayer: Cache
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 114
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: false
+    - operationName: GuavaCache/invalidateAll
+      parentSpanId: 0
+      spanId: 7
+      spanLayer: Cache
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 114
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: false
+    - operationName: GET:/guava-cache-scenario/case/guava
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/h2-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/h2-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -38,7 +37,6 @@ segmentItems:
           \ NOT NULL)"
       skipAnalysis: 'false'
     - operationName: H2/JDBI/CallableStatement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -54,7 +52,6 @@ segmentItems:
       - {key: db.statement, value: 'INSERT INTO test_007(id, value) VALUES(?,?)'}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -70,7 +67,6 @@ segmentItems:
       - {key: db.statement, value: DROP table test_007}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -85,8 +81,7 @@ segmentItems:
       - {key: db.instance, value: test}
       - {key: db.statement, value: ''}
       skipAnalysis: 'false'
-    - operationName: /h2-scenario/case/h2-scenario
-      operationId: 0
+    - operationName: GET:/h2-scenario/case/h2-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/hbase-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/hbase-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /HTable/put
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -35,7 +34,6 @@ segmentItems:
       - {key: db.type, value: hbase}
       - {key: db.instance, value: test_table}
     - operationName: /HTable/getScanner
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -50,7 +48,6 @@ segmentItems:
       - {key: db.type, value: hbase}
       - {key: db.instance, value: test_table}
     - operationName: /HTable/get
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -65,7 +62,6 @@ segmentItems:
       - {key: db.type, value: hbase}
       - {key: db.instance, value: test_table}
     - operationName: /HTable/delete
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -79,8 +75,7 @@ segmentItems:
       tags:
       - {key: db.type, value: hbase}
       - {key: db.instance, value: test_table}
-    - operationName: /hbase-scenario/case/hbase-case
-      operationId: 0
+    - operationName: GET:/hbase-scenario/case/hbase-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/hikaricp-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/hikaricp-scenario/config/expectedData.yaml
@@ -190,7 +190,7 @@ segmentItems:
       isError: false
       spanType: Local
       peer: ''
-    - operationName: /hikaricp-scenario/case/hikaricp-scenario
+    - operationName: GET:/hikaricp-scenario/case/hikaricp-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/httpasyncclient-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/httpasyncclient-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /httpasyncclient/case/httpasyncclient
-      operationId: 0
+    - operationName: GET:/httpasyncclient/case/httpasyncclient
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 1
       isError: false
       spanType: Entry
       peer: ''
@@ -36,14 +35,13 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /httpasyncclient/back
-      operationId: 0
+    - operationName: GET:/httpasyncclient/back
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 1
       isError: false
       spanType: Entry
       peer: ''
@@ -54,13 +52,12 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /httpasyncclient/back
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 26
       isError: false
       spanType: Exit
       peer: 127.0.0.1:8080
@@ -68,6 +65,14 @@ segmentItems:
       - {key: url, value: 'http://127.0.0.1:8080/httpasyncclient/back'}
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
-    - {operationName: httpasyncclient/local, operationId: 0, parentSpanId: -1, spanId: 0,
-      spanLayer: not null, startTime: nq 0, endTime: nq 0, componentId: 0, isError: false,
-      spanType: Local, peer: '', skipAnalysis: 'false'}
+    - operationName: httpasyncclient/local
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: not null
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 0
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'

--- a/test/plugin/scenarios/httpclient-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/httpclient-3.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /httpclient-3.x-scenario/case/context-propagate
-      operationId: 0
+    - operationName: GET:/httpclient-3.x-scenario/case/context-propagate
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -38,14 +37,13 @@ segmentItems:
           q1=[v1]
           chinese=[中文]
       refs:
-      - {parentEndpoint: /httpclient-3.x-scenario/case/httpclient, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/httpclient-3.x-scenario/case/httpclient, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: httpclient-3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /httpclient-3.x-scenario/case/context-propagate
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -60,8 +58,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.params, value: q1=v1&chinese=%e4%b8%ad%e6%96%87}
       skipAnalysis: 'false'
-    - operationName: /httpclient-3.x-scenario/case/httpclient
-      operationId: 0
+    - operationName: GET:/httpclient-3.x-scenario/case/httpclient
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/httpclient-4.3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/httpclient-4.3.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /httpclient-4.3.x-scenario/case/context-propagate
-      operationId: 0
+    - operationName: GET:/httpclient-4.3.x-scenario/case/context-propagate
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -34,14 +33,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/httpclient-4.3.x-scenario/case/context-propagate'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /httpclient-4.3.x-scenario/case/httpclient, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/httpclient-4.3.x-scenario/case/httpclient, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: httpclient-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /httpclient-4.3.x-scenario/case/context-propagate
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -55,8 +53,7 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/httpclient-4.3.x-scenario/case/context-propagate'}
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
-    - operationName: /httpclient-4.3.x-scenario/case/httpclient
-      operationId: 0
+    - operationName: GET:/httpclient-4.3.x-scenario/case/httpclient
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/httpclient-5.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/httpclient-5.x-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /httpclient-5.x/back
+          - operationName: GET:/httpclient-5.x/back
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -64,13 +64,13 @@ segmentItems:
             spanType: Local
             peer: ''
             refs:
-              - {parentEndpoint: /httpclient-5.x/case/asyncGet, networkAddress: '',
+              - {parentEndpoint: GET:/httpclient-5.x/case/asyncGet, networkAddress: '',
                 refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
                  null, parentService: httpclient-5.x-scenario, traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /httpclient-5.x/case/asyncGet
+          - operationName: GET:/httpclient-5.x/case/asyncGet
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -84,7 +84,7 @@ segmentItems:
               - {key: url, value: 'http://127.0.0.1:8080/httpclient-5.x/case/asyncGet'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /httpclient-5.x/case/get, networkAddress: '127.0.0.1:8080',
+              - {parentEndpoint: GET:/httpclient-5.x/case/get, networkAddress: '127.0.0.1:8080',
                 refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                  null, parentService: httpclient-5.x-scenario, traceId: not null}
             skipAnalysis: 'false'
@@ -104,7 +104,7 @@ segmentItems:
               - {key: url, value: 'http://127.0.0.1:8080/httpclient-5.x/case/asyncGet'}
               - {key: http.method, value: GET}
             skipAnalysis: 'false'
-          - operationName: /httpclient-5.x/case/get
+          - operationName: GET:/httpclient-5.x/case/get
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
@@ -36,7 +36,7 @@ segmentItems:
         - {key: message, value: not null}
         - {key: stack, value: not null}
       refs:
-      - {parentEndpoint: /case/hystrix-scenario, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/case/hystrix-scenario, networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: hystrix-scenario, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/hystrix-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Hystrix/TestACommand/Execution
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Hystrix/TestACommand/Fallback
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -61,11 +59,18 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - {operationName: Hystrix/TestBCommand/Execution, operationId: 0, parentSpanId: 0,
-      spanId: 1, spanLayer: Unknown, startTime: nq 0, endTime: nq 0, componentId: 29,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - operationName: /case/hystrix-scenario
-      operationId: 0
+    - operationName: Hystrix/TestBCommand/Execution
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: Unknown
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 29
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: GET:/case/hystrix-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/influxdb-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/influxdb-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: InfluxDB/ping
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -33,8 +32,7 @@ segmentItems:
       tags:
       - {key: db.type, value: InfluxDB}
       skipAnalysis: 'false'
-    - operationName: /influxdb-scenario/case/healthCheck
-      operationId: 0
+    - operationName: HEAD:/influxdb-scenario/case/healthCheck
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -51,7 +49,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: InfluxDB/query
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -67,7 +64,6 @@ segmentItems:
       - {key: db.statement, value: 'CREATE DATABASE skywalking'}
       skipAnalysis: 'false'
     - operationName: InfluxDB/query
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -83,7 +79,6 @@ segmentItems:
       - {key: db.statement, value: 'CREATE RETENTION POLICY one_day ON skywalking DURATION 1d REPLICATION 1 DEFAULT'}
       skipAnalysis: 'false'
     - operationName: InfluxDB/write
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -99,7 +94,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: InfluxDB/query
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -114,8 +108,7 @@ segmentItems:
       - {key: db.instance, value: skywalking}
       - {key: db.statement, value: 'SELECT * FROM heartbeat'}
       skipAnalysis: 'false'
-    - operationName: /influxdb-scenario/case/influxdb-scenario
-      operationId: 0
+    - operationName: GET:/influxdb-scenario/case/influxdb-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/jdk-http-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jdk-http-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /jdk-http-scenario/case/receiveContext-0
-      operationId: 0
+    - operationName: GET:/jdk-http-scenario/case/receiveContext-0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -34,14 +33,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/jdk-http-scenario/case/receiveContext-0'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /jdk-http-scenario/case/jdk-http-scenario, networkAddress: 'localhost:8080',
+      - {parentEndpoint: GET:/jdk-http-scenario/case/jdk-http-scenario, networkAddress: 'localhost:8080',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: jdk-http-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /jdk-http-scenario/case/receiveContext-0
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -55,8 +53,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/jdk-http-scenario/case/receiveContext-0'}
       skipAnalysis: 'false'
-    - operationName: /jdk-http-scenario/case/jdk-http-scenario
-      operationId: 0
+    - operationName: GET:/jdk-http-scenario/case/jdk-http-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/jdk-threading-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jdk-threading-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: '{GET}/greet/{username}'
-      operationId: 0
+    - operationName: 'GET:/greet/{username}'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -37,7 +36,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /apache/skywalking
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -52,7 +50,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: Threading/test.apache.skywalking.apm.testcase.jdk.threading.Application$TestController$1/run
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -63,14 +60,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: '{GET}/greet/{username}', networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: 'GET:/greet/{username}', networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: jdk-threading-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /apache/skywalking
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -85,7 +81,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: Threading/test.apache.skywalking.apm.testcase.jdk.threading.Application$TestController$2/call
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -96,7 +91,7 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: '{GET}/greet/{username}', networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: 'GET:/greet/{username}', networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: jdk-threading-scenario, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/jdk14-with-gson-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jdk14-with-gson-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: nq 0
     spans:
     - operationName: Gson/ToJson
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -34,7 +33,6 @@ segmentItems:
       peer: ' '
       skipAnalysis: 'false'
     - operationName: Gson/FromJson
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Unknown
@@ -48,7 +46,6 @@ segmentItems:
       peer: ''
       skipAnalysis: 'false'
     - operationName: /person/action
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Unknown
@@ -61,8 +58,7 @@ segmentItems:
       skipAnalysis: 'false'
       tags:
         - {key: key, value: value}
-    - operationName: /case/gson-scenario
-      operationId: 0
+    - operationName: GET:/case/gson-scenario
       spanId: 0
       spanLayer: Http
       startTime: nq 0

--- a/test/plugin/scenarios/jedis-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jedis-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Jedis/echo
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Cache
@@ -35,7 +34,6 @@ segmentItems:
       - {key: db.statement, value: echo Test}
       skipAnalysis: 'false'
     - operationName: Jedis/set
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Cache
@@ -50,7 +48,6 @@ segmentItems:
       - {key: db.statement, value: set a}
       skipAnalysis: 'false'
     - operationName: Jedis/get
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Cache
@@ -65,7 +62,6 @@ segmentItems:
       - {key: db.statement, value: get a}
       skipAnalysis: 'false'
     - operationName: Jedis/del
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Cache
@@ -80,7 +76,6 @@ segmentItems:
       - {key: db.statement, value: del a}
       skipAnalysis: 'false'
     - operationName: Jedis/hset
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Cache
@@ -95,7 +90,6 @@ segmentItems:
         - {key: db.statement, value: hset a}
       skipAnalysis: 'false'
     - operationName: Jedis/hget
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Cache
@@ -110,7 +104,6 @@ segmentItems:
         - {key: db.statement, value: hget a}
       skipAnalysis: 'false'
     - operationName: Jedis/hdel
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Cache
@@ -124,8 +117,7 @@ segmentItems:
         - {key: db.type, value: Redis}
         - {key: db.statement, value: hdel a}
       skipAnalysis: 'false'
-    - operationName: /jedis-scenario/case/jedis-scenario
-      operationId: 0
+    - operationName: GET:/jedis-scenario/case/jedis-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/jetty-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jetty-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /jettyserver-case/case/receiveContext-0
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -34,7 +33,7 @@ segmentItems:
       - {key: url, value: 'http://localhost:18080/jettyserver-case/case/receiveContext-0'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /jettyclient-case/case/jettyclient-case, networkAddress: 'localhost:18080',
+      - {parentEndpoint: GET:/jettyclient-case/case/jettyclient-case, networkAddress: 'localhost:18080',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: jettyclient-scenario, traceId: not null}
       skipAnalysis: 'false'
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /jettyserver-case/case/receiveContext-0
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -58,14 +56,13 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:18080/jettyserver-case/case/receiveContext-0'}
       skipAnalysis: 'false'
-    - operationName: /jettyclient-case/case/jettyclient-case
-      operationId: 0
+    - operationName: GET:/jettyclient-case/case/jettyclient-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: gt 0
+      componentId: 1
       isError: false
       spanType: Entry
       tags:

--- a/test/plugin/scenarios/jsonrpc4j-1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jsonrpc4j-1.x-scenario/config/expectedData.yaml
@@ -21,7 +21,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /jsonrpc4j-1.x-scenario/path/to/demo-service.sayHello
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: RPCFramework
@@ -38,8 +37,7 @@ segmentItems:
                 key: url,
                 value: 'http://localhost:8080/jsonrpc4j-1.x-scenario/path/to/demo-service',
               }
-          - operationName: /jsonrpc4j-1.x-scenario/case/json-rpc
-            operationId: 0
+          - operationName: GET:/jsonrpc4j-1.x-scenario/case/json-rpc
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -59,7 +57,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /jsonrpc4j-1.x-scenario/path/to/demo-service
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -80,7 +77,7 @@ segmentItems:
               - { key: http.status_code, value: '200' }
             refs:
               - {
-                parentEndpoint: /jsonrpc4j-1.x-scenario/case/json-rpc,
+                parentEndpoint: GET:/jsonrpc4j-1.x-scenario/case/json-rpc,
                 networkAddress: 'localhost:8080',
                 refType: CrossProcess,
                 parentSpanId: 1,

--- a/test/plugin/scenarios/kafka-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/kafka-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Kafka/Producer/Callback
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: MQ
@@ -33,14 +32,13 @@ segmentItems:
       tags:
       - {key: mq.topic, value: test}
       refs:
-      - {parentEndpoint: /case/kafka-case, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/case/kafka-case, networkAddress: '', refType: CrossThread,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: 'kafka-scenario', traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
       - operationName: Kafka/Producer/Callback
-        operationId: 0
         parentSpanId: -1
         spanId: 0
         spanLayer: MQ
@@ -53,14 +51,13 @@ segmentItems:
         tags:
           - {key: mq.topic, value: test2}
         refs:
-          - {parentEndpoint: /case/kafka-case, networkAddress: '', refType: CrossThread,
+          - {parentEndpoint: GET:/case/kafka-case, networkAddress: '', refType: CrossThread,
              parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                 null, parentService: 'kafka-scenario', traceId: not null}
         skipAnalysis: 'false'
   - segmentId: not null
     spans:
       - operationName: Kafka/Producer/Callback
-        operationId: 0
         parentSpanId: -1
         spanId: 0
         spanLayer: MQ
@@ -73,14 +70,13 @@ segmentItems:
         tags:
           - { key: mq.topic, value: assign }
         refs:
-          - { parentEndpoint: /case/kafka-case, networkAddress: '', refType: CrossThread,
+          - { parentEndpoint: GET:/case/kafka-case, networkAddress: '', refType: CrossThread,
             parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                null, parentService: 'kafka-scenario', traceId: not null }
         skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: Kafka/test/Producer
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: MQ
@@ -95,7 +91,6 @@ segmentItems:
       - {key: mq.topic, value: test}
       skipAnalysis: 'false'
     - operationName: Kafka/test2/Producer
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: MQ
@@ -110,7 +105,6 @@ segmentItems:
         - {key: mq.topic, value: test2}
       skipAnalysis: 'false'
     - operationName: Kafka/test2/Producer
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: MQ
@@ -125,7 +119,6 @@ segmentItems:
         - {key: mq.topic, value: test2}
       skipAnalysis: 'false'
     - operationName: Kafka/assign/Producer
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: MQ
@@ -139,8 +132,7 @@ segmentItems:
         - { key: mq.broker, value: 'kafka-server:9092' }
         - { key: mq.topic, value: assign }
       skipAnalysis: 'false'
-    - operationName: /case/kafka-case
-      operationId: 0
+    - operationName: GET:/case/kafka-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -157,7 +149,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Kafka/test/Consumer/testGroup
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: MQ
@@ -172,14 +163,13 @@ segmentItems:
       - {key: mq.topic, value: test}
       - {key: transmission.latency, value: not null}
       refs:
-      - {parentEndpoint: /case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: 'kafka-scenario', traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
       - operationName: /kafka-scenario/case/kafka-thread2-ping
-        operationId: 0
         parentSpanId: 0
         spanId: 1
         spanLayer: Http
@@ -194,7 +184,6 @@ segmentItems:
         - {key: http.method, value: GET}
         - {key: url, value: 'http://localhost:8080/kafka-scenario/case/kafka-thread2-ping'}
       - operationName: Kafka/test./Consumer/testGroup2
-        operationId: 0
         parentSpanId: -1
         spanId: 0
         spanLayer: MQ
@@ -210,17 +199,16 @@ segmentItems:
           - {key: transmission.latency, value: not null}
           - {key: transmission.latency, value: not null}
         refs:
-          - {parentEndpoint: /case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
+          - {parentEndpoint: GET:/case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
              parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                 null, parentService: 'kafka-scenario', traceId: not null}
-          - {parentEndpoint: /case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
+          - {parentEndpoint: GET:/case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
              parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                 null, parentService: 'kafka-scenario', traceId: not null}
         skipAnalysis: 'false'
   - segmentId: not null
     spans:
-      - operationName: /case/kafka-thread2-ping
-        operationId: 0
+      - operationName: GET:/case/kafka-thread2-ping
         parentSpanId: -1
         spanId: 0
         spanLayer: Http
@@ -242,7 +230,6 @@ segmentItems:
   - segmentId: not null
     spans:
       - operationName: Kafka/assign/Consumer/testGroup3
-        operationId: 0
         parentSpanId: -1
         spanId: 0
         spanLayer: MQ
@@ -257,7 +244,7 @@ segmentItems:
           - { key: mq.topic, value: assign }
           - { key: transmission.latency, value: not null }
         refs:
-          - { parentEndpoint: /case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
+          - { parentEndpoint: GET:/case/kafka-case, networkAddress: 'kafka-server:9092', refType: CrossProcess,
             parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                null, parentService: 'kafka-scenario', traceId: not null }
         skipAnalysis: 'false'

--- a/test/plugin/scenarios/kotlin-coroutine-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/kotlin-coroutine-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.statement, value: 'SELECT * FROM PERSON WHERE ID = ?'}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/Connection/commit
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -52,7 +50,6 @@ segmentItems:
       - {key: db.statement, value: ''}
       skipAnalysis: 'false'
     - operationName: /Kotlin/Coroutine
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       startTime: nq 0
@@ -62,14 +59,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /kotlin-coroutine-scenario/case/h2, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/kotlin-coroutine-scenario/case/h2, networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: kotlin-coroutine-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -85,7 +81,6 @@ segmentItems:
       - {key: db.statement, value: 'SELECT * FROM PERSON WHERE ID = ?'}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/Connection/commit
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -100,8 +95,7 @@ segmentItems:
       - {key: db.instance, value: demo}
       - {key: db.statement, value: ''}
       skipAnalysis: 'false'
-    - operationName: /kotlin-coroutine-scenario/case/h2
-      operationId: 0
+    - operationName: GET:/kotlin-coroutine-scenario/case/h2
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/lettuce-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/lettuce-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /lettuce-scenario/case/healthCheck
-            operationId: 0
+          - operationName: HEAD:/lettuce-scenario/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -37,7 +36,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Lettuce/GET
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Cache
@@ -52,7 +50,6 @@ segmentItems:
               - {key: db.type, value: Redis}
               - {key: db.statement, value: GET key<key>}
           - operationName: Lettuce/SET
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Cache
@@ -67,7 +64,6 @@ segmentItems:
               - {key: db.type, value: Redis}
               - {key: db.statement, value: SET key<key0> value<value0>}
           - operationName: Lettuce/SET
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Cache
@@ -81,8 +77,7 @@ segmentItems:
             tags:
               - {key: db.type, value: Redis}
               - {key: db.statement, value: SET key<key1> value<value1>}
-          - operationName: /lettuce-scenario/case/lettuce-case
-            operationId: 0
+          - operationName: GET:/lettuce-scenario/case/lettuce-case
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/mariadb-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mariadb-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Mariadb/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -38,7 +37,6 @@ segmentItems:
         value: "CREATE TABLE test_table(\nid VARCHAR(1) PRIMARY KEY, \nvalue VARCHAR(10)\
           \ NOT NULL)"
     - operationName: Mariadb/JDBI/PreparedStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -54,7 +52,6 @@ segmentItems:
       - {key: db.instance, value: test}
       - {key: db.statement, value: "INSERT INTO test_table(id, value) VALUES(?,?)"}
     - operationName: Mariadb/JDBI/PreparedStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -70,7 +67,6 @@ segmentItems:
       - {key: db.instance, value: test}
       - {key: db.statement, value: "SELECT id, value FROM test_table WHERE id = ?"}
     - operationName: Mariadb/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -86,7 +82,6 @@ segmentItems:
       - {key: db.instance, value: test}
       - {key: db.statement, value: "DROP table test_table"}
     - operationName: Mariadb/JDBI/Connection/close
-      operationId: eq 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -101,8 +96,7 @@ segmentItems:
       - {key: db.type, value: sql}
       - {key: db.instance, value: test}
       - {key: db.statement, value: ''}
-    - operationName: /mariadb-scenario/case/mariadb-scenario
-      operationId: eq 0
+    - operationName: GET:/mariadb-scenario/case/mariadb-scenario
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mongodb-3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: MongoDB/CreateCollectionOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -35,7 +34,6 @@ segmentItems:
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -50,7 +48,6 @@ segmentItems:
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/FindOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -65,7 +62,6 @@ segmentItems:
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -80,7 +76,6 @@ segmentItems:
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/FindOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -95,7 +90,6 @@ segmentItems:
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/MixedBulkWriteOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Database
@@ -110,7 +104,6 @@ segmentItems:
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
     - operationName: MongoDB/DropDatabaseOperation
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Database
@@ -124,8 +117,7 @@ segmentItems:
       - {key: db.type, value: MongoDB}
       - {key: db.bind_vars, value: not null}
       skipAnalysis: 'false'
-    - operationName: /mongodb-case/case/mongodb
-      operationId: 0
+    - operationName: GET:/mongodb-case/case/mongodb
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/mongodb-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mongodb-4.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: MongoDB/CreateCollectionOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Database
@@ -35,7 +34,6 @@ segmentItems:
               - {key: db.bind_vars, value: 'testCollection'}
             skipAnalysis: 'false'
           - operationName: MongoDB/MixedBulkWriteOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Database
@@ -50,7 +48,6 @@ segmentItems:
               - {key: db.bind_vars, value: not null}
             skipAnalysis: 'false'
           - operationName: MongoDB/FindOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Database
@@ -65,7 +62,6 @@ segmentItems:
               - {key: db.bind_vars, value: '{"name": "org"}'}
             skipAnalysis: 'false'
           - operationName: MongoDB/MixedBulkWriteOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Database
@@ -80,7 +76,6 @@ segmentItems:
               - {key: db.bind_vars, value: '{"name": "org"},'}
             skipAnalysis: 'false'
           - operationName: MongoDB/FindOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Database
@@ -95,7 +90,6 @@ segmentItems:
               - {key: db.bind_vars, value: '{"name": "testA"}'}
             skipAnalysis: 'false'
           - operationName: MongoDB/MixedBulkWriteOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 6
             spanLayer: Database
@@ -110,7 +104,6 @@ segmentItems:
               - {key: db.bind_vars, value: '{"id": "1"},'}
             skipAnalysis: 'false'
           - operationName: MongoDB/DropDatabaseOperation
-            operationId: 0
             parentSpanId: 0
             spanId: 7
             spanLayer: Database
@@ -124,8 +117,7 @@ segmentItems:
               - {key: db.type, value: MongoDB}
               - {key: db.bind_vars, value: null}
             skipAnalysis: 'false'
-          - operationName: /mongodb-4.x-scenario/case/mongodb-4.x-scenario
-            operationId: 0
+          - operationName: GET:/mongodb-4.x-scenario/case/mongodb-4.x-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/mssql-jdbc-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mssql-jdbc-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Mssql/JDBI/PreparedStatement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 1
             tags:
@@ -39,7 +38,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/PreparedStatement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 2
             tags:
@@ -57,7 +55,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/PreparedStatement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 3
             tags:
@@ -75,7 +72,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/Statement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 4
             tags:
@@ -92,7 +88,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/Connection/close
-            operationId: eq 0
             parentSpanId: 0
             spanId: 5
             tags:
@@ -108,8 +103,7 @@ segmentItems:
             componentId: 104
             peer: mssql-server:1433
             skipAnalysis: 'false'
-          - operationName: /mssql-jdbc-scenario/case/mssql-jdbc-scenario
-            operationId: eq 0
+          - operationName: GET:/mssql-jdbc-scenario/case/mssql-jdbc-scenario
             parentSpanId: -1
             spanId: 0
             startTime: nq 0

--- a/test/plugin/scenarios/mssql-jtds-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mssql-jtds-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Mssql/JDBI/PreparedStatement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 1
             tags:
@@ -39,7 +38,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/PreparedStatement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 2
             tags:
@@ -56,7 +54,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/Statement/execute
-            operationId: eq 0
             parentSpanId: 0
             spanId: 3
             tags:
@@ -73,7 +70,6 @@ segmentItems:
             peer: mssql-server:1433
             skipAnalysis: 'false'
           - operationName: Mssql/JDBI/Connection/close
-            operationId: eq 0
             parentSpanId: 0
             spanId: 4
             tags:
@@ -89,8 +85,7 @@ segmentItems:
             componentId: 104
             peer: mssql-server:1433
             skipAnalysis: 'false'
-          - operationName: /mssql-jtds-scenario/case/mssql-jtds-scenario
-            operationId: eq 0
+          - operationName: GET:/mssql-jtds-scenario/case/mssql-jtds-scenario
             parentSpanId: -1
             spanId: 0
             startTime: nq 0

--- a/test/plugin/scenarios/mybatis-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mybatis-3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
     - segmentId: not null
       spans:
       - operationName: Mysql/JDBI/PreparedStatement/execute
-        operationId: 0
         parentSpanId: 1
         spanId: 2
         spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
         - {key: db.instance, value: ''}
         - {key: db.statement, value: 'insert into test.table_demo (name) values (?)'}
       - operationName: org.apache.ibatis.session.defaults.DefaultSqlSession.insert(java.lang.String,java.lang.Object)
-        operationId: 0
         parentSpanId: 0
         spanId: 1
         spanLayer: Unknown
@@ -50,7 +48,6 @@ segmentItems:
         tags:
         - {key: mybatis.mapper, value: test.apache.skywalking.apm.testcase.mybatis.mapper.DemoMapper.insert}
       - operationName: Mysql/JDBI/Connection/close
-        operationId: 0
         parentSpanId: 0
         spanId: 3
         spanLayer: Database
@@ -66,7 +63,6 @@ segmentItems:
           - {key: db.instance, value: ''}
           - {key: db.statement, value: ''}
       - operationName: Mysql/JDBI/PreparedStatement/execute
-        operationId: 0
         parentSpanId: 4
         spanId: 5
         spanLayer: Database
@@ -82,7 +78,6 @@ segmentItems:
         - {key: db.instance, value: ''}
         - {key: db.statement, value: 'insert into test.table_demo (name) values (?)'}
       - operationName: org.apache.ibatis.session.defaults.DefaultSqlSession.insert(java.lang.String,java.lang.Object)
-        operationId: 0
         parentSpanId: 0
         spanId: 4
         spanLayer: Unknown
@@ -96,7 +91,6 @@ segmentItems:
         tags:
         - {key: mybatis.mapper, value: test.apache.skywalking.apm.testcase.mybatis.mapper.DemoMapper.insert}
       - operationName: Mysql/JDBI/Connection/close
-        operationId: 0
         parentSpanId: 0
         spanId: 6
         spanLayer: Database
@@ -111,8 +105,7 @@ segmentItems:
         - {key: db.type, value: sql}
         - {key: db.instance, value: ''}
         - {key: db.statement, value: ''}
-      - operationName: /case/mybatis-case
-        operationId: 0
+      - operationName: GET:/case/mybatis-case
         parentSpanId: -1
         spanId: 0
         spanLayer: Http

--- a/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Mysql/JDBI/PreparedStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 1
       tags:
@@ -39,7 +38,6 @@ segmentItems:
       peer: mysql-server:3306
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/PreparedStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 2
       tags:
@@ -56,7 +54,6 @@ segmentItems:
       peer: mysql-server:3306
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 3
       tags:
@@ -73,7 +70,6 @@ segmentItems:
       peer: mysql-server:3306
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 4
       tags:
@@ -90,7 +86,6 @@ segmentItems:
       peer: mysql-server:3306
       skipAnalysis: 'false'  
     - operationName: Mysql/JDBI/Statement/executeQuery
-      operationId: eq 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -106,7 +101,6 @@ segmentItems:
         - {key: db.instance, value: test}
         - {key: db.statement, value: SHOW CREATE PROCEDURE `test`.`testProcedure`}
     - operationName: Mysql/JDBI/CallableStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 6
       tags:
@@ -123,7 +117,6 @@ segmentItems:
       peer: mysql-server:3306
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 7
       tags:
@@ -140,7 +133,6 @@ segmentItems:
       peer: mysql-server:3306
       skipAnalysis: 'false'  
     - operationName: Mysql/JDBI/Connection/close
-      operationId: eq 0
       parentSpanId: 0
       spanId: 8
       tags:
@@ -156,8 +148,7 @@ segmentItems:
       componentId: 33
       peer: mysql-server:3306
       skipAnalysis: 'false'
-    - operationName: /mysql-scenario/case/mysql-scenario
-      operationId: eq 0
+    - operationName: GET:/mysql-scenario/case/mysql-scenario
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/neo4j-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/neo4j-4.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Neo4j/Transaction/runAsync
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Database
@@ -37,14 +36,13 @@ segmentItems:
               - { key: db.statement, value: 'CREATE (a:Person {name: $name}) RETURN a.name' }
               - { key: db.cypher.parameters, value: not null }
             refs:
-              - { parentEndpoint: /neo4j-scenario/case/neo4j-scenario, networkAddress: '',
+              - { parentEndpoint: GET:/neo4j-scenario/case/neo4j-scenario, networkAddress: '',
                   refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
                   parentServiceInstance: not null, parentService: neo4j-4.x-scenario,
                   traceId: not null }
       - segmentId: not null
         spans:
           - operationName: Neo4j/Session/runAsync
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Database
@@ -61,7 +59,6 @@ segmentItems:
               - { key: db.statement, value: 'CREATE (a:Person {name: $name}) RETURN a.name' }
               - { key: db.cypher.parameters, value: not null }
           - operationName: Neo4j/Session/runAsync
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Database
@@ -78,7 +75,6 @@ segmentItems:
               - { key: db.statement, value: 'CREATE (a:Person {name: $name}) RETURN a.name' }
               - { key: db.cypher.parameters, value: not null }
           - operationName: Neo4j/Session/runRx
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Database
@@ -95,7 +91,6 @@ segmentItems:
               - { key: db.statement, value: 'CREATE (a:Person {name: $name}) RETURN a.name' }
               - { key: db.cypher.parameters, value: not null }
           - operationName: Neo4j/Transaction/runAsync
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Database
@@ -112,7 +107,6 @@ segmentItems:
               - { key: db.statement, value: 'CREATE (a:Person {name: $name}) RETURN a.name' }
               - { key: db.cypher.parameters, value: not null }
           - operationName: Neo4j/Transaction/runRx
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Database
@@ -128,8 +122,7 @@ segmentItems:
               - { key: db.instance, value: neo4j }
               - { key: db.statement, value: 'CREATE (a:Person {name: $name}) RETURN a.name' }
               - { key: db.cypher.parameters, value: not null }
-          - operationName: /neo4j-scenario/case/neo4j-scenario
-            operationId: 0
+          - operationName: GET:/neo4j-scenario/case/neo4j-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/netty-socketio-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/netty-socketio-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /netty-socketio-scenario/case/netty-socketio
-      operationId: 0
+    - operationName: GET:/netty-socketio-scenario/case/netty-socketio
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -37,7 +36,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: SocketIO/onConnect
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -52,13 +50,20 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - {operationName: SocketIO/send_data/receive, operationId: 0, parentSpanId: -1,
-      spanId: 0, spanLayer: Http, startTime: nq 0, endTime: nq 0, componentId: 76,
-      isError: false, spanType: Entry, peer: '', skipAnalysis: 'false'}
+    - operationName: SocketIO/send_data/receive
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 76
+      isError: false
+      spanType: Entry
+      peer: ''
+      skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /socket.io/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/okhttp-scenario/config/expectedData.yaml
@@ -19,11 +19,16 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - {operationName: Async/okhttp-case/case/receiveContext-0, operationId: 0, parentSpanId: 0,
-      spanId: 1, startTime: nq 0, endTime: nq 0, componentId: 0, isError: false, spanType: Local,
-      skipAnalysis: 'false'}
-    - operationName: /case/okhttp-case
-      operationId: 0
+    - operationName: Async/okhttp-case/case/receiveContext-0
+      parentSpanId: 0
+      spanId: 1
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 0
+      isError: false
+      spanType: Local
+      skipAnalysis: 'false'
+    - operationName: GET:/case/okhttp-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -38,8 +43,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /case/receiveContext-0
-      operationId: 0
+    - operationName: GET:/case/receiveContext-0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -58,8 +62,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /case/receiveContext-1
-      operationId: 0
+    - operationName: GET:/case/receiveContext-1
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -79,7 +82,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /okhttp-case/case/receiveContext-0
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -93,7 +95,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://127.0.0.1:8080/okhttp-case/case/receiveContext-0'}
       refs:
-      - {parentEndpoint: /case/okhttp-case, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/case/okhttp-case, networkAddress: '', refType: CrossThread,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: okhttp-scenario, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/oracle-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/oracle-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Oracle/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -38,7 +37,6 @@ segmentItems:
           \ NOT NULL)"
       skipAnalysis: 'false'
     - operationName: Oracle/JDBI/PreparedStatement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -54,7 +52,6 @@ segmentItems:
       - {key: db.statement, value: 'INSERT INTO test_007(id, value) VALUES(?,?)'}
       skipAnalysis: 'false'
     - operationName: Oracle/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -70,7 +67,6 @@ segmentItems:
       - {key: db.statement, value: 'SELECT id, value FROM test_007 WHERE id=?'}
       skipAnalysis: 'false'
     - operationName: Oracle/JDBI/Statement/execute
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -86,7 +82,6 @@ segmentItems:
       - {key: db.statement, value: DROP table test_007}
       skipAnalysis: 'false'
     - operationName: Oracle/JDBI/Connection/close
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -101,8 +96,7 @@ segmentItems:
       spanType: Exit
       peer: oracle-server:1521
       skipAnalysis: 'false'
-    - operationName: /oracle-scenario/case/oracle
-      operationId: 0
+    - operationName: GET:/oracle-scenario/case/oracle
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/play-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/play-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /play-scenario/case/play-scenario/projects/{projectId}
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/postgresql-above9.4.1207-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/postgresql-above9.4.1207-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: PostgreSQL/JDBI/PreparedStatement/executeWithFlags
-      operationId: eq 0
       parentSpanId: 0
       spanId: 1
       tags:
@@ -38,7 +37,6 @@ segmentItems:
       peer: postgresql-server:5432
       skipAnalysis: 'false'
     - operationName: PostgreSQL/JDBI/CallableStatement/executeWithFlags
-      operationId: eq 0
       parentSpanId: 0
       spanId: 2
       tags:
@@ -55,7 +53,6 @@ segmentItems:
       peer: postgresql-server:5432
       skipAnalysis: 'false'
     - operationName: PostgreSQL/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 3
       tags:
@@ -71,7 +68,6 @@ segmentItems:
       peer: postgresql-server:5432
       skipAnalysis: 'false'
     - operationName: PostgreSQL/JDBI/Connection/close
-      operationId: eq 0
       parentSpanId: 0
       spanId: 4
       tags:
@@ -86,8 +82,7 @@ segmentItems:
       componentId: 37
       peer: postgresql-server:5432
       skipAnalysis: 'false'
-    - operationName: /postgresql-scenario/case/postgres
-      operationId: eq 0
+    - operationName: GET:/postgresql-scenario/case/postgres
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/postgresql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/postgresql-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: PostgreSQL/JDBI/PreparedStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 1
       tags:
@@ -38,7 +37,6 @@ segmentItems:
       peer: postgresql-server:5432
       skipAnalysis: 'false'
     - operationName: PostgreSQL/JDBI/CallableStatement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 2
       tags:
@@ -54,7 +52,6 @@ segmentItems:
       peer: postgresql-server:5432
       skipAnalysis: 'false'
     - operationName: PostgreSQL/JDBI/Statement/execute
-      operationId: eq 0
       parentSpanId: 0
       spanId: 3
       tags:
@@ -70,7 +67,6 @@ segmentItems:
       peer: postgresql-server:5432
       skipAnalysis: 'false'
     - operationName: PostgreSQL/JDBI/Connection/close
-      operationId: eq 0
       parentSpanId: 0
       spanId: 4
       tags:
@@ -85,8 +81,7 @@ segmentItems:
       componentId: 37
       peer: postgresql-server:5432
       skipAnalysis: 'false'
-    - operationName: /postgresql-scenario/case/postgres
-      operationId: eq 0
+    - operationName: GET:/postgresql-scenario/case/postgres
       parentSpanId: -1
       spanId: 0
       startTime: nq 0

--- a/test/plugin/scenarios/pulsar-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/pulsar-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
     - segmentId: not null
       spans:
         - operationName: Pulsar/test/Producer
-          operationId: 0
           parentSpanId: 0
           spanId: 1
           spanLayer: MQ
@@ -35,7 +34,6 @@ segmentItems:
             - { key: mq.topic, value: test }
           skipAnalysis: 'false'
         - operationName: Pulsar/testMultiPartition/Producer
-          operationId: 0
           parentSpanId: 0
           spanId: 2
           spanLayer: MQ
@@ -49,8 +47,7 @@ segmentItems:
           tags:
             - { key: mq.broker, value: not null }
             - { key: mq.topic, value: testMultiPartition }
-        - operationName: /case/pulsar-case
-          operationId: 0
+        - operationName: GET:/case/pulsar-case
           parentSpanId: -1
           spanId: 0
           spanLayer: Http
@@ -67,7 +64,6 @@ segmentItems:
     - segmentId: not null
       spans:
         - operationName: Pulsar/Producer/Callback
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -80,14 +76,13 @@ segmentItems:
           tags:
             - { key: mq.topic, value: test }
           refs:
-            - { parentEndpoint: /case/pulsar-case, networkAddress: '', refType: CrossThread,
+            - { parentEndpoint: GET:/case/pulsar-case, networkAddress: '', refType: CrossThread,
               parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                  null, parentService: pulsar-scenario, traceId: not null }
           skipAnalysis: 'false'
     - segmentId: not null
       spans:
         - operationName: Pulsar/test/Consumer/test
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -102,14 +97,13 @@ segmentItems:
             - { key: mq.broker, value: not null }
             - { key: mq.topic, value: test }
           refs:
-            - { parentEndpoint: /case/pulsar-case, networkAddress: not null, refType: CrossProcess,
+            - { parentEndpoint: GET:/case/pulsar-case, networkAddress: not null, refType: CrossProcess,
               parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                  null, parentService: pulsar-scenario, traceId: not null }
           skipAnalysis: 'false'
     - segmentId: not null
       spans:
         - operationName: Pulsar/test/Consumer/testWithListener
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -125,14 +119,13 @@ segmentItems:
             - { key: mq.broker, value: not null }
             - { key: mq.topic, value: test }
           refs:
-            - { parentEndpoint: /case/pulsar-case, networkAddress: not null,
+            - { parentEndpoint: GET:/case/pulsar-case, networkAddress: not null,
                 refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
                 parentServiceInstance: not null, parentService: pulsar-scenario,
                 traceId: not null }
     - segmentId: not null
       spans:
         - operationName: Pulsar/test/Consumer/MessageListener
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -152,7 +145,6 @@ segmentItems:
     - segmentId: not null
       spans:
         - operationName: Pulsar/Producer/Callback
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -165,14 +157,13 @@ segmentItems:
           tags:
             - { key: mq.topic, value: testMultiPartition }
           refs:
-            - { parentEndpoint: /case/pulsar-case, networkAddress: '', refType: CrossThread,
+            - { parentEndpoint: GET:/case/pulsar-case, networkAddress: '', refType: CrossThread,
               parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                  null, parentService: pulsar-scenario, traceId: not null }
           skipAnalysis: 'false'
     - segmentId: not null
       spans:
         - operationName: Pulsar/testMultiPartition/Consumer/test
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -187,14 +178,13 @@ segmentItems:
             - { key: mq.broker, value: not null }
             - { key: mq.topic, value: testMultiPartition }
           refs:
-            - { parentEndpoint: /case/pulsar-case, networkAddress: not null, refType: CrossProcess,
+            - { parentEndpoint: GET:/case/pulsar-case, networkAddress: not null, refType: CrossProcess,
               parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
                                                                  null, parentService: pulsar-scenario, traceId: not null }
           skipAnalysis: 'false'
     - segmentId: not null
       spans:
         - operationName: Pulsar/testMultiPartition/Consumer/testWithListener
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ
@@ -210,14 +200,13 @@ segmentItems:
             - { key: mq.broker, value: not null }
             - { key: mq.topic, value: testMultiPartition }
           refs:
-            - { parentEndpoint: /case/pulsar-case, networkAddress: not null,
+            - { parentEndpoint: GET:/case/pulsar-case, networkAddress: not null,
                 refType: CrossProcess, parentSpanId: 2, parentTraceSegmentId: not null,
                 parentServiceInstance: not null, parentService: pulsar-scenario,
                 traceId: not null }
     - segmentId: not null
       spans:
         - operationName: Pulsar/testMultiPartition/Consumer/MessageListener
-          operationId: 0
           parentSpanId: -1
           spanId: 0
           spanLayer: MQ

--- a/test/plugin/scenarios/quartz-scheduler-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/quartz-scheduler-2.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /quartz-scheduler-2.x-scenario/case/call
-      operationId: 0
+    - operationName: GET:/quartz-scheduler-2.x-scenario/case/call
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -39,7 +38,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /quartz-scheduler-2.x-scenario/case/call
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -54,7 +52,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/quartz-scheduler-2.x-scenario/case/call'}
     - operationName: quartz-scheduler/org.apache.skywalking.apm.testcase.quartzscheduler.job.DemoJob
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -73,7 +70,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: quartz-scheduler/org.apache.skywalking.apm.testcase.quartzscheduler.job.ExceptionJob
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown

--- a/test/plugin/scenarios/quasar-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/quasar-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /quasar-scenario/case/quasar-scenario
-      operationId: 0
+    - operationName: GET:/quasar-scenario/case/quasar-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -37,7 +36,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /quasar-scenario/case/ping
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -52,7 +50,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/quasar-scenario/case/ping'}
     - operationName: QUASAR/Fiber
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -64,7 +61,7 @@ segmentItems:
       peer: ''
       skipAnalysis: false
       refs:
-      - {parentEndpoint: /quasar-scenario/case/quasar-scenario, networkAddress: '',
+      - {parentEndpoint: GET:/quasar-scenario/case/quasar-scenario, networkAddress: '',
          refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
          parentServiceInstance: not null, parentService: quasar-scenario,
          traceId: not null}

--- a/test/plugin/scenarios/rabbitmq-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/rabbitmq-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: RabbitMQ/Topic/Queue/test/Consumer
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: MQ
@@ -36,14 +35,13 @@ segmentItems:
       - {key: mq.queue, value: test}
       - {key: transmission.latency, value: not null}
       refs:
-      - {parentEndpoint: /rabbitmq-scenario/case/rabbitmq, networkAddress: not null,
+      - {parentEndpoint: GET:/rabbitmq-scenario/case/rabbitmq, networkAddress: not null,
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: rabbitmq-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: RabbitMQ/Topic/Queue/test/Producer
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: MQ
@@ -58,8 +56,7 @@ segmentItems:
       - {key: mq.queue, value: test}
       - {key: mq.topic, value: ''}
       skipAnalysis: 'false'
-    - operationName: /rabbitmq-scenario/case/rabbitmq
-      operationId: 0
+    - operationName: GET:/rabbitmq-scenario/case/rabbitmq
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/redisson-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/redisson-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Redisson/SET
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Cache
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.statement, value: 'SET key_a ?'}
       skipAnalysis: 'false'
     - operationName: Redisson/BATCH_EXECUTE
-      operationId: 0
       parentSpanId: 0
       spanId: nq 0
       spanLayer: Cache
@@ -52,8 +50,7 @@ segmentItems:
       - {key: db.statement, value: 'SET batch_k_a ?;SET batch_k_b ?;PEXPIRE batch_k_b
           20000;'}
       skipAnalysis: 'false'
-    - operationName: /case/redisson-case
-      operationId: 0
+    - operationName: GET:/case/redisson-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/resttemplate-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/resttemplate-4.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /resttemplate-4.x-scenario/resttemplate/case/healthcheck
-      operationId: 0
+    - operationName: HEAD:/resttemplate-4.x-scenario/resttemplate/case/healthcheck
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 1
       isError: false
       spanType: Entry
       peer: ''
@@ -36,14 +35,13 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /resttemplate-4.x-scenario/resttemplate/asyncback
-      operationId: 0
+    - operationName: GET:/resttemplate-4.x-scenario/resttemplate/asyncback
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 1
       isError: false
       spanType: Entry
       peer: ''
@@ -51,21 +49,20 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/resttemplate-4.x-scenario/resttemplate/asyncback'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /resttemplate-4.x-scenario/resttemplate/case/resttemplate,
+      - {parentEndpoint: GET:/resttemplate-4.x-scenario/resttemplate/case/resttemplate,
         networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: 1,
         parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: resttemplate-4.x-scenario,
         traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /resttemplate-4.x-scenario/resttemplate/syncback
-      operationId: 0
+    - operationName: GET:/resttemplate-4.x-scenario/resttemplate/syncback
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 1
       isError: false
       spanType: Entry
       peer: ''
@@ -73,7 +70,7 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/resttemplate-4.x-scenario/resttemplate/syncback'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /resttemplate-4.x-scenario/resttemplate/case/resttemplate,
+      - {parentEndpoint: GET:/resttemplate-4.x-scenario/resttemplate/case/resttemplate,
         networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: 3,
         parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: resttemplate-4.x-scenario,
         traceId: not null}
@@ -81,13 +78,12 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /resttemplate-4.x-scenario/resttemplate/asyncback
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 13
       isError: false
       spanType: Exit
       peer: localhost:8080
@@ -95,18 +91,24 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/resttemplate-4.x-scenario/resttemplate/asyncback'}
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
-    - {operationName: 'future/get:/resttemplate-4.x-scenario/resttemplate/asyncback',
-      operationId: 0, parentSpanId: 0, spanId: 2, spanLayer: Unknown, startTime: nq
-        0, endTime: nq 0, componentId: 0, isError: false, spanType: Local, peer: '',
-      skipAnalysis: 'false'}
+    - operationName: 'future/get:/resttemplate-4.x-scenario/resttemplate/asyncback'
+      parentSpanId: 0
+      spanId: 2
+      spanLayer: Unknown
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 0
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
     - operationName: /resttemplate-4.x-scenario/resttemplate/syncback
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Http
       startTime: nq 0
       endTime: nq 0
-      componentId: not null
+      componentId: 13
       isError: false
       spanType: Exit
       peer: localhost:8080
@@ -114,8 +116,7 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/resttemplate-4.x-scenario/resttemplate/syncback'}
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
-    - operationName: /resttemplate-4.x-scenario/resttemplate/case/resttemplate
-      operationId: 0
+    - operationName: GET:/resttemplate-4.x-scenario/resttemplate/case/resttemplate
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/retransform-class-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/retransform-class-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /case/retransform-class-scenario
-            operationId: 0
+          - operationName: GET:/case/retransform-class-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: ge 1
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''

--- a/test/plugin/scenarios/retransform-class-tomcat-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/retransform-class-tomcat-scenario/config/expectedData.yaml
@@ -26,7 +26,7 @@ segmentItems:
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: 1
+            componentId: 14
             isError: false
             spanType: Entry
             peer: ''

--- a/test/plugin/scenarios/retransform-class-tomcat-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/retransform-class-tomcat-scenario/config/expectedData.yaml
@@ -20,14 +20,13 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /case/retransform-class
-            operationId: 0
+          - operationName: GET:/case/retransform-class
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: ge 1
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''

--- a/test/plugin/scenarios/sentinel-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/sentinel-scenario/config/expectedData.yaml
@@ -20,8 +20,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /case/healthCheck
-      operationId: 0
+    - operationName: HEAD:/case/healthCheck
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -38,7 +37,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Sentinel/test_SphO_entry
-      operationId: 0
       parentSpanId: 1
       spanId: 2
       spanLayer: Unknown
@@ -53,11 +51,18 @@ segmentItems:
       - logEvent:
         - {key: block_type, value: flow}
         - {key: blocked, value: 'true'}
-    - {operationName: Sentinel/test_SphU_entry, operationId: 0, parentSpanId: 0, spanId: 1,
-      spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 113,
-      isError: false, spanType: Local, peer: '', skipAnalysis: false}
+    - operationName: Sentinel/test_SphU_entry
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 113
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: false
     - operationName: Sentinel/test_SphU_asyncEntry
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Unknown
@@ -72,8 +77,7 @@ segmentItems:
       - logEvent:
         - {key: block_type, value: flow}
         - {key: blocked, value: 'true'}
-    - operationName: /case/sentinel-scenario
-      operationId: 0
+    - operationName: GET:/case/sentinel-scenario
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/servicecomb-0.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/servicecomb-0.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: codefirst.codeFirstHello.sayHi
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -41,7 +40,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: codefirst.codeFirstHello.sayHi
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: RPCFramework
@@ -55,7 +53,6 @@ segmentItems:
       - {key: url, value: /sayHi}
       skipAnalysis: 'false'
     - operationName: codefirst.codeFirstSpringmvcHelloClient.say
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework

--- a/test/plugin/scenarios/servicecomb-1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/servicecomb-1.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: codefirst.codeFirstHello.sayHi
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -41,7 +40,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: codefirst.codeFirstHello.sayHi
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: RPCFramework
@@ -55,7 +53,6 @@ segmentItems:
       - {key: url, value: /sayHi}
       skipAnalysis: 'false'
     - operationName: codefirst.codeFirstSpringmvcHelloClient.say
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework

--- a/test/plugin/scenarios/shardingsphere-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/shardingsphere-3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_1}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -47,14 +45,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-3.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-3.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -70,7 +67,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_1}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -81,14 +77,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-3.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-3.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -104,7 +99,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_0}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -115,14 +109,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-3.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-3.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: shardingsphere-3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /ShardingSphere/parseSQL/
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -136,7 +129,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 3
       spanId: 4
       spanLayer: Database
@@ -151,14 +143,29 @@ segmentItems:
       - {key: db.instance, value: demo_ds_0}
       - {key: db.statement, value: SELECT * FROM t_order_0}
       skipAnalysis: 'false'
-    - {operationName: /ShardingSphere/executeSQL/, operationId: 0, parentSpanId: 2,
-      spanId: 3, spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 60,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - {operationName: /ShardingSphere/JDBCRootInvoke/, operationId: 0, parentSpanId: 0,
-      spanId: 2, spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 60,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - operationName: /shardingsphere-3.x-scenario/case/execute
-      operationId: 0
+    - operationName: /ShardingSphere/executeSQL/
+      parentSpanId: 2
+      spanId: 3
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 60
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: /ShardingSphere/JDBCRootInvoke/
+      parentSpanId: 0
+      spanId: 2
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 60
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: GET:/shardingsphere-3.x-scenario/case/execute
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/shardingsphere-4.0.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/shardingsphere-4.0.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_1}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -47,14 +45,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-4.0.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-4.0.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -70,7 +67,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_1}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -81,14 +77,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-4.0.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-4.0.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -104,7 +99,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_0}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -115,14 +109,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-4.0.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-4.0.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: shardingsphere-4.0.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /ShardingSphere/parseSQL/
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -136,7 +129,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 3
       spanId: 4
       spanLayer: Database
@@ -151,14 +143,29 @@ segmentItems:
       - {key: db.instance, value: demo_ds_0}
       - {key: db.statement, value: SELECT * FROM t_order_0}
       skipAnalysis: 'false'
-    - {operationName: /ShardingSphere/executeSQL/, operationId: 0, parentSpanId: 2,
-      spanId: 3, spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 60,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - {operationName: /ShardingSphere/JDBCRootInvoke/, operationId: 0, parentSpanId: 0,
-      spanId: 2, spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 60,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - operationName: /shardingsphere-4.0.x-scenario/case/execute
-      operationId: 0
+    - operationName: /ShardingSphere/executeSQL/
+      parentSpanId: 2
+      spanId: 3
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 60
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: /ShardingSphere/JDBCRootInvoke/
+      parentSpanId: 0
+      spanId: 2
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 60
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: GET:/shardingsphere-4.0.x-scenario/case/execute
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/shardingsphere-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/shardingsphere-4.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_1}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -47,14 +45,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-4.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-4.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -70,7 +67,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_1}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -81,14 +77,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-4.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-4.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -104,7 +99,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order_0}
       skipAnalysis: 'false'
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -115,14 +109,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /shardingsphere-4.x-scenario/case/execute, networkAddress: '',
+      - {parentEndpoint: GET:/shardingsphere-4.x-scenario/case/execute, networkAddress: '',
         refType: CrossThread, parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: shardingsphere-4.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /ShardingSphere/parseSQL/
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -136,7 +129,6 @@ segmentItems:
       - {key: db.statement, value: SELECT * FROM t_order}
       skipAnalysis: 'false'
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 3
       spanId: 4
       spanLayer: Database
@@ -151,14 +143,29 @@ segmentItems:
       - {key: db.instance, value: demo_ds_0}
       - {key: db.statement, value: SELECT * FROM t_order_0}
       skipAnalysis: 'false'
-    - {operationName: /ShardingSphere/executeSQL/, operationId: 0, parentSpanId: 2,
-      spanId: 3, spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 60,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - {operationName: /ShardingSphere/JDBCRootInvoke/, operationId: 0, parentSpanId: 0,
-      spanId: 2, spanLayer: Unknown, startTime: not null, endTime: not null, componentId: 60,
-      isError: false, spanType: Local, peer: '', skipAnalysis: 'false'}
-    - operationName: /shardingsphere-4.x-scenario/case/execute
-      operationId: 0
+    - operationName: /ShardingSphere/executeSQL/
+      parentSpanId: 2
+      spanId: 3
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 60
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: /ShardingSphere/JDBCRootInvoke/
+      parentSpanId: 0
+      spanId: 2
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 60
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: GET:/shardingsphere-4.x-scenario/case/execute
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/shardingsphere-5.0.0-beta-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/shardingsphere-5.0.0-beta-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -36,7 +35,6 @@ segmentItems:
       - {key: db.instance, value: demo_ds_1}
       - {key: db.statement, value: SELECT * FROM t_order_0}
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -48,7 +46,7 @@ segmentItems:
       peer: ''
       skipAnalysis: false
       refs:
-      - parentEndpoint: /shardingsphere-5.0.0-beta-scenario/case/execute
+      - parentEndpoint: GET:/shardingsphere-5.0.0-beta-scenario/case/execute
         networkAddress: ''
         refType: CrossThread
         parentSpanId: 2
@@ -59,7 +57,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -75,7 +72,6 @@ segmentItems:
       - {key: db.instance, value: demo_ds_0}
       - {key: db.statement, value: SELECT * FROM t_order_1}
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -87,7 +83,7 @@ segmentItems:
       peer: ''
       skipAnalysis: false
       refs:
-      - parentEndpoint: /shardingsphere-5.0.0-beta-scenario/case/execute
+      - parentEndpoint: GET:/shardingsphere-5.0.0-beta-scenario/case/execute
         networkAddress: ''
         refType: CrossThread
         parentSpanId: 2
@@ -98,7 +94,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -114,7 +109,6 @@ segmentItems:
       - {key: db.instance, value: demo_ds_1}
       - {key: db.statement, value: SELECT * FROM t_order_1}
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -126,7 +120,7 @@ segmentItems:
       peer: ''
       skipAnalysis: false
       refs:
-      - parentEndpoint: /shardingsphere-5.0.0-beta-scenario/case/execute
+      - parentEndpoint: GET:/shardingsphere-5.0.0-beta-scenario/case/execute
         networkAddress: ''
         refType: CrossThread
         parentSpanId: 2
@@ -137,7 +131,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /ShardingSphere/parseSQL/
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -151,7 +144,6 @@ segmentItems:
       tags:
       - {key: db.statement, value: SELECT * FROM t_order}
     - operationName: /ShardingSphere/routeSQL/
-      operationId: 0
       parentSpanId: 2
       spanId: 3
       spanLayer: Unknown
@@ -163,7 +155,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: /ShardingSphere/rewriteSQL/
-      operationId: 0
       parentSpanId: 2
       spanId: 4
       spanLayer: Unknown
@@ -175,7 +166,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 5
       spanId: 6
       spanLayer: Database
@@ -191,7 +181,6 @@ segmentItems:
       - {key: db.instance, value: demo_ds_0}
       - {key: db.statement, value: SELECT * FROM t_order_0}
     - operationName: /ShardingSphere/executeSQL/
-      operationId: 0
       parentSpanId: 2
       spanId: 5
       spanLayer: Unknown
@@ -203,7 +192,6 @@ segmentItems:
       peer: ''
       skipAnalysis: false
     - operationName: /ShardingSphere/JDBCRootInvoke/
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Unknown
@@ -214,8 +202,7 @@ segmentItems:
       spanType: Local
       peer: ''
       skipAnalysis: false
-    - operationName: /shardingsphere-5.0.0-beta-scenario/case/execute
-      operationId: 0
+    - operationName: GET:/shardingsphere-5.0.0-beta-scenario/case/execute
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/sofarpc-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/sofarpc-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: org.apache.skywalking.apm.testcase.sofarpc.interfaces.SofaRpcDemoService.hello(java.lang.String)
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: RPCFramework
@@ -31,14 +30,13 @@ segmentItems:
       spanType: Entry
       peer: ''
       refs:
-      - {parentEndpoint: /sofarpc-scenario/case/sofarpc, networkAddress: '127.0.0.1:12200',
+      - {parentEndpoint: GET:/sofarpc-scenario/case/sofarpc, networkAddress: '127.0.0.1:12200',
         refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: sofarpc-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: org.apache.skywalking.apm.testcase.sofarpc.interfaces.SofaRpcDemoService.hello(java.lang.String)
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: RPCFramework
@@ -51,8 +49,7 @@ segmentItems:
       tags:
       - {key: url, value: 'bolt://127.0.0.1:12200/org.apache.skywalking.apm.testcase.sofarpc.interfaces.SofaRpcDemoService.hello(java.lang.String)'}
       skipAnalysis: 'false'
-    - operationName: /sofarpc-scenario/case/sofarpc
-      operationId: 0
+    - operationName: GET:/sofarpc-scenario/case/sofarpc
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/solrj-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/solrj-7.x-scenario/config/expectedData.yaml
@@ -121,7 +121,7 @@ segmentItems:
       - {key: db.type, value: Solr}
       - {key: QTime, value: gt 0}
       skipAnalysis: 'false'
-    - operationName: /solrj-scenario/case/solr
+    - operationName: GET:/solrj-scenario/case/solrj
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/solrj-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/solrj-7.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: solrJ/mycore/update/ADD
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -35,7 +34,6 @@ segmentItems:
       - {key: QTime, value: gt 0}
       skipAnalysis: 'false'
     - operationName: solrJ/mycore/update/COMMIT
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -50,7 +48,6 @@ segmentItems:
       - {key: QTime, value: gt 0}
       skipAnalysis: 'false'
     - operationName: solrJ/mycore/update/OPTIMIZE
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -65,7 +62,6 @@ segmentItems:
       - {key: QTime, value: gt 0}
       skipAnalysis: 'false'
     - operationName: solrJ/mycore/select
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Database
@@ -82,7 +78,6 @@ segmentItems:
       - {key: numFound, value: '100'}
       skipAnalysis: 'false'
     - operationName: solrJ/mycore/get
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Database
@@ -99,7 +94,6 @@ segmentItems:
       - {key: numFound, value: '1'}
       skipAnalysis: 'false'
     - operationName: solrJ/mycore/update/DELETE_BY_IDS
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Database
@@ -114,7 +108,6 @@ segmentItems:
       - {key: QTime, value: gt 0}
       skipAnalysis: 'false'
     - operationName: solrJ/mycore/update/DELETE_BY_QUERY
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Database
@@ -128,8 +121,7 @@ segmentItems:
       - {key: db.type, value: Solr}
       - {key: QTime, value: gt 0}
       skipAnalysis: 'false'
-    - operationName: /solrj-scenario/case/solrj
-      operationId: 0
+    - operationName: /solrj-scenario/case/solr
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/spring-3.0.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-3.0.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /healthCheck
-            operationId: 0
+          - operationName: HEAD:/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -36,8 +35,7 @@ segmentItems:
               - {key: http.method, value: HEAD}
       - segmentId: not null
         spans:
-          - operationName: /impl/requestmapping
-            operationId: 0
+          - operationName: GET:/impl/requestmapping
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -52,14 +50,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.0.x-scenario/impl/requestmapping'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/spring3, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/spring3, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 5, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: spring-3.0.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{GET}/impl/restmapping'
-            operationId: 0
+          - operationName: 'GET:/impl/restmapping'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -74,26 +71,46 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.0.x-scenario/impl/restmapping'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/spring3, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/spring3, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 6, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: spring-3.0.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod,
-             operationId: 0, parentSpanId: 1, spanId: 2, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff,
-             operationId: 0, parentSpanId: 1, spanId: 3, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness,
-             operationId: 0, parentSpanId: 0, spanId: 1, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
+          - operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod
+            parentSpanId: 1
+            spanId: 2
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff
+            parentSpanId: 1
+            spanId: 3
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
           - operationName: /spring-3.0.x-scenario/impl/requestmapping
-            operationId: 0
             parentSpanId: 4
             spanId: 5
             spanLayer: Http
@@ -108,7 +125,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.0.x-scenario/impl/requestmapping'}
               - {key: http.method, value: GET}
           - operationName: /spring-3.0.x-scenario/impl/restmapping
-            operationId: 0
             parentSpanId: 4
             spanId: 6
             spanLayer: Http
@@ -122,12 +138,18 @@ segmentItems:
             tags:
               - {key: url, value: 'http://localhost:8080/spring-3.0.x-scenario/impl/restmapping'}
               - {key: http.method, value: GET}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doInvokeImplCase,
-             operationId: 0, parentSpanId: 0, spanId: 4, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - operationName: /case/spring3
-            operationId: 0
+          - operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doInvokeImplCase
+            parentSpanId: 0
+            spanId: 4
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: GET:/case/spring3
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/spring-3.1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-3.1.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /healthCheck
-            operationId: 0
+          - operationName: HEAD:/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -36,20 +35,40 @@ segmentItems:
               - {key: http.method, value: HEAD}
       - segmentId: not null
         spans:
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod,
-             operationId: 0, parentSpanId: 1, spanId: 2, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff,
-             operationId: 0, parentSpanId: 1, spanId: 3, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness,
-             operationId: 0, parentSpanId: 0, spanId: 1, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - operationName: /case/spring3
-            operationId: 0
+          - operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod
+            parentSpanId: 1
+            spanId: 2
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff
+            parentSpanId: 1
+            spanId: 3
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: GET:/case/spring3
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -64,14 +83,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/case/spring3/'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 1,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{POST}/create/'
-            operationId: 0
+          - operationName: 'POST:/create/'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -86,14 +104,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/create/'}
               - {key: http.method, value: POST}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 2,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{GET}/get/{id}'
-            operationId: 0
+          - operationName: 'GET:/get/{id}'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -108,14 +125,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/get/1'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 3,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{DELETE}/delete/{id}'
-            operationId: 0
+          - operationName: 'DELETE:/delete/{id}'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -130,14 +146,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/delete/1'}
               - {key: http.method, value: DELETE}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 5,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{PUT}/update/{id}'
-            operationId: 0
+          - operationName: 'PUT:/update/{id}'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -152,14 +167,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/update/1'}
               - {key: http.method, value: PUT}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 4,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: /impl/requestmapping
-            operationId: 0
+          - operationName: GET:/impl/requestmapping
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -174,14 +188,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/impl/requestmapping'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 6,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}
       - segmentId: not null
         spans:
           - operationName: /spring-3.1.x-scenario/case/spring3/
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -196,7 +209,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/case/spring3/'}
           - operationName: /spring-3.1.x-scenario/create/
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Http
@@ -211,7 +223,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/create/'}
               - {key: http.method, value: POST}
           - operationName: /spring-3.1.x-scenario/get/1
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Http
@@ -226,7 +237,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/get/1'}
               - {key: http.method, value: GET}
           - operationName: /spring-3.1.x-scenario/update/1
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Http
@@ -241,7 +251,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/update/1'}
               - {key: http.method, value: PUT}
           - operationName: /spring-3.1.x-scenario/delete/1
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Http
@@ -256,7 +265,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/delete/1'}
               - {key: http.method, value: DELETE}
           - operationName: /spring-3.1.x-scenario/impl/requestmapping
-            operationId: 0
             parentSpanId: 0
             spanId: 6
             spanLayer: Http
@@ -271,7 +279,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/impl/requestmapping'}
           - operationName: /spring-3.1.x-scenario/impl/restmapping
-            operationId: 0
             parentSpanId: 0
             spanId: 7
             spanLayer: Http
@@ -285,8 +292,7 @@ segmentItems:
             tags:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/impl/restmapping'}
-          - operationName: /case/resttemplate
-            operationId: 0
+          - operationName: GET:/case/resttemplate
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -306,8 +312,7 @@ segmentItems:
                   chinese=[中文]
       - segmentId: not null
         spans:
-          - operationName: '{GET}/impl/restmapping'
-            operationId: 0
+          - operationName: 'GET:/impl/restmapping'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -322,7 +327,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-3.1.x-scenario/impl/restmapping'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 7,  parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-3.1.x-scenario,
                   traceId: not null}

--- a/test/plugin/scenarios/spring-4.1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-4.1.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /healthCheck
-            operationId: 0
+          - operationName: HEAD:/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -36,20 +35,40 @@ segmentItems:
               - {key: http.method, value: HEAD}
       - segmentId: not null
         spans:
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod,
-             operationId: 0, parentSpanId: 1, spanId: 2, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff,
-             operationId: 0, parentSpanId: 1, spanId: 3, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - {operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness,
-             operationId: 0, parentSpanId: 0, spanId: 1, spanLayer: Unknown, startTime: nq 0,
-             endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-             skipAnalysis: false}
-          - operationName: /case/spring3
-            operationId: 0
+          - operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod
+            parentSpanId: 1
+            spanId: 2
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff
+            parentSpanId: 1
+            spanId: 3
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Unknown
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 93
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+          - operationName: GET:/case/spring3
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -64,14 +83,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/case/spring3/'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 1, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{POST}/create/'
-            operationId: 0
+          - operationName: 'POST:/create/'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -86,14 +104,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/create/'}
               - {key: http.method, value: POST}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 2, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{GET}/get/{id}'
-            operationId: 0
+          - operationName: 'GET:/get/{id}'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -108,14 +125,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/get/1'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 3, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{PUT}/update/{id}'
-            operationId: 0
+          - operationName: 'PUT:/update/{id}'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -130,14 +146,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/update/1'}
               - {key: http.method, value: PUT}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 4, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{DELETE}/delete/{id}'
-            operationId: 0
+          - operationName: 'DELETE:/delete/{id}'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -152,14 +167,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/delete/1'}
               - {key: http.method, value: DELETE}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 5, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: /impl/requestmapping
-            operationId: 0
+          - operationName: GET:/impl/requestmapping
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -174,14 +188,13 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/impl/requestmapping'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 6, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}
       - segmentId: not null
         spans:
           - operationName: /spring-4.1.x-scenario/case/spring3/
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -196,7 +209,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/case/spring3/'}
           - operationName: /spring-4.1.x-scenario/create/
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: Http
@@ -211,7 +223,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/create/'}
               - {key: http.method, value: POST}
           - operationName: /spring-4.1.x-scenario/get/1
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Http
@@ -226,7 +237,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/get/1'}
               - {key: http.method, value: GET}
           - operationName: /spring-4.1.x-scenario/update/1
-            operationId: 0
             parentSpanId: 0
             spanId: 4
             spanLayer: Http
@@ -241,7 +251,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/update/1'}
               - {key: http.method, value: PUT}
           - operationName: /spring-4.1.x-scenario/delete/1
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Http
@@ -256,7 +265,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/delete/1'}
               - {key: http.method, value: DELETE}
           - operationName: /spring-4.1.x-scenario/impl/requestmapping
-            operationId: 0
             parentSpanId: 0
             spanId: 6
             spanLayer: Http
@@ -271,7 +279,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/impl/requestmapping'}
           - operationName: /spring-4.1.x-scenario/impl/restmapping
-            operationId: 0
             parentSpanId: 0
             spanId: 7
             spanLayer: Http
@@ -285,8 +292,7 @@ segmentItems:
             tags:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/impl/restmapping'}
-          - operationName: /case/resttemplate
-            operationId: 0
+          - operationName: GET:/case/resttemplate
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -302,8 +308,7 @@ segmentItems:
               - {key: http.method, value: GET}
       - segmentId: not null
         spans:
-          - operationName: '{GET}/impl/restmapping'
-            operationId: 0
+          - operationName: 'GET:/impl/restmapping'
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -318,7 +323,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-4.1.x-scenario/impl/restmapping'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+              - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
                  parentSpanId: 7, parentTraceSegmentId: not null,
                  parentServiceInstance:  not null, parentService: spring-4.1.x-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/spring-4.3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-4.3.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /healthCheck
-      operationId: 0
+    - operationName: HEAD:/healthCheck
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -36,20 +35,40 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - {operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod,
-      operationId: 0, parentSpanId: 1, spanId: 2, spanLayer: Unknown, startTime: nq
-        0, endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-      skipAnalysis: 'false'}
-    - {operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff,
-      operationId: 0, parentSpanId: 1, spanId: 3, spanLayer: Unknown, startTime: nq
-        0, endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-      skipAnalysis: 'false'}
-    - {operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness,
-      operationId: 0, parentSpanId: 0, spanId: 1, spanLayer: Unknown, startTime: nq
-        0, endTime: nq 0, componentId: 93, isError: false, spanType: Local, peer: '',
-      skipAnalysis: 'false'}
-    - operationName: /case/spring3
-      operationId: 0
+    - operationName: test.apache.skywalking.apm.testcase.spring3.component.TestComponentBean.componentMethod
+      parentSpanId: 1
+      spanId: 2
+      spanLayer: Unknown
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 93
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: test.apache.skywalking.apm.testcase.spring3.dao.TestRepositoryBean.doSomeStuff
+      parentSpanId: 1
+      spanId: 3
+      spanLayer: Unknown
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 93
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: test.apache.skywalking.apm.testcase.spring3.service.TestServiceBean.doSomeBusiness
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: Unknown
+      startTime: nq 0
+      endTime: nq 0
+      componentId: 93
+      isError: false
+      spanType: Local
+      peer: ''
+      skipAnalysis: 'false'
+    - operationName: GET:/case/spring3
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -64,14 +83,13 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.headers, value: 'mock_header=[mock_value]'}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{POST}/create/'
-      operationId: 0
+    - operationName: 'POST:/create/'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -85,14 +103,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/create/'}
       - {key: http.method, value: POST}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{GET}/get/{id}'
-      operationId: 0
+    - operationName: 'GET:/get/{id}'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -106,14 +123,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/get/1'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{PUT}/update/{id}'
-      operationId: 0
+    - operationName: 'PUT:/update/{id}'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -127,14 +143,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/update/1'}
       - {key: http.method, value: PUT}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{DELETE}/delete/{id}'
-      operationId: 0
+    - operationName: 'DELETE:/delete/{id}'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -148,14 +163,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/delete/1'}
       - {key: http.method, value: DELETE}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint:  GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 5, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /inherit/child/test
-      operationId: 0
+    - operationName: GET:/inherit/child/test
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -169,14 +183,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/inherit/child/test'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 6, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /impl/requestmapping
-      operationId: 0
+    - operationName: GET:/impl/requestmapping
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -190,14 +203,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/impl/requestmapping'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 7, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{GET}/impl/restmapping'
-      operationId: 0
+    - operationName: 'GET:/impl/restmapping'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -211,14 +223,13 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/impl/restmapping'}
       - {key: http.method, value: GET}
       refs:
-      - {parentEndpoint: /case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
+      - {parentEndpoint: GET:/case/resttemplate, networkAddress: 'localhost:8080', refType: CrossProcess,
         parentSpanId: 8, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-4.3.x-scenario, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /spring-4.3.x-scenario/case/spring3/
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -233,7 +244,6 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/case/spring3/'}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/create/
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Http
@@ -248,7 +258,6 @@ segmentItems:
       - {key: http.method, value: POST}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/get/1
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Http
@@ -263,7 +272,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/update/1
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Http
@@ -278,7 +286,6 @@ segmentItems:
       - {key: http.method, value: PUT}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/delete/1
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Http
@@ -293,7 +300,6 @@ segmentItems:
       - {key: http.method, value: DELETE}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/inherit/child/test
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Http
@@ -308,7 +314,6 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/inherit/child/test'}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/impl/requestmapping
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Http
@@ -323,7 +328,6 @@ segmentItems:
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/impl/requestmapping'}
       skipAnalysis: 'false'
     - operationName: /spring-4.3.x-scenario/impl/restmapping
-      operationId: 0
       parentSpanId: 0
       spanId: 8
       spanLayer: Http
@@ -337,8 +341,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/spring-4.3.x-scenario/impl/restmapping'}
       skipAnalysis: 'false'
-    - operationName: /case/resttemplate
-      operationId: 0
+    - operationName: GET:/case/resttemplate
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-async-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /spring-async-scenario/case/spring-async
-      operationId: 0
+    - operationName: GET:/spring-async-scenario/case/spring-async
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -36,8 +35,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /spring-async-scenario/case/asyncVisit
-      operationId: 0
+    - operationName: GET:/spring-async-scenario/case/asyncVisit
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -57,8 +55,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /spring-async-scenario/case/asyncVisit
-      operationId: 0
+    - operationName: GET:/spring-async-scenario/case/asyncVisit
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -79,7 +76,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /spring-async-scenario/case/asyncVisit
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -94,7 +90,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: SpringAsync
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -105,14 +100,13 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /spring-async-scenario/case/spring-async, networkAddress: '',
+      - {parentEndpoint: GET:/spring-async-scenario/case/spring-async, networkAddress: '',
         refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
     - operationName: /spring-async-scenario/case/asyncVisit
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -127,7 +121,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: SpringAsync
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -138,7 +131,7 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /spring-async-scenario/case/spring-async, networkAddress: '',
+      - {parentEndpoint: GET:/spring-async-scenario/case/spring-async, networkAddress: '',
         refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: spring-async-scenario, traceId: not null}
       skipAnalysis: 'false'

--- a/test/plugin/scenarios/spring-cloud-feign-1.1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-cloud-feign-1.1.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-1.1.x-scenario/case/healthCheck
-            operationId: 0
+          - operationName: HEAD:/spring-cloud-feign-1.1.x-scenario/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -36,14 +35,13 @@ segmentItems:
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-1.1.x-scenario/get
-            operationId: 0
+          - operationName: GET:/spring-cloud-feign-1.1.x-scenario/get
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -51,7 +49,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-1.1.x-scenario/get'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /spring-cloud-feign-1.1.x-scenario/case/spring-cloud-feign-1.1.x-scenario,
+              - {parentEndpoint: GET:/spring-cloud-feign-1.1.x-scenario/case/spring-cloud-feign-1.1.x-scenario,
                  networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: not null,
                  parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: spring-cloud-feign-1.1.x-scenario,
                  traceId: not null}
@@ -59,13 +57,12 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /spring-cloud-feign-1.1.x-scenario/get
-            operationId: 0
             parentSpanId: 1
             spanId: 2
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Exit
             peer: localhost:8080
@@ -74,13 +71,12 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-1.1.x-scenario/get'}
             skipAnalysis: 'false'
           - operationName: Balancer/spring-cloud-feign-1.1.x-scenario/get
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Local
             peer: ''
@@ -88,14 +84,13 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://spring-cloud-feign-1.1.x-scenario/spring-cloud-feign-1.1.x-scenario/get'}
             skipAnalysis: 'false'
-          - operationName: /spring-cloud-feign-1.1.x-scenario/case/spring-cloud-feign-1.1.x-scenario
-            operationId: 0
+          - operationName: GET:/spring-cloud-feign-1.1.x-scenario/case/spring-cloud-feign-1.1.x-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''

--- a/test/plugin/scenarios/spring-cloud-feign-1.2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-cloud-feign-1.2.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-1.2.x-scenario/case/healthCheck
-            operationId: 0
+          - operationName: HEAD:/spring-cloud-feign-1.2.x-scenario/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -36,14 +35,13 @@ segmentItems:
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-1.2.x-scenario/get
-            operationId: 0
+          - operationName: GET:/spring-cloud-feign-1.2.x-scenario/get
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -51,7 +49,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-1.2.x-scenario/get'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /spring-cloud-feign-1.2.x-scenario/case/spring-cloud-feign-1.2.x-scenario,
+              - {parentEndpoint: GET:/spring-cloud-feign-1.2.x-scenario/case/spring-cloud-feign-1.2.x-scenario,
                  networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: not null,
                  parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: spring-cloud-feign-1.2.x-scenario,
                  traceId: not null}
@@ -59,13 +57,12 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /spring-cloud-feign-1.2.x-scenario/get
-            operationId: 0
             parentSpanId: 1
             spanId: 2
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Exit
             peer: localhost:8080
@@ -74,13 +71,12 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-1.2.x-scenario/get'}
             skipAnalysis: 'false'
           - operationName: Balancer/spring-cloud-feign-1.2.x-scenario/get
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Local
             peer: ''
@@ -88,14 +84,13 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://spring-cloud-feign-1.2.x-scenario/spring-cloud-feign-1.2.x-scenario/get'}
             skipAnalysis: 'false'
-          - operationName: /spring-cloud-feign-1.2.x-scenario/case/spring-cloud-feign-1.2.x-scenario
-            operationId: 0
+          - operationName: GET:/spring-cloud-feign-1.2.x-scenario/case/spring-cloud-feign-1.2.x-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''

--- a/test/plugin/scenarios/spring-cloud-feign-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-cloud-feign-2.x-scenario/config/expectedData.yaml
@@ -19,14 +19,13 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-2.x-scenario/case/healthCheck
-            operationId: 0
+          - operationName: HEAD:/spring-cloud-feign-2.x-scenario/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -37,13 +36,12 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /spring-cloud-feign-2.x-scenario/create/
-            operationId: 0
             parentSpanId: 1
             spanId: 2
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Exit
             peer: localhost:8080
@@ -52,13 +50,12 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/create/'}
             skipAnalysis: 'false'
           - operationName: Balancer/spring-cloud-feign-2.x-scenario/create/
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Local
             peer: ''
@@ -67,13 +64,12 @@ segmentItems:
               - {key: url, value: 'http://spring-cloud-feign-2.x-scenario/spring-cloud-feign-2.x-scenario/create/'}
             skipAnalysis: 'false'
           - operationName: /spring-cloud-feign-2.x-scenario/get/1
-            operationId: 0
             parentSpanId: 3
             spanId: 4
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Exit
             peer: localhost:8080
@@ -82,13 +78,12 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/get/1'}
             skipAnalysis: 'false'
           - operationName: Balancer/spring-cloud-feign-2.x-scenario/get/{id}
-            operationId: 0
             parentSpanId: 0
             spanId: 3
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 11
             isError: false
             spanType: Local
             peer: ''
@@ -97,7 +92,6 @@ segmentItems:
               - {key: url, value: 'http://spring-cloud-feign-2.x-scenario/spring-cloud-feign-2.x-scenario/get/1'}
             skipAnalysis: 'false'
           - operationName: /spring-cloud-feign-2.x-scenario/update/1
-            operationId: 0
             parentSpanId: 5
             spanId: 6
             spanLayer: Http
@@ -112,7 +106,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/update/1'}
             skipAnalysis: 'false'
           - operationName: Balancer/spring-cloud-feign-2.x-scenario/update/{id}
-            operationId: 0
             parentSpanId: 0
             spanId: 5
             spanLayer: Http
@@ -127,7 +120,6 @@ segmentItems:
               - {key: url, value: 'http://spring-cloud-feign-2.x-scenario/spring-cloud-feign-2.x-scenario/update/1'}
             skipAnalysis: 'false'
           - operationName: /spring-cloud-feign-2.x-scenario/delete/1
-            operationId: 0
             parentSpanId: 7
             spanId: 8
             spanLayer: Http
@@ -142,7 +134,6 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/delete/1'}
             skipAnalysis: 'false'
           - operationName: Balancer/spring-cloud-feign-2.x-scenario/delete/{id}
-            operationId: 0
             parentSpanId: 0
             spanId: 7
             spanLayer: Http
@@ -156,14 +147,13 @@ segmentItems:
               - {key: http.method, value: DELETE}
               - {key: url, value: 'http://spring-cloud-feign-2.x-scenario/spring-cloud-feign-2.x-scenario/delete/1'}
             skipAnalysis: 'false'
-          - operationName: /spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario
-            operationId: 0
+          - operationName: GET:/spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -173,14 +163,13 @@ segmentItems:
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-2.x-scenario/create/
-            operationId: 0
+          - operationName: POST:/spring-cloud-feign-2.x-scenario/create/
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -188,21 +177,20 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/create/'}
               - {key: http.method, value: POST}
             refs:
-              - {parentEndpoint: /spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
+              - {parentEndpoint: GET:/spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
                  networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: 2,
                  parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: spring-cloud-feign-2.x-scenario,
                  traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-2.x-scenario/get/1
-            operationId: 0
+          - operationName: GET:/spring-cloud-feign-2.x-scenario/get/1
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -210,21 +198,20 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/get/1'}
               - {key: http.method, value: GET}
             refs:
-              - {parentEndpoint: /spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
+              - {parentEndpoint: GET:/spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
                  networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: 4,
                  parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: spring-cloud-feign-2.x-scenario,
                  traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-2.x-scenario/update/1
-            operationId: 0
+          - operationName: PUT:/spring-cloud-feign-2.x-scenario/update/1
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -232,21 +219,20 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/update/1'}
               - {key: http.method, value: PUT}
             refs:
-              - {parentEndpoint: /spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
+              - {parentEndpoint: GET:/spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
                  networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: 6,
                  parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: spring-cloud-feign-2.x-scenario,
                  traceId: not null}
             skipAnalysis: 'false'
       - segmentId: not null
         spans:
-          - operationName: /spring-cloud-feign-2.x-scenario/delete/1
-            operationId: 0
+          - operationName: DELETE:/spring-cloud-feign-2.x-scenario/delete/1
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
             startTime: nq 0
             endTime: nq 0
-            componentId: not null
+            componentId: 1
             isError: false
             spanType: Entry
             peer: ''
@@ -254,7 +240,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/spring-cloud-feign-2.x-scenario/delete/1'}
               - {key: http.method, value: DELETE}
             refs:
-              - {parentEndpoint: /spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
+              - {parentEndpoint: GET:/spring-cloud-feign-2.x-scenario/case/spring-cloud-feign-2.x-scenario,
                  networkAddress: 'localhost:8080', refType: CrossProcess, parentSpanId: 8,
                  parentTraceSegmentId: not null, parentServiceInstance: not null, parentService: spring-cloud-feign-2.x-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/spring-kafka-1.3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-kafka-1.3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Kafka/spring_test/Producer
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: MQ
@@ -34,8 +33,7 @@ segmentItems:
             tags:
               - {key: mq.broker, value: 'kafka-server:9092'}
               - {key: mq.topic, value: spring_test}
-          - operationName: /case/spring-kafka-case
-            operationId: 0
+          - operationName: GET:/case/spring-kafka-case
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -51,8 +49,7 @@ segmentItems:
               - {key: http.method, value: GET}
       - segmentId: not null
         spans:
-          - operationName: /case/spring-kafka-consumer-ping
-            operationId: 0
+          - operationName: GET:/case/spring-kafka-consumer-ping
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -74,7 +71,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /spring-kafka-1.3.x-scenario/case/spring-kafka-consumer-ping
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -89,7 +85,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-kafka-1.3.x-scenario/case/spring-kafka-consumer-ping'}
           - operationName: Kafka/spring_test/Consumer/grop:spring_test
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: MQ
@@ -105,7 +100,7 @@ segmentItems:
               - {key: mq.topic, value: spring_test}
               - {key: transmission.latency, value: not null}
             refs:
-              - {parentEndpoint: /case/spring-kafka-case, networkAddress: 'kafka-server:9092',
+              - {parentEndpoint: GET:/case/spring-kafka-case, networkAddress: 'kafka-server:9092',
                  refType: CrossProcess, parentSpanId: not null, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: spring-kafka-1.3.x-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/spring-kafka-2.2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-kafka-2.2.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Kafka/spring_test/Producer
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: MQ
@@ -34,8 +33,7 @@ segmentItems:
             tags:
               - {key: mq.broker, value: 'kafka-server:9092'}
               - {key: mq.topic, value: spring_test}
-          - operationName: /case/spring-kafka-case
-            operationId: 0
+          - operationName: GET:/case/spring-kafka-case
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -51,8 +49,7 @@ segmentItems:
               - {key: http.method, value: GET}
       - segmentId: not null
         spans:
-          - operationName: /case/spring-kafka-consumer-ping
-            operationId: 0
+          - operationName: GET:/case/spring-kafka-consumer-ping
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -74,7 +71,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /spring-kafka-2.2.x-scenario/case/spring-kafka-consumer-ping
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -89,7 +85,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-kafka-2.2.x-scenario/case/spring-kafka-consumer-ping'}
           - operationName: Kafka/spring_test/Consumer/grop:spring_test
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: MQ
@@ -105,7 +100,7 @@ segmentItems:
               - {key: mq.topic, value: spring_test}
               - {key: transmission.latency, value: not null}
             refs:
-              - {parentEndpoint: /case/spring-kafka-case, networkAddress: 'kafka-server:9092',
+              - {parentEndpoint: GET:/case/spring-kafka-case, networkAddress: 'kafka-server:9092',
                  refType: CrossProcess, parentSpanId: not null, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: spring-kafka-2.2.x-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/spring-kafka-2.3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-kafka-2.3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: Kafka/spring_test/Producer
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: MQ
@@ -35,7 +34,6 @@ segmentItems:
               - {key: mq.broker, value: 'kafka-server:9092'}
               - {key: mq.topic, value: spring_test}
           - operationName: Kafka/spring_test/Producer
-            operationId: 0
             parentSpanId: 0
             spanId: 2
             spanLayer: MQ
@@ -49,8 +47,7 @@ segmentItems:
             tags:
               - { key: mq.broker, value: 'kafka-server:9092' }
               - { key: mq.topic, value: spring_test }
-          - operationName: /case/spring-kafka-case
-            operationId: 0
+          - operationName: GET:/case/spring-kafka-case
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -66,30 +63,7 @@ segmentItems:
               - {key: http.method, value: GET}
       - segmentId: not null
         spans:
-          - operationName: /case/spring-kafka-consumer-ping
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: Http
-            startTime: not null
-            endTime: not null
-            componentId: 14
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - {key: url, value: 'http://localhost:8080/spring-kafka-2.3.x-scenario/case/spring-kafka-consumer-ping'}
-              - {key: http.method, value: GET}
-            refs:
-              - {parentEndpoint: 'Kafka/spring_test/Consumer/grop:spring_test', networkAddress: 'localhost:8080',
-                 refType: CrossProcess, parentSpanId: 1, parentTraceSegmentId: not null,
-                 parentServiceInstance: not null, parentService: spring-kafka-2.3.x-scenario,
-                 traceId: not null}
-      - segmentId: not null
-        spans:
-          - operationName: /case/spring-kafka-consumer-ping
-            operationId: 0
+          - operationName: GET:/case/spring-kafka-consumer-ping
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -111,7 +85,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: /spring-kafka-2.3.x-scenario/case/spring-kafka-consumer-ping
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -126,7 +99,6 @@ segmentItems:
               - {key: http.method, value: GET}
               - {key: url, value: 'http://localhost:8080/spring-kafka-2.3.x-scenario/case/spring-kafka-consumer-ping'}
           - operationName: Kafka/spring_test/Consumer/grop:spring_test
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: MQ
@@ -142,45 +114,7 @@ segmentItems:
               - {key: mq.topic, value: spring_test}
               - {key: transmission.latency, value: not null}
             refs:
-              - {parentEndpoint: /case/spring-kafka-case, networkAddress: 'kafka-server:9092',
-                 refType: CrossProcess, parentSpanId: not null, parentTraceSegmentId: not null,
-                 parentServiceInstance: not null, parentService: spring-kafka-2.3.x-scenario,
-                 traceId: not null}
-      - segmentId: not null
-        spans:
-          - operationName: /spring-kafka-2.3.x-scenario/case/spring-kafka-consumer-ping
-            operationId: 0
-            parentSpanId: 0
-            spanId: 1
-            spanLayer: Http
-            startTime: not null
-            endTime: not null
-            componentId: 12
-            isError: false
-            spanType: Exit
-            peer: localhost:8080
-            skipAnalysis: false
-            tags:
-              - {key: http.method, value: GET}
-              - {key: url, value: 'http://localhost:8080/spring-kafka-2.3.x-scenario/case/spring-kafka-consumer-ping'}
-          - operationName: Kafka/spring_test/Consumer/grop:spring_test
-            operationId: 0
-            parentSpanId: -1
-            spanId: 0
-            spanLayer: MQ
-            startTime: not null
-            endTime: not null
-            componentId: 41
-            isError: false
-            spanType: Entry
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - {key: mq.broker, value: 'kafka-server:9092'}
-              - {key: mq.topic, value: spring_test}
-              - {key: transmission.latency, value: not null}
-            refs:
-              - {parentEndpoint: /case/spring-kafka-case, networkAddress: 'kafka-server:9092',
+              - {parentEndpoint: GET:/case/spring-kafka-case, networkAddress: 'kafka-server:9092',
                  refType: CrossProcess, parentSpanId: not null, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: spring-kafka-2.3.x-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/spring-scheduled-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-scheduled-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /spring-scheduled-scenario/case/call
-      operationId: 0
+    - operationName: GET:/spring-scheduled-scenario/case/call
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -39,7 +38,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /spring-scheduled-scenario/case/call
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -54,7 +52,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/spring-scheduled-scenario/case/call'}
     - operationName: SpringScheduled/org.apache.skywalking.apm.testcase.spring.scheduled.job.SchedulingJob.work
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown

--- a/test/plugin/scenarios/spring-tx-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/spring-tx-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: TX/get/t.a.s.a.t.s.t.s.i.DemoServiceImpl.doBiz
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Unknown
@@ -36,7 +35,6 @@ segmentItems:
       - {key: timeout, value: '-1'}
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/PreparedStatement/executeUpdate
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Database
@@ -52,7 +50,6 @@ segmentItems:
       - {key: db.statement, value: 'insert into `test`.`table_demo`(name) values(?)'}
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/PreparedStatement/executeUpdate
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Database
@@ -68,7 +65,6 @@ segmentItems:
       - {key: db.statement, value: 'insert into `test`.`table_demo`(name) values(?)'}
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/Connection/commit
-      operationId: 0
       parentSpanId: 4
       spanId: 5
       spanLayer: Database
@@ -84,7 +80,6 @@ segmentItems:
       - {key: db.statement, value: ''}
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/Statement/executeQuery
-      operationId: 0
       parentSpanId: 4
       spanId: 6
       spanLayer: Database
@@ -100,7 +95,6 @@ segmentItems:
       - {key: db.statement, value: select @@session.tx_read_only}
       skipAnalysis: 'false'
     - operationName: Mysql/JDBI/Connection/close
-      operationId: 0
       parentSpanId: 4
       spanId: 7
       spanLayer: Database
@@ -116,7 +110,6 @@ segmentItems:
       - {key: db.statement, value: ''}
       skipAnalysis: 'false'
     - operationName: TX/commit
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Unknown
@@ -132,8 +125,7 @@ segmentItems:
       - {key: rollbackOnly, value: 'false'}
       - {key: isCompleted, value: 'false'}
       skipAnalysis: 'false'
-    - operationName: /case/spring-tx-case
-      operationId: 0
+    - operationName: GET:/case/spring-tx-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/springmvc-reactive-devtools-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/springmvc-reactive-devtools-scenario/config/expectedData.yaml
@@ -21,7 +21,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -37,7 +36,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: '/testcase/error'
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Http
@@ -50,7 +48,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: 'future/get:/testcase/error'
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: not null
@@ -65,8 +62,7 @@ segmentItems:
         - {key: message, value: not null}
         - {key: stack, value: not null}
       skipAnalysis: 'false'
-    - operationName: '{GET}/testcase/{test}'
-      operationId: 0
+    - operationName: 'GET:/testcase/{test}'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -80,8 +76,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{GET}/testcase/error'
-      operationId: 0
+    - operationName: 'GET:/testcase/error'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/springmvc-reactive-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/springmvc-reactive-scenario/config/expectedData.yaml
@@ -21,7 +21,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: H2/JDBI/PreparedStatement/executeQuery
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Database
@@ -37,7 +36,6 @@ segmentItems:
       - {key: db.statement, value: not null}
       skipAnalysis: 'false'
     - operationName: '/testcase/error'
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Http
@@ -50,7 +48,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: 'future/get:/testcase/error'
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: not null
@@ -65,8 +62,7 @@ segmentItems:
         - {key: message, value: not null}
         - {key: stack, value: not null}
       skipAnalysis: 'false'
-    - operationName: '{GET}/testcase/{test}'
-      operationId: 0
+    - operationName: 'GET:/testcase/{test}'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -80,8 +76,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: '{GET}/testcase/error'
-      operationId: 0
+    - operationName: 'GET:/testcase/error'
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/struts2.3-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/struts2.3-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /struts2.3-scenario/struts-scenario/case1.action
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /struts2.3-scenario/struts-scenario/case1.action
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -59,7 +57,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /struts2.3-scenario/struts-scenario/case.action
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/struts2.5-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/struts2.5-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /struts2.5-scenario/struts-scenario/case1.action
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -44,7 +43,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /struts2.5-scenario/struts-scenario/case1.action
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -59,7 +57,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /struts2.5-scenario/struts-scenario/case.action
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/thrift-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/thrift-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.thrift.protocol.GreeterService$AsyncProcessor$echo
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -42,7 +41,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.thrift.protocol.GreeterService$Processor$echo
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -67,7 +65,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.thrift.protocol.GreeterService$Client.echo
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -83,7 +80,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.thrift.protocol.GreeterService$AsyncClient$echo_call
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework

--- a/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /undertow-scenario/case/undertow
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -37,7 +36,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /undertow-routing-scenario/case/{context}
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -58,7 +56,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /undertow-scenario/case/undertow1
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -79,7 +76,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /undertow-routing-scenario/case/undertow
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -94,7 +90,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: UndertowDispatch
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -112,7 +107,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /undertow-scenario/case/undertow1
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -127,7 +121,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: UndertowDispatch
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown

--- a/test/plugin/scenarios/vertx-eventbus-3.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/vertx-eventbus-3.x-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxeventbus.controller.VertxEventbusController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -32,7 +31,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{HEAD}/vertx-eventbus-3-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -50,7 +48,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: local-message-receiver
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -69,7 +66,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: local-message-receiver
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -83,7 +79,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '/vertx-eventbus-3-scenario/case/executeTest'
-            operationId: 0
             parentSpanId: 1
             spanId: 2
             spanLayer: Http
@@ -99,7 +94,6 @@ segmentItems:
               - {key: url, value: '/vertx-eventbus-3-scenario/case/executeTest'}
               - {key: http.status_code, value: '200'}
           - operationName: org.apache.skywalking.apm.testcase.vertxeventbus.controller.VertxEventbusController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -111,7 +105,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-eventbus-3-scenario/case/eventbus-case'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -129,7 +122,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '#/vertx-eventbus-3-scenario/case/executeTest'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -148,7 +140,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: cluster-message-receiver
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -167,7 +158,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: cluster-message-receiver
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: RPCFramework
@@ -181,7 +171,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxeventbus.controller.VertxEventbusController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -193,7 +182,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-eventbus-3-scenario/case/executeTest'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/vertx-web-3.54minus-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/vertx-web-3.54minus-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -32,7 +31,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{HEAD}/vertx-web-3_54minus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -50,7 +48,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '/vertx-web-3_54minus-scenario/dynamicEndpoint/100'
-            operationId: 0
             parentSpanId: 1
             spanId: 2
             spanLayer: Http
@@ -66,7 +63,6 @@ segmentItems:
               - {key: url, value: '/vertx-web-3_54minus-scenario/dynamicEndpoint/100'}
               - {key: http.status_code, value: '200'}
           - operationName: '/vertx-web-3_54minus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: 1
             spanId: 3
             spanLayer: Http
@@ -82,7 +78,6 @@ segmentItems:
               - {key: url, value: '/vertx-web-3_54minus-scenario/case/healthCheck'}
               - {key: http.status_code, value: '200'}
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -94,7 +89,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-web-3_54minus-scenario/case/web-case'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -112,7 +106,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -124,7 +117,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{HEAD}/vertx-web-3_54minus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -147,7 +139,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -159,7 +150,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-web-3_54minus-scenario/dynamicEndpoint/:id'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -182,7 +172,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: io.vertx.ext.web.handler.impl.BodyHandlerImpl.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -194,7 +183,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-web-3_54minus-scenario/case/web-case/withBodyHandler'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -217,7 +205,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '#/vertx-web-3_54minus-scenario/dynamicEndpoint/100'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -236,7 +223,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -255,7 +241,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '/vertx-web-3_54minus-scenario/case/web-case/withBodyHandler'
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -271,7 +256,6 @@ segmentItems:
               - {key: url, value: '/vertx-web-3_54minus-scenario/case/web-case/withBodyHandler'}
               - {key: http.status_code, value: '200'}
           - operationName: '#/vertx-web-3_54minus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -290,7 +274,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '#/vertx-web-3_54minus-scenario/case/web-case/withBodyHandler'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/vertx-web-3.6plus-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/vertx-web-3.6plus-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -32,7 +31,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{HEAD}/vertx-web-3_6plus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -50,7 +48,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '/vertx-web-3_6plus-scenario/dynamicEndpoint/100'
-            operationId: 0
             parentSpanId: 1
             spanId: 2
             spanLayer: Http
@@ -66,7 +63,6 @@ segmentItems:
               - {key: url, value: '/vertx-web-3_6plus-scenario/dynamicEndpoint/100'}
               - {key: http.status_code, value: '200'}
           - operationName: '/vertx-web-3_6plus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: 1
             spanId: 3
             spanLayer: Http
@@ -82,7 +78,6 @@ segmentItems:
               - {key: url, value: '/vertx-web-3_6plus-scenario/case/healthCheck'}
               - {key: http.status_code, value: '200'}
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -94,7 +89,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-web-3_6plus-scenario/case/web-case'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -112,7 +106,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -124,7 +117,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{HEAD}/vertx-web-3_6plus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -147,7 +139,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -159,7 +150,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-web-3_6plus-scenario/dynamicEndpoint/:id'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -182,7 +172,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: io.vertx.ext.web.handler.impl.BodyHandlerImpl.handle(RoutingContext)
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -194,7 +183,6 @@ segmentItems:
             peer: ''
             skipAnalysis: false
           - operationName: '{GET}/vertx-web-3_6plus-scenario/case/web-case/withBodyHandler'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -217,7 +205,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '#/vertx-web-3_6plus-scenario/dynamicEndpoint/100'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -236,7 +223,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: org.apache.skywalking.apm.testcase.vertxweb.controller.VertxWebController$$Lambda$.handle(RoutingContext)
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -255,7 +241,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '/vertx-web-3_6plus-scenario/case/web-case/withBodyHandler'
-            operationId: 0
             parentSpanId: 0
             spanId: 1
             spanLayer: Http
@@ -271,7 +256,6 @@ segmentItems:
               - {key: url, value: '/vertx-web-3_6plus-scenario/case/web-case/withBodyHandler'}
               - {key: http.status_code, value: '200'}
           - operationName: '#/vertx-web-3_6plus-scenario/case/healthCheck'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
@@ -290,7 +274,6 @@ segmentItems:
       - segmentId: not null
         spans:
           - operationName: '#/vertx-web-3_6plus-scenario/case/web-case/withBodyHandler'
-            operationId: 0
             parentSpanId: -1
             spanId: 0
             spanLayer: Http

--- a/test/plugin/scenarios/webflux-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/webflux-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/annotation/success
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -42,7 +41,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/annotation/error
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -64,7 +62,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/annotation/{test}
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -86,7 +83,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/annotation/{test}
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -108,7 +104,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/route/{test}
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -130,7 +125,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/route/{test}
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -152,7 +146,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /**
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -174,7 +167,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/annotation/mono/hello
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -196,7 +188,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/webclient/server
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -221,7 +212,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /testcase/annotation/success
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -236,7 +226,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /testcase/annotation/error
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Http
@@ -252,7 +241,6 @@ segmentItems:
       - {key: http.status_code, value: '500'}
       skipAnalysis: 'false'
     - operationName: /testcase/annotation/foo
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Http
@@ -267,7 +255,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /testcase/annotation/loo
-      operationId: 0
       parentSpanId: 0
       spanId: 4
       spanLayer: Http
@@ -282,7 +269,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /testcase/route/success
-      operationId: 0
       parentSpanId: 0
       spanId: 5
       spanLayer: Http
@@ -297,7 +283,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /testcase/route/error
-      operationId: 0
       parentSpanId: 0
       spanId: 6
       spanLayer: Http
@@ -313,7 +298,6 @@ segmentItems:
       - {key: http.status_code, value: '500'}
       skipAnalysis: 'false'
     - operationName: /notFound
-      operationId: 0
       parentSpanId: 0
       spanId: 7
       spanLayer: Http
@@ -329,7 +313,6 @@ segmentItems:
       - {key: http.status_code, value: '404'}
       skipAnalysis: 'false'
     - operationName: /testcase/annotation/mono/hello
-      operationId: 0
       parentSpanId: 0
       spanId: 8
       spanLayer: Http
@@ -344,7 +327,6 @@ segmentItems:
       - {key: http.method, value: GET}
       skipAnalysis: 'false'
     - operationName: /testcase/webclient/server
-      operationId: 0
       parentSpanId: 0
       spanId: 9
       spanLayer: Http
@@ -360,7 +342,6 @@ segmentItems:
       - {key: http.status_code, value: '200'}
       skipAnalysis: 'false'
     - operationName: /projectA/testcase
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/webflux-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/webflux-scenario/config/expectedData.yaml
@@ -34,7 +34,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -55,7 +55,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '500'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -76,7 +76,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -97,7 +97,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -118,7 +118,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 5, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -139,7 +139,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '500'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 6, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -160,7 +160,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '404'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 7, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -181,7 +181,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 8, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -202,7 +202,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       refs:
-      - {parentEndpoint: /projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
         parentSpanId: 9, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -341,7 +341,7 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: http.status_code, value: '200'}
       skipAnalysis: 'false'
-    - operationName: /projectA/testcase
+    - operationName: GET:/projectA/testcase
       parentSpanId: -1
       spanId: 0
       spanLayer: Http

--- a/test/plugin/scenarios/xxl-job-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/xxl-job-2.x-scenario/config/expectedData.yaml
@@ -19,8 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /xxl-job-2.x-scenario/case/simpleJob
-      operationId: 0
+    - operationName: GET:/xxl-job-2.x-scenario/case/simpleJob
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -39,7 +38,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /xxl-job-2.x-scenario/case/simpleJob
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -54,7 +52,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/xxl-job-2.x-scenario/case/simpleJob'}
     - operationName: xxl-job/SimpleJob/test.apache.skywalking.apm.testcase.xxljob.job.BeanJob
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -70,8 +67,7 @@ segmentItems:
       - {key: jobParam, value: 'k=1'}
   - segmentId: not null
     spans:
-    - operationName: /xxl-job-2.x-scenario/case/methodJob
-      operationId: 0
+    - operationName: GET:/xxl-job-2.x-scenario/case/methodJob
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -90,7 +86,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /xxl-job-2.x-scenario/case/methodJob
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -105,7 +100,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/xxl-job-2.x-scenario/case/methodJob'}
     - operationName: xxl-job/MethodJob/org.apache.skywalking.apm.testcase.xxljob.job.MethodJob.work
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -121,8 +115,7 @@ segmentItems:
       - {key: jobParam, value: 'k=2'}
   - segmentId: not null
     spans:
-    - operationName: /xxl-job-2.x-scenario/case/glueJob
-      operationId: 0
+    - operationName: GET:/xxl-job-2.x-scenario/case/glueJob
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -141,7 +134,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: /xxl-job-2.x-scenario/case/glueJob
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Http
@@ -156,7 +148,6 @@ segmentItems:
       - {key: http.method, value: GET}
       - {key: url, value: 'http://localhost:8080/xxl-job-2.x-scenario/case/glueJob'}
     - operationName: xxl-job/SimpleJob/com.xxl.job.service.handler.GlueJob
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -173,7 +164,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: xxl-job/ScriptJob/GLUE_SHELL/id/4
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown

--- a/test/plugin/scenarios/zookeeper-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/zookeeper-scenario/config/expectedData.yaml
@@ -20,7 +20,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Zookeeper/exists
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Cache
@@ -36,7 +35,6 @@ segmentItems:
       - {key: watch, value: 'true'}
       skipAnalysis: 'false'
     - operationName: Zookeeper/WatchedEvent/NodeDeleted
-      operationId: 0
       parentSpanId: -1
       spanId: 0
       spanLayer: Unknown
@@ -54,7 +52,6 @@ segmentItems:
   - segmentId: not null
     spans:
     - operationName: Zookeeper/create
-      operationId: 0
       parentSpanId: 0
       spanId: 1
       spanLayer: Cache
@@ -69,7 +66,6 @@ segmentItems:
       - {key: path, value: /path}
       skipAnalysis: 'false'
     - operationName: Zookeeper/exists
-      operationId: 0
       parentSpanId: 0
       spanId: 2
       spanLayer: Cache
@@ -85,7 +81,6 @@ segmentItems:
       - {key: watch, value: 'true'}
       skipAnalysis: 'false'
     - operationName: Zookeeper/delete
-      operationId: 0
       parentSpanId: 0
       spanId: 3
       spanLayer: Cache
@@ -100,8 +95,7 @@ segmentItems:
       - {key: path, value: /path}
       - {key: version, value: '-1'}
       skipAnalysis: 'false'
-    - operationName: /zookeeper-scenario/case/zookeeper-case
-      operationId: 0
+    - operationName: GET:/zookeeper-scenario/case/zookeeper-case
       parentSpanId: -1
       spanId: 0
       spanLayer: Http


### PR DESCRIPTION
### Format Springmvc & Tomcat EntrySpan operation name to `METHOD:URI`
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

related to https://github.com/apache/skywalking/issues/7135

clean up `operationId` in `expectedData.yaml` because not use anymore.
