### PR TITLE
Fix broken cross process in Vertx 4 core plugin

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/SWVertxTracer.java
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/vertx4/SWVertxTracer.java
@@ -127,12 +127,14 @@ public class SWVertxTracer implements VertxTracer<AbstractSpan, AbstractSpan> {
                     remotePeer = (String) enhancedInstance.getSkyWalkingDynamicField();
                 }
             }
+
             ContextCarrier contextCarrier = new ContextCarrier();
             AbstractSpan span = toExitSpan(clientRequest.address(), remotePeer, contextCarrier, context);
             SpanLayer.asRPCFramework(span);
 
             return toExitAsyncSpan(context, headers, contextCarrier, span);
         }
+
         return null;
     }
 
@@ -178,6 +180,7 @@ public class SWVertxTracer implements VertxTracer<AbstractSpan, AbstractSpan> {
 
     private AbstractSpan toExitAsyncSpan(Context context, BiConsumer<String, String> headers,
                                          ContextCarrier contextCarrier, AbstractSpan span) {
+        ContextManager.inject(contextCarrier);
         CarrierItem next = contextCarrier.items();
         while (next.hasNext()) {
             next = next.next();


### PR DESCRIPTION
This is a continuation of https://github.com/apache/skywalking-java/pull/118. Produces the correct UI output.

Previous:
![image](https://user-images.githubusercontent.com/3278877/156886663-0d5b036b-d857-4fd7-9d72-bfed1c706220.png)

New:
![image](https://user-images.githubusercontent.com/3278877/156894665-ddeacbea-4b44-41a1-825c-06302422716d.png)
