### PR TITLE
fix the bug that maybe generate multiple trace when invoke http reque…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+
 Changes by Version
 ==================
 Release Notes.
@@ -9,6 +10,7 @@ Release Notes.
 * Remove plugin for ServiceComb Java Chassis 0.x
 * Add Guava EventBus plugin.
 * Fix Dubbo 3.x plugin's tracing problem.
+* Fix the bug that maybe generate multiple trace when invoke http request by spring webflux webclient.
 * Support Druid Connection pool metrics collecting.
 * Support HikariCP Connection pool metrics collecting.
 * Support Dbcp2 Connection pool metrics collecting.

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/webclient/WebFluxWebClientInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/webclient/WebFluxWebClientInterceptor.java
@@ -20,6 +20,7 @@ package org.apache.skywalking.apm.plugin.spring.webflux.v5.webclient;
 
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
@@ -34,40 +35,13 @@ import reactor.core.publisher.Mono;
 
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.util.Optional;
 
 public class WebFluxWebClientInterceptor implements InstanceMethodsAroundInterceptorV2 {
 
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes, MethodInvocationContext context) throws Throwable {
-        if (allArguments[0] == null) {
-            //illegal args,can't trace ignore
-            return;
-        }
 
-        ClientRequest request = (ClientRequest) allArguments[0];
-        final ContextCarrier contextCarrier = new ContextCarrier();
-
-        URI uri = request.url();
-        final String requestURIString = getRequestURIString(uri);
-        final String operationName = requestURIString;
-        final String remotePeer = getIPAndPort(uri);
-        AbstractSpan span = ContextManager.createExitSpan(operationName, contextCarrier, remotePeer);
-
-        //set components name
-        span.setComponent(ComponentsDefine.SPRING_WEBCLIENT);
-        Tags.URL.set(span, uri.toString());
-        Tags.HTTP.METHOD.set(span, request.method().toString());
-        SpanLayer.asHttp(span);
-
-        if (request instanceof EnhancedInstance) {
-            ((EnhancedInstance) request).setSkyWalkingDynamicField(contextCarrier);
-        }
-
-        //user async interface
-        span.prepareForAsync();
-        ContextManager.stopSpan();
-
-        context.setContext(span);
     }
 
     @Override
@@ -77,19 +51,43 @@ public class WebFluxWebClientInterceptor implements InstanceMethodsAroundInterce
             return ret;
         }
         Mono<ClientResponse> ret1 = (Mono<ClientResponse>) ret;
-        AbstractSpan span = (AbstractSpan) context.getContext();
-        return ret1.doOnSuccess(clientResponse -> {
-            HttpStatus httpStatus = clientResponse.statusCode();
-            if (httpStatus != null) {
-                Tags.HTTP_RESPONSE_STATUS_CODE.set(span, httpStatus.value());
-                if (httpStatus.isError()) {
-                    span.errorOccurred();
-                }
+        return Mono.subscriberContext().flatMap(ctx -> {
+
+            ClientRequest request = (ClientRequest) allArguments[0];
+            URI uri = request.url();
+            final String operationName = getRequestURIString(uri);
+            final String remotePeer = getIPAndPort(uri);
+            AbstractSpan span = ContextManager.createExitSpan(operationName, remotePeer);
+
+            final Optional<Object> optional = ctx.getOrEmpty("SKYWALKING_CONTEXT_SNAPSHOT");
+            optional.ifPresent(snapshot -> ContextManager.continued((ContextSnapshot) snapshot));
+
+            //set components name
+            span.setComponent(ComponentsDefine.SPRING_WEBCLIENT);
+            Tags.URL.set(span, uri.toString());
+            Tags.HTTP.METHOD.set(span, request.method().toString());
+            SpanLayer.asHttp(span);
+
+            final ContextCarrier contextCarrier = new ContextCarrier();
+            ContextManager.inject(contextCarrier);
+            if (request instanceof EnhancedInstance) {
+                ((EnhancedInstance) request).setSkyWalkingDynamicField(contextCarrier);
             }
-        }).doOnError(error -> {
-            span.log(error);
-        }).doFinally(s -> {
-            span.asyncFinish();
+
+            //user async interface
+            span.prepareForAsync();
+            ContextManager.stopSpan();
+            return ret1.doOnSuccess(clientResponse -> {
+                HttpStatus httpStatus = clientResponse.statusCode();
+                if (httpStatus != null) {
+                    Tags.HTTP_RESPONSE_STATUS_CODE.set(span, httpStatus.value());
+                    if (httpStatus.isError()) {
+                        span.errorOccurred();
+                    }
+                }
+            }).doOnError(span::log).doFinally(s -> {
+                span.asyncFinish();
+            });
         });
     }
 


### PR DESCRIPTION



### Fix the bug that maybe generate multiple trace when invoke http request by spring webflux webclient.
- [ ] Add a unit test to verify that the fix works.
- [x ] Explain briefly why the bug exists and how to fix it.  
     spring webflux is base on  async framework [reactor](https://projectreactor.io/) , and  the webclient create exit span without restore Skywalking context from ContextSnapshot. This may generate multiple trace.   
     This commit set Skywalking ContextSnapshot  into Reactor Context when enter Spring WebFlux,  and  get ContextSnapshot from Reactor Context then call ContextManager.continue before construct webcliet request.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
