### PR TITLE
Optimize ProfileTaskChannelService

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@ Release Notes.
 * Support set instance properties in json format.
 * Upgrade grpc-java to 1.42.1 and protoc to 3.17.3 to allow using native Mac osx-aarch_64 artifacts.
 * Add doc about system environment variables to configurations.md
+* Avoid `ProfileTaskChannelService.addProfilingSnapshot` throw IllegalStateException(Queue full) 
+* Increase `ProfileTaskChannelService.snapshotQueue` default size from 50 to 4500
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/profile/ProfileTaskChannelService.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/profile/ProfileTaskChannelService.java
@@ -179,7 +179,7 @@ public class ProfileTaskChannelService implements BootService, Runnable, GRPCCha
      * add a new profiling snapshot, send to {@link #snapshotQueue}
      */
     public void addProfilingSnapshot(TracingThreadSnapshot snapshot) {
-        snapshotQueue.add(snapshot);
+        snapshotQueue.offer(snapshot);
     }
 
     /**

--- a/apm-sniffer/config/agent.config
+++ b/apm-sniffer/config/agent.config
@@ -157,7 +157,7 @@ profile.duration=${SW_AGENT_PROFILE_DURATION:10}
 # Max dump thread stack depth
 profile.dump_max_stack_depth=${SW_AGENT_PROFILE_DUMP_MAX_STACK_DEPTH:500}
 # Snapshot transport to backend buffer size
-profile.snapshot_transport_buffer_size=${SW_AGENT_PROFILE_SNAPSHOT_TRANSPORT_BUFFER_SIZE:50}
+profile.snapshot_transport_buffer_size=${SW_AGENT_PROFILE_SNAPSHOT_TRANSPORT_BUFFER_SIZE:4500}
 # If true, the agent collects and reports metrics to the backend.
 meter.active=${SW_METER_ACTIVE:true}
 # Report meters interval. The unit is second

--- a/docs/en/setup/service-agent/java-agent/configurations.md
+++ b/docs/en/setup/service-agent/java-agent/configurations.md
@@ -53,7 +53,7 @@ property key | Description | **System Environment Variable** | Default
 `profile.max_parallel`|Parallel monitor segment count|SW_AGENT_PROFILE_MAX_PARALLEL|`5`
 `profile.duration`|Max monitor segment time(minutes), if current segment monitor time out of limit, then stop it.|SW_AGENT_PROFILE_DURATION|`10`
 `profile.dump_max_stack_depth`|Max dump thread stack depth|SW_AGENT_PROFILE_DUMP_MAX_STACK_DEPTH|`500`
-`profile.snapshot_transport_buffer_size`|Snapshot transport to backend buffer size|SW_AGENT_PROFILE_SNAPSHOT_TRANSPORT_BUFFER_SIZE|`50`
+`profile.snapshot_transport_buffer_size`|Snapshot transport to backend buffer size|SW_AGENT_PROFILE_SNAPSHOT_TRANSPORT_BUFFER_SIZE|`4500`
 `meter.active`|If true, the agent collects and reports metrics to the backend.|SW_METER_ACTIVE|`true`
 `meter.report_interval`|Report meters interval. The unit is second|SW_METER_REPORT_INTERVAL|`20`
 `meter.max_meter_size`| Max size of the meter pool |SW_METER_MAX_METER_SIZE|`500`


### PR DESCRIPTION
related issue  https://github.com/apache/skywalking/issues/8221

1. Avoid ProfileTaskChannelService.addProfilingSnapshot throw IllegalStateException(Queue full)
2. Increase ProfileTaskChannelService.snapshotQueue default size from 50 to 4500