### PR TITLE
Add witness classes to graphql and vertx-core-3.x plugins 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 * Support HikariCP Connection pool metrics collecting.
 * Support Dbcp2 Connection pool metrics collecting.
 * Ignore the synthetic constructor created by the agent in the Spring patch plugin.
+* Add witness class for vertx-core-3.x plugin.
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 * Support Dbcp2 Connection pool metrics collecting.
 * Ignore the synthetic constructor created by the agent in the Spring patch plugin.
 * Add witness class for vertx-core-3.x plugin.
+* Add witness class for graphql plugin.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-12.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/graphql/v12/define/GraphqlInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-12.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/graphql/v12/define/GraphqlInstrumentation.java
@@ -64,6 +64,9 @@ public class GraphqlInstrumentation extends ClassInstanceMethodsEnhancePluginDef
 
     @Override
     protected String[] witnessClasses() {
-        return new String[] {"graphql.cachecontrol.CacheControl"};
+        return new String[] {
+                "graphql.cachecontrol.CacheControl",
+                "graphql.execution.ExecutionPath"
+        };
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/graphql/v8/define/GraphqlInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/graphql/v8/define/GraphqlInstrumentation.java
@@ -64,6 +64,10 @@ public class GraphqlInstrumentation extends ClassInstanceMethodsEnhancePluginDef
 
     @Override
     protected String[] witnessClasses() {
-        return new String[] {"graphql.util.SimpleTraverserContext", "graphql.analysis.FieldVisitor"};
+        return new String[] {
+                "graphql.util.SimpleTraverserContext",
+                "graphql.analysis.FieldVisitor",
+                "graphql.execution.ExecutionPath"
+        };
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-9.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/graphql/v9/define/GraphqlInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-9.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/graphql/v9/define/GraphqlInstrumentation.java
@@ -64,6 +64,10 @@ public class GraphqlInstrumentation extends ClassInstanceMethodsEnhancePluginDef
 
     @Override
     protected String[] witnessClasses() {
-        return new String[] {"graphql.util.SimpleTraverserContext", "graphql.analysis.QueryVisitor"};
+        return new String[] {
+                "graphql.util.SimpleTraverserContext",
+                "graphql.analysis.QueryVisitor",
+                "graphql.execution.ExecutionPath"
+        };
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/ClusteredEventBusSendRemoteInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/ClusteredEventBusSendRemoteInstrumentation.java
@@ -73,6 +73,9 @@ public class ClusteredEventBusSendRemoteInstrumentation extends ClassInstanceMet
 
     @Override
     protected String[] witnessClasses() {
-        return new String[] {"io.vertx.core.eventbus.impl.clustered.ClusteredMessage"};
+        return new String[] {
+                "io.vertx.core.eventbus.impl.clustered.ClusteredMessage",
+                "io.vertx.core.http.impl.WebSocketFrameFactoryImpl"
+        };
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/EventBusImplDeliverToHandlerInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/EventBusImplDeliverToHandlerInstrumentation.java
@@ -73,6 +73,9 @@ public class EventBusImplDeliverToHandlerInstrumentation extends ClassInstanceMe
 
     @Override
     protected String[] witnessClasses() {
-        return new String[] {"io.vertx.core.eventbus.impl.clustered.ClusteredMessage"};
+        return new String[] {
+                "io.vertx.core.eventbus.impl.clustered.ClusteredMessage",
+                "io.vertx.core.http.impl.WebSocketFrameFactoryImpl"
+        };
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HandlerRegistrationInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HandlerRegistrationInstrumentation.java
@@ -73,6 +73,9 @@ public class HandlerRegistrationInstrumentation extends ClassInstanceMethodsEnha
 
     @Override
     protected String[] witnessClasses() {
-        return new String[] {"io.vertx.core.eventbus.impl.clustered.ClusteredMessage"};
+        return new String[] {
+                "io.vertx.core.eventbus.impl.clustered.ClusteredMessage",
+                "io.vertx.core.http.impl.WebSocketFrameFactoryImpl"
+        };
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpClientRequestImplHandleExceptionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpClientRequestImplHandleExceptionInstrumentation.java
@@ -70,4 +70,9 @@ public class HttpClientRequestImplHandleExceptionInstrumentation extends ClassIn
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpClientRequestImplHandleResponseInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpClientRequestImplHandleResponseInstrumentation.java
@@ -72,4 +72,9 @@ public class HttpClientRequestImplHandleResponseInstrumentation extends ClassIns
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpClientRequestImplInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpClientRequestImplInstrumentation.java
@@ -106,4 +106,9 @@ public class HttpClientRequestImplInstrumentation extends ClassInstanceMethodsEn
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpContextHandleDispatchResponseInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpContextHandleDispatchResponseInstrumentation.java
@@ -72,4 +72,9 @@ public class HttpContextHandleDispatchResponseInstrumentation extends ClassInsta
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpContextSendRequestInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpContextSendRequestInstrumentation.java
@@ -70,4 +70,9 @@ public class HttpContextSendRequestInstrumentation extends ClassInstanceMethodsE
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerRequestImplConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerRequestImplConstructorInstrumentation.java
@@ -64,4 +64,9 @@ public class HttpServerRequestImplConstructorInstrumentation extends ClassInstan
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerRequestWrapperConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerRequestWrapperConstructorInstrumentation.java
@@ -64,4 +64,9 @@ public class HttpServerRequestWrapperConstructorInstrumentation extends ClassIns
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerResponseImplHandleExceptionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerResponseImplHandleExceptionInstrumentation.java
@@ -70,4 +70,9 @@ public class HttpServerResponseImplHandleExceptionInstrumentation extends ClassI
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerResponseImplInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/HttpServerResponseImplInstrumentation.java
@@ -88,4 +88,9 @@ public class HttpServerResponseImplInstrumentation extends ClassInstanceMethodsE
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouteImplHandlerInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouteImplHandlerInstrumentation.java
@@ -72,4 +72,9 @@ public class RouteImplHandlerInstrumentation extends ClassInstanceMethodsEnhance
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouteImplInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouteImplInstrumentation.java
@@ -85,4 +85,9 @@ public class RouteImplInstrumentation extends ClassInstanceMethodsEnhancePluginD
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouteStateInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouteStateInstrumentation.java
@@ -87,4 +87,9 @@ public class RouteStateInstrumentation extends ClassInstanceMethodsEnhancePlugin
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouterContextImplBaseConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RouterContextImplBaseConstructorInstrumentation.java
@@ -64,4 +64,9 @@ public class RouterContextImplBaseConstructorInstrumentation extends ClassInstan
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RoutingContextWrapperConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/RoutingContextWrapperConstructorInstrumentation.java
@@ -66,4 +66,9 @@ public class RoutingContextWrapperConstructorInstrumentation extends ClassInstan
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/ServerConnectionHandleMessageInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx3/define/ServerConnectionHandleMessageInstrumentation.java
@@ -74,4 +74,9 @@ public class ServerConnectionHandleMessageInstrumentation extends ClassInstanceM
                 SERVER_CONNECTION_ENHANCE_CLASS //ver. 3.0.0 - 3.5.0
         );
     }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] {"io.vertx.core.http.impl.WebSocketFrameFactoryImpl"};
+    }
 }


### PR DESCRIPTION
Added witness classes to graphql and vertx-core-3.x plugins.

`graphql.execution.ExecutionPath` which is available for provided plugins:
https://github.com/graphql-java/graphql-java/blob/v8.0/src/main/java/graphql/execution/ExecutionPath.java
https://github.com/graphql-java/graphql-java/blob/v9.0/src/main/java/graphql/execution/ExecutionPath.java
https://github.com/graphql-java/graphql-java/blob/v12.0/src/main/java/graphql/execution/ExecutionPath.java

Is not available for v16+:
https://github.com/graphql-java/graphql-java/blob/v16.0/src/main/java/graphql/execution/ExecutionPath.java

---

`io.vertx.core.http.impl.WebSocketFrameFactoryImpl` which is available for beginning to end of 3.x
https://github.com/eclipse-vertx/vert.x/blob/3.0.0/src/main/java/io/vertx/core/http/impl/WebSocketFrameFactoryImpl.java
https://github.com/eclipse-vertx/vert.x/blob/3.9.12/src/main/java/io/vertx/core/http/impl/WebSocketFrameFactoryImpl.java

Is not available for 4.x:
https://github.com/eclipse-vertx/vert.x/blob/4.0.0/src/main/java/io/vertx/core/http/impl/WebSocketFrameFactoryImpl.java