### PR TITLE
Vertx 4 Core Plugin

### DIFF
--- a/.github/workflows/plugins-test.3.yaml
+++ b/.github/workflows/plugins-test.3.yaml
@@ -63,6 +63,7 @@ jobs:
           - spring-4.1.x-scenario
           - spring-4.3.x-scenario
           - spring-async-scenario
+          - vertx-core-4.x-scenario
           - vertx-eventbus-3.x-scenario
           - vertx-web-3.54minus-scenario
           - vertx-web-3.6plus-scenario

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Release Notes.
 * Ignore the synthetic constructor created by the agent in the Spring patch plugin.
 * Add witness class for vertx-core-3.x plugin.
 * Add witness class for graphql plugin.
+* Add vertx-core-4.x plugin.
 
 #### Documentation
 * Add link about java agent injector.

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
@@ -41,17 +41,5 @@
             <version>${vertx.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-web</artifactId>
-            <version>${vertx.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-web-client</artifactId>
-            <version>${vertx.version}</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with
@@ -18,27 +17,41 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-
     <parent>
+        <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <artifactId>apm-sdk-plugin</artifactId>
         <version>8.10.0-SNAPSHOT</version>
     </parent>
+    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>vertx-plugins</artifactId>
-    <modules>
-        <module>vertx-core-4.x-plugin</module>
-        <module>vertx-core-3.x-plugin</module>
-    </modules>
-    <packaging>pom</packaging>
+    <artifactId>apm-vertx-core-4.x-plugin</artifactId>
+    <packaging>jar</packaging>
 
-    <name>vertx-plugins</name>
+    <name>vertx-core-4.x-plugin</name>
     <url>http://maven.apache.org</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sdk.plugin.related.dir>/..</sdk.plugin.related.dir>
+        <vertx.version>4.2.5</vertx.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <version>${vertx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+            <version>${vertx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web-client</artifactId>
+            <version>${vertx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/ClusteredMessageConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/ClusteredMessageConstructorInterceptor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx4;
+
+import io.vertx.core.eventbus.impl.clustered.ClusteredEventBus;
+import io.vertx.core.spi.cluster.NodeInfo;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
+
+import java.lang.reflect.Field;
+
+public class ClusteredMessageConstructorInterceptor implements InstanceConstructorInterceptor {
+
+    @Override
+    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) throws Exception {
+        for (Object arg : allArguments) {
+            if (arg instanceof ClusteredEventBus) {
+                Field nodeInfoField = ClusteredEventBus.class.getDeclaredField("nodeInfo");
+                nodeInfoField.setAccessible(true);
+                NodeInfo nodeInfo = (NodeInfo) nodeInfoField.get(arg);
+
+                objInst.setSkyWalkingDynamicField(nodeInfo.host() + ":" + nodeInfo.port());
+                break;
+            }
+        }
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/SWVertxTracer.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/SWVertxTracer.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx4;
+
+import io.vertx.core.Context;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.observability.HttpResponse;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+import org.apache.skywalking.apm.agent.core.context.CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class SWVertxTracer implements VertxTracer<AbstractSpan, AbstractSpan> {
+
+    @Override
+    public <R> AbstractSpan receiveRequest(Context context, SpanKind kind, TracingPolicy policy, R request,
+                                           String operation, Iterable<Map.Entry<String, String>> headers,
+                                           TagExtractor<R> tagExtractor) {
+        if (TracingPolicy.IGNORE.equals(policy)) {
+            return null;
+        }
+
+        if (request instanceof HttpRequest) {
+            HttpRequest serverRequest = (HttpRequest) request;
+
+            ContextCarrier contextCarrier = getContextCarrier(headers);
+            AbstractSpan span = toEntrySpan(
+                    "{" + serverRequest.method() + "}" + serverRequest.uri(),
+                    contextCarrier,
+                    context
+            );
+            SpanLayer.asHttp(span);
+            Tags.HTTP.METHOD.set(span, serverRequest.method().toString());
+            Tags.URL.set(span, serverRequest.absoluteURI());
+
+            return toAsyncSpan(context, span);
+        } else if (request instanceof Message) {
+            Message serverRequest = (Message) request;
+
+            ContextCarrier contextCarrier = getContextCarrier(headers);
+            AbstractSpan span = toEntrySpan(serverRequest.address(), contextCarrier, context);
+            SpanLayer.asRPCFramework(span);
+
+            return toAsyncSpan(context, span);
+        }
+
+        return null;
+    }
+
+    @Override
+    public <R> void sendResponse(Context context, R response, AbstractSpan payload, Throwable failure,
+                                 TagExtractor<R> tagExtractor) {
+        if (payload != null) {
+            if (failure != null) {
+                payload.log(failure);
+            }
+
+            if (response instanceof HttpResponse) {
+                Tags.HTTP_RESPONSE_STATUS_CODE.set(payload, ((HttpResponse) response).statusCode());
+            }
+            payload.asyncFinish();
+        }
+    }
+
+    @Override
+    public <R> AbstractSpan sendRequest(Context context, SpanKind kind, TracingPolicy policy, R request,
+                                        String operation, BiConsumer<String, String> headers,
+                                        TagExtractor<R> tagExtractor) {
+        if (TracingPolicy.IGNORE.equals(policy) || request == null) {
+            return null;
+        }
+
+        if (request instanceof HttpRequest) {
+            HttpRequest clientRequest = (HttpRequest) request;
+
+            ContextCarrier contextCarrier = new ContextCarrier();
+            AbstractSpan span = toExitSpan(
+                    clientRequest.uri(),
+                    clientRequest.remoteAddress().host() + ":" + clientRequest.remoteAddress().port(),
+                    contextCarrier,
+                    context
+            );
+            SpanLayer.asHttp(span);
+            Tags.HTTP.METHOD.set(span, clientRequest.method().name());
+            Tags.URL.set(span, clientRequest.absoluteURI());
+
+            return toExitAsyncSpan(context, headers, contextCarrier, span);
+        } else if (request instanceof Message) {
+            Message clientRequest = (Message) request;
+
+            ContextCarrier contextCarrier = new ContextCarrier();
+            AbstractSpan span = toExitSpan(clientRequest.address(), "localhost", contextCarrier, context);
+            SpanLayer.asRPCFramework(span);
+
+            return toExitAsyncSpan(context, headers, contextCarrier, span);
+        }
+        return null;
+    }
+
+    @Override
+    public <R> void receiveResponse(Context context, R response, AbstractSpan payload, Throwable failure,
+                                    TagExtractor<R> tagExtractor) {
+        this.sendResponse(context, response, payload, failure, tagExtractor);
+    }
+
+    private void continueContextIfNecessary(Context context) {
+        //Context.getLocal(String) changes to Context.getLocal(Object) from 4.0.x to 4.1.x, so direct access local map
+        Map<Object, Object> contextMap = ((ContextInternal) context).localContextData();
+        ContextSnapshot contextSnapshot = (ContextSnapshot) contextMap.get("sw.context-snapshot");
+
+        if (contextSnapshot != null) {
+            ContextManager.continued(contextSnapshot);
+        }
+    }
+
+    private ContextCarrier getContextCarrier(Iterable<Map.Entry<String, String>> headers) {
+        Map<String, String> headerMap = new HashMap<>();
+        headers.forEach(it -> headerMap.put(it.getKey(), it.getValue()));
+        ContextCarrier contextCarrier = new ContextCarrier();
+        CarrierItem next = contextCarrier.items();
+        while (next.hasNext()) {
+            next = next.next();
+            next.setHeadValue(headerMap.get(next.getHeadKey()));
+        }
+        return contextCarrier;
+    }
+
+    private AbstractSpan toAsyncSpan(Context context, AbstractSpan span) {
+        //Context.putLocal(String) changes to Context.putLocal(Object) from 4.0.x to 4.1.x, so direct access local map
+        Map<Object, Object> contextMap = ((ContextInternal) context).localContextData();
+        contextMap.put("sw.context-snapshot", ContextManager.capture());
+
+        AbstractSpan asyncSpan = span.prepareForAsync();
+        ContextManager.stopSpan();
+        return asyncSpan;
+    }
+
+    private AbstractSpan toExitAsyncSpan(Context context, BiConsumer<String, String> headers,
+                                         ContextCarrier contextCarrier, AbstractSpan span) {
+        CarrierItem next = contextCarrier.items();
+        while (next.hasNext()) {
+            next = next.next();
+            headers.accept(next.getHeadKey(), next.getHeadValue());
+        }
+        return toAsyncSpan(context, span);
+    }
+
+    private AbstractSpan toEntrySpan(String operationName, ContextCarrier contextCarrier, Context context) {
+        AbstractSpan span = ContextManager.createEntrySpan(operationName, contextCarrier);
+        continueContextIfNecessary(context);
+        span.setComponent(ComponentsDefine.VERTX);
+        return span;
+    }
+
+    private AbstractSpan toExitSpan(String operationName, String remotePeer, ContextCarrier contextCarrier,
+                                    Context context) {
+        AbstractSpan span = ContextManager.createExitSpan(operationName, contextCarrier, remotePeer);
+        continueContextIfNecessary(context);
+        span.setComponent(ComponentsDefine.VERTX);
+        return span;
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/VertxBuilderConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/VertxBuilderConstructorInterceptor.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx4;
+
+import io.vertx.core.impl.VertxBuilder;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
+
+public class VertxBuilderConstructorInterceptor implements InstanceConstructorInterceptor {
+
+    @Override
+    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+        VertxBuilder vertxBuilder = (VertxBuilder) objInst;
+        vertxBuilder.tracer(new SWVertxTracer());
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/define/ClusteredMessageConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/define/ClusteredMessageConstructorInstrumentation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx4.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+
+/**
+ * {@link ClusteredMessageConstructorInstrumentation} enhance the constructor in
+ * <code>io.vertx.core.eventbus.impl.clustered.ClusteredMessage</code> class by
+ * <code>ClusteredMessageConstructorInterceptor</code> class.
+ */
+public class ClusteredMessageConstructorInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+
+    private static final String ENHANCE_CLASS = "io.vertx.core.eventbus.impl.clustered.ClusteredMessage";
+    private static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.vertx4.ClusteredMessageConstructorInterceptor";
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[] {
+                new ConstructorInterceptPoint() {
+                    @Override
+                    public ElementMatcher<MethodDescription> getConstructorMatcher() {
+                        return isPublic();
+                    }
+
+                    @Override
+                    public String getConstructorInterceptor() {
+                        return INTERCEPT_CLASS;
+                    }
+                }
+        };
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[0];
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[] { "io.vertx.core.impl.VertxBuilder" };
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/define/VertxBuilderConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/define/VertxBuilderConstructorInstrumentation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.vertx4.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
+
+/**
+ * {@link VertxBuilderConstructorInstrumentation} enhance the constructor in
+ * <code>io.vertx.core.impl.VertxBuilder</code> class by
+ * <code>VertxBuilderConstructorInterceptor</code> class.
+ */
+public class VertxBuilderConstructorInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+
+    private static final String ENHANCE_CLASS = "io.vertx.core.impl.VertxBuilder";
+    private static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.vertx4.VertxBuilderConstructorInterceptor";
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[] {
+                new ConstructorInterceptPoint() {
+                    @Override
+                    public ElementMatcher<MethodDescription> getConstructorMatcher() {
+                        return any();
+                    }
+
+                    @Override
+                    public String getConstructorInterceptor() {
+                        return INTERCEPT_CLASS;
+                    }
+                }
+        };
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[0];
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/resources/skywalking-plugin.def
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+vertx-core-4.x=org.apache.skywalking.apm.plugin.vertx4.define.VertxBuilderConstructorInstrumentation

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/resources/skywalking-plugin.def
@@ -14,4 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+vertx-core-4.x=org.apache.skywalking.apm.plugin.vertx4.define.ClusteredMessageConstructorInstrumentation
 vertx-core-4.x=org.apache.skywalking.apm.plugin.vertx4.define.VertxBuilderConstructorInstrumentation

--- a/docs/en/setup/service-agent/java-agent/Plugin-list.md
+++ b/docs/en/setup/service-agent/java-agent/Plugin-list.md
@@ -117,6 +117,7 @@
 - toolkit-exception
 - undertow-2.x-plugin
 - vertx-core-3.x
+- vertx-core-4.x
 - xxl-job-2.x
 - zookeeper-3.4.x
 - mssql-jtds-1.x

--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -112,8 +112,8 @@ metrics based on the tracing data.
   * [Fastjson](https://github.com/alibaba/fastjson) 1.2.x (Optional²)
   * [Jackson](https://github.com/FasterXML/jackson) 2.x (Optional²)
 * Vert.x Ecosystem
-  * Vert.x Eventbus 3.2+
-  * Vert.x Web 3.x
+  * Vert.x Eventbus 3.2 -> 4.x
+  * Vert.x Web 3.x -> 4.x
 * Thread Schedule Framework
   * [Spring @Async](https://github.com/spring-projects/spring-framework) 4.x and 5.x
   * [Quasar](https://github.com/puniverse/quasar) 0.7.x

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/bin/startup.sh
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/bin/startup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+home="$(cd "$(dirname $0)"; pwd)"
+
+java -jar ${agent_opts} ${home}/../libs/vertx-core-4.x-scenario.jar &

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/config/expectedData.yaml
@@ -50,8 +50,8 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: local-message-receiver, networkAddress: localhost, refType: CrossProcess,
-                 parentSpanId: 0, parentTraceSegmentId: not null,
+              - {parentEndpoint: local-message-receiver, networkAddress: not null,
+                 refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -66,7 +66,7 @@ segmentItems:
             componentId: 59
             isError: false
             spanType: Exit
-            peer: localhost
+            peer: not null
             skipAnalysis: false
             refs:
               - {parentEndpoint: '{GET}/vertx-core-4-scenario/case/executeTest', networkAddress: '',
@@ -88,8 +88,8 @@ segmentItems:
             peer: ''
             skipAnalysis: false
             refs:
-              - {parentEndpoint: cluster-message-receiver, networkAddress: localhost, refType: CrossProcess,
-                 parentSpanId: 0, parentTraceSegmentId: not null,
+              - {parentEndpoint: cluster-message-receiver, networkAddress: not null,
+                 refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -168,7 +168,7 @@ segmentItems:
             componentId: 59
             isError: false
             spanType: Exit
-            peer: localhost
+            peer: not null
             skipAnalysis: false
             refs:
               - {parentEndpoint: local-message-receiver, networkAddress: '', refType: CrossThread,

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/config/expectedData.yaml
@@ -1,0 +1,177 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+segmentItems:
+  - serviceName: vertx-core-4.x-scenario
+    segmentSize: 8
+    segments:
+      - segmentId: not null
+        spans:
+          - operationName: '{HEAD}/vertx-core-4-scenario/case/healthCheck'
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: HEAD}
+              - {key: url, value: 'http://localhost:8080/vertx-core-4-scenario/case/healthCheck'}
+              - {key: http.status_code, value: '200'}
+      - segmentId: not null
+        spans:
+          - operationName: local-message-receiver
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            refs:
+              - {parentEndpoint: local-message-receiver, networkAddress: localhost, refType: CrossProcess,
+                 parentSpanId: 0, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: local-message-receiver
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Exit
+            peer: localhost
+            skipAnalysis: false
+            refs:
+              - {parentEndpoint: '{GET}/vertx-core-4-scenario/case/executeTest', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: cluster-message-receiver
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            refs:
+              - {parentEndpoint: cluster-message-receiver, networkAddress: localhost, refType: CrossProcess,
+                 parentSpanId: 0, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: '{GET}/vertx-core-4-scenario/case/executeTest'
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'http://localhost:8080/vertx-core-4-scenario/case/executeTest'}
+              - {key: http.status_code, value: '200'}
+            refs:
+              - {parentEndpoint: /vertx-core-4-scenario/case/executeTest, networkAddress: 'localhost:8080',
+                 refType: CrossProcess, parentSpanId: 0, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: '{GET}/vertx-core-4-scenario/case/core-case'
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'http://localhost:8080/vertx-core-4-scenario/case/core-case'}
+              - {key: http.status_code, value: '200'}
+      - segmentId: not null
+        spans:
+          - operationName: /vertx-core-4-scenario/case/executeTest
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            skipAnalysis: false
+            tags:
+              - {key: http.method, value: GET}
+              - {key: url, value: 'http://localhost:8080/vertx-core-4-scenario/case/executeTest'}
+              - {key: http.status_code, value: '200'}
+            refs:
+              - {parentEndpoint: '{GET}/vertx-core-4-scenario/case/core-case', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: cluster-message-receiver
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: RPCFramework
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 59
+            isError: false
+            spanType: Exit
+            peer: localhost
+            skipAnalysis: false
+            refs:
+              - {parentEndpoint: local-message-receiver, networkAddress: '', refType: CrossThread,
+                 parentSpanId: 0, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
+                 traceId: not null}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ segmentItems:
     segments:
       - segmentId: not null
         spans:
-          - operationName: '{HEAD}/vertx-core-4-scenario/case/healthCheck'
+          - operationName: HEAD:/vertx-core-4-scenario/case/healthCheck
             operationId: 0
             parentSpanId: -1
             spanId: 0
@@ -69,7 +69,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             refs:
-              - {parentEndpoint: '{GET}/vertx-core-4-scenario/case/executeTest', networkAddress: '',
+              - {parentEndpoint: 'GET:/vertx-core-4-scenario/case/executeTest', networkAddress: '',
                  refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
                  traceId: not null}
@@ -94,7 +94,7 @@ segmentItems:
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{GET}/vertx-core-4-scenario/case/executeTest'
+          - operationName: GET:/vertx-core-4-scenario/case/executeTest
             operationId: 0
             parentSpanId: -1
             spanId: 0
@@ -117,7 +117,7 @@ segmentItems:
                  traceId: not null}
       - segmentId: not null
         spans:
-          - operationName: '{GET}/vertx-core-4-scenario/case/core-case'
+          - operationName: GET:/vertx-core-4-scenario/case/core-case
             operationId: 0
             parentSpanId: -1
             spanId: 0
@@ -152,7 +152,7 @@ segmentItems:
               - {key: url, value: 'http://localhost:8080/vertx-core-4-scenario/case/executeTest'}
               - {key: http.status_code, value: '200'}
             refs:
-              - {parentEndpoint: '{GET}/vertx-core-4-scenario/case/core-case', networkAddress: '',
+              - {parentEndpoint: 'GET:/vertx-core-4-scenario/case/core-case', networkAddress: '',
                  refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
                  traceId: not null}
@@ -171,7 +171,7 @@ segmentItems:
             peer: not null
             skipAnalysis: false
             refs:
-              - {parentEndpoint: local-message-receiver, networkAddress: '', refType: CrossThread,
-                 parentSpanId: 0, parentTraceSegmentId: not null,
+              - {parentEndpoint: 'GET:/vertx-core-4-scenario/case/executeTest', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: vertx-core-4.x-scenario,
                  traceId: not null}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/configuration.yml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/configuration.yml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: jvm
+entryService: http://localhost:8080/vertx-core-4-scenario/case/core-case
+healthCheck: http://localhost:8080/vertx-core-4-scenario/case/healthCheck
+startScript: ./bin/startup.sh

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/pom.xml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <groupId>org.apache.skywalking.apm.testcase</groupId>
+    <artifactId>vertx-core-4.x-scenario</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <compiler.version>1.8</compiler.version>
+        <test.framework.version>4.2.5</test.framework.version>
+        <spring.boot.version>2.1.6.RELEASE</spring.boot.version>
+        <jackson.version>2.9.4</jackson.version>
+    </properties>
+
+    <name>skywalking-vertx-core-4.x-scenario</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-web</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-hazelcast</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>vertx-core-4.x-scenario</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${compiler.version}</source>
+                    <target>${compiler.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <outputDirectory>./target/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/assembly/assembly.xml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/assembly/assembly.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+            <directory>./bin</directory>
+            <fileMode>0775</fileMode>
+        </fileSet>
+    </fileSets>
+
+    <files>
+        <file>
+            <source>${project.build.directory}/vertx-core-4.x-scenario.jar</source>
+            <outputDirectory>./libs</outputDirectory>
+            <fileMode>0775</fileMode>
+        </file>
+    </files>
+</assembly>

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/Application.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/Application.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.testcase.vertxcore;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+
+import org.apache.skywalking.apm.testcase.vertxcore.controller.ClusterReceiver;
+import org.apache.skywalking.apm.testcase.vertxcore.controller.VertxCoreController;
+
+public class Application {
+
+    public static void main(String[] args) {
+        System.setProperty("vertx.disableFileCPResolving", "true");
+        ClusterManager mgr = new HazelcastClusterManager();
+        VertxOptions options = new VertxOptions().setClusterManager(mgr);
+        Vertx.clusteredVertx(options, cluster -> {
+            if (cluster.succeeded()) {
+                cluster.result().deployVerticle(new ClusterReceiver(), deploy -> {
+                    if (deploy.succeeded()) {
+                        ClusterManager mgr2 = new HazelcastClusterManager();
+                        VertxOptions options2 = new VertxOptions().setClusterManager(mgr2);
+                        Vertx.clusteredVertx(options2, cluster2 -> {
+                            if (cluster2.succeeded()) {
+                                cluster2.result().deployVerticle(new VertxCoreController());
+                            } else {
+                                cluster2.cause().printStackTrace();
+                                System.exit(-1);
+                            }
+                        });
+                    } else {
+                        deploy.cause().printStackTrace();
+                        System.exit(-1);
+                    }
+                });
+            } else {
+                cluster.cause().printStackTrace();
+                System.exit(-1);
+            }
+        });
+    }
+}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/ClusterReceiver.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/ClusterReceiver.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.testcase.vertxcore.controller;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.eventbus.EventBus;
+import org.apache.skywalking.apm.testcase.vertxcore.util.CustomMessage;
+import org.apache.skywalking.apm.testcase.vertxcore.util.CustomMessageCodec;
+
+public class ClusterReceiver extends AbstractVerticle {
+
+    @Override
+    public void start() {
+        EventBus eventBus = vertx.eventBus();
+        eventBus.registerDefaultCodec(CustomMessage.class, new CustomMessageCodec());
+
+        eventBus.consumer("cluster-message-receiver",
+                message -> message.reply(new CustomMessage("cluster-message-receiver reply")));
+    }
+}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/LocalReceiver.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/LocalReceiver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.testcase.vertxcore.controller;
+
+import io.vertx.core.AbstractVerticle;
+import org.apache.skywalking.apm.testcase.vertxcore.util.CustomMessage;
+
+public class LocalReceiver extends AbstractVerticle {
+
+    @Override
+    public void start() {
+        vertx.eventBus().consumer("local-message-receiver",
+                message -> message.reply(new CustomMessage("local-message-receiver reply")));
+    }
+}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/VertxCoreController.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/VertxCoreController.java
@@ -53,7 +53,6 @@ public class VertxCoreController extends AbstractVerticle {
                         });
                     }
                 });
-        System.out.println("done");
     }
 
     private void executeTest(RoutingContext routingContext) {

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/VertxCoreController.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/controller/VertxCoreController.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.testcase.vertxcore.controller;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.skywalking.apm.testcase.vertxcore.util.CustomMessage;
+import org.apache.skywalking.apm.testcase.vertxcore.util.CustomMessageCodec;
+
+public class VertxCoreController extends AbstractVerticle {
+
+    @Override
+    public void start() {
+        Router router = Router.router(vertx);
+        router.get("/vertx-core-4-scenario/case/core-case").handler(this::handleCoreCase);
+        router.get("/vertx-core-4-scenario/case/executeTest").handler(this::executeTest);
+        router.head("/vertx-core-4-scenario/case/healthCheck").handler(this::healthCheck);
+        vertx.createHttpServer().requestHandler(router).listen(8080);
+
+        vertx.eventBus().registerDefaultCodec(CustomMessage.class, new CustomMessageCodec());
+        vertx.deployVerticle(LocalReceiver.class.getName());
+    }
+
+    private void handleCoreCase(RoutingContext routingContext) {
+        vertx.createHttpClient().request(HttpMethod.GET, 8080, "localhost",
+                "/vertx-core-4-scenario/case/executeTest").onComplete(it -> {
+                    if (it.succeeded()) {
+                        it.result().end();
+                        it.result().response().onComplete(it2 -> {
+                            if (it2.succeeded()) {
+                                routingContext.response().setStatusCode(it2.result().statusCode()).end();
+                            }
+                        });
+                    }
+                });
+        System.out.println("done");
+    }
+
+    private void executeTest(RoutingContext routingContext) {
+        Promise<Void> localMessageFuture = Promise.promise();
+        CustomMessage localMessage = new CustomMessage("local-message-receiver request");
+        vertx.eventBus().request("local-message-receiver", localMessage, reply -> {
+            if (reply.succeeded()) {
+                CustomMessage replyMessage = (CustomMessage) reply.result().body();
+                replyMessage.getMessage();
+                localMessageFuture.complete();
+            } else {
+                localMessageFuture.fail(reply.cause());
+            }
+        });
+
+        Promise<Void> clusterMessageFuture = Promise.promise();
+        CustomMessage clusterWideMessage = new CustomMessage("cluster-message-receiver request");
+        vertx.eventBus().request("cluster-message-receiver", clusterWideMessage, reply -> {
+            if (reply.succeeded()) {
+                CustomMessage replyMessage = (CustomMessage) reply.result().body();
+                replyMessage.getMessage();
+                clusterMessageFuture.complete();
+            } else {
+                clusterMessageFuture.fail(reply.cause());
+            }
+        });
+
+        localMessageFuture.future().onComplete(localHandler -> {
+            if (localHandler.succeeded()) {
+                clusterMessageFuture.future().onComplete(clusterHandler -> {
+                    if (clusterHandler.succeeded()) {
+                        routingContext.response().setStatusCode(200).end();
+                    } else {
+                        routingContext.response().setStatusCode(500).end(Json.encodePrettily(clusterHandler.cause()));
+                    }
+                });
+            } else {
+                routingContext.response().setStatusCode(500).end(Json.encodePrettily(localHandler.cause()));
+            }
+        });
+    }
+
+    private void healthCheck(RoutingContext routingContext) {
+        routingContext.response().setStatusCode(200).end("Success");
+    }
+}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/util/CustomMessage.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/util/CustomMessage.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.testcase.vertxcore.util;
+
+public class CustomMessage {
+
+    private final String message;
+
+    public CustomMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/util/CustomMessageCodec.java
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/vertxcore/util/CustomMessageCodec.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.testcase.vertxcore.util;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+
+public class CustomMessageCodec implements MessageCodec<CustomMessage, CustomMessage> {
+
+    @Override
+    public void encodeToWire(Buffer buffer, CustomMessage customMessage) {
+        String jsonStr = Json.encode(customMessage);
+        int length = jsonStr.getBytes().length;
+        buffer.appendInt(length);
+        buffer.appendString(jsonStr);
+    }
+
+    @Override
+    public CustomMessage decodeFromWire(int position, Buffer buffer) {
+        int length = buffer.getInt(position);
+        JsonObject jsonMessage = new JsonObject(buffer.getString(position += 4, position + length));
+        return new CustomMessage(jsonMessage.getString("message"));
+    }
+
+    @Override
+    public CustomMessage transform(CustomMessage customMessage) {
+        return customMessage;
+    }
+
+    @Override
+    public String name() {
+        return getClass().getSimpleName();
+    }
+
+    @Override
+    public byte systemCodecID() {
+        return -1;
+    }
+}

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/resources/log4j2.xml
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/src/main/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<Configuration status="debug">
+<Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d [%traceId] %-5p %c{1}:%L - %m%n"/>
+    </Console>
+</Appenders>
+<Loggers>
+    <Root level="OFF">
+        <AppenderRef ref="Console"/>
+    </Root>
+</Loggers>
+</Configuration>

--- a/test/plugin/scenarios/vertx-core-4.x-scenario/support-version.list
+++ b/test/plugin/scenarios/vertx-core-4.x-scenario/support-version.list
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+4.2.5
+4.1.8
+4.0.3


### PR DESCRIPTION
### Add an agent plugin to support <framework name>
- [x] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [x] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [x] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)

Vertx 4.x added native tracing support (https://vertx.io/blog/eclipse-vert-x-4-milestone-1-released/#tracing) making this plugin pretty straightforward.