### PR TITLE
Make sure the parent endpoint from existing first ENTRY span

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Release Notes.
 * The namespace and cluster would be reported as instance properties, keys are `namespace` and `cluster`. Notice, if
   instance_properties_json includes these two keys, they would be overrided by the agent core.
 * [Breaking Change] Remove the namespace from `cross process propagation` key.
+* Make sure the parent endpoint in tracing context from existing first ENTRY span, rather than first span only.
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -527,9 +527,9 @@ public class TracingContext implements AbstractTracerContext {
      */
     private AbstractSpan push(AbstractSpan span) {
         if (primaryEndpoint == null) {
-            primaryEndpoint = new PrimaryEndpoint(span.isEntry(), span);
+            primaryEndpoint = new PrimaryEndpoint(span);
         } else {
-            primaryEndpoint.set(span.isEntry(), span);
+            primaryEndpoint.set(span);
         }
         activeSpanStack.addLast(span);
         this.extensionContext.handle(span);
@@ -578,20 +578,18 @@ public class TracingContext implements AbstractTracerContext {
      * @since 8.10.0
      */
     private class PrimaryEndpoint {
-        private boolean isEntry;
         @Getter
         private AbstractSpan span;
 
-        private PrimaryEndpoint(final boolean isEntry, final AbstractSpan span) {
-            this.isEntry = isEntry;
+        private PrimaryEndpoint(final AbstractSpan span) {
             this.span = span;
         }
 
         /**
          * Set endpoint name according to priority
          */
-        private void set(final boolean isEntry, final AbstractSpan span) {
-            if (!this.isEntry && isEntry) {
+        private void set(final AbstractSpan span) {
+            if (!this.span.isEntry() && span.isEntry()) {
                 this.span = span;
             }
         }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -78,12 +78,11 @@ public class TracingContext implements AbstractTracerContext {
      * LinkedList#getLast()} instead of {@link #pop()}, {@link #push(AbstractSpan)}, {@link #peek()}
      */
     private LinkedList<AbstractSpan> activeSpanStack = new LinkedList<>();
+
     /**
-     * @since 7.0.0 SkyWalking support lazy injection through {@link ExitTypeSpan#inject(ContextCarrier)}. Due to that,
-     * the {@link #activeSpanStack} could be blank by then, this is a pointer forever to the first span, even the main
-     * thread tracing has been finished.
+     * @since 8.10.0 replace the removed "firstSpan"(before 8.10.0) reference. see {@link PrimaryEndpoint} for more details.
      */
-    private AbstractSpan firstSpan = null;
+    private PrimaryEndpoint primaryEndpoint = null;
 
     /**
      * A counter for the next span.
@@ -175,7 +174,7 @@ public class TracingContext implements AbstractTracerContext {
         carrier.setSpanId(exitSpan.getSpanId());
         carrier.setParentService(Config.Agent.SERVICE_NAME);
         carrier.setParentServiceInstance(Config.Agent.INSTANCE_NAME);
-        carrier.setParentEndpoint(first().getOperationName());
+        carrier.setParentEndpoint(primaryEndpoint.getName());
         carrier.setAddressUsedAtClient(peer);
 
         this.correlationContext.inject(carrier);
@@ -212,7 +211,7 @@ public class TracingContext implements AbstractTracerContext {
             segment.getTraceSegmentId(),
             activeSpan().getSpanId(),
             getPrimaryTraceId(),
-            first().getOperationName(),
+            primaryEndpoint.getName(),
             this.correlationContext,
             this.extensionContext
         );
@@ -527,8 +526,10 @@ public class TracingContext implements AbstractTracerContext {
      * @param span the {@code span} to push
      */
     private AbstractSpan push(AbstractSpan span) {
-        if (firstSpan == null) {
-            firstSpan = span;
+        if (primaryEndpoint == null) {
+            primaryEndpoint = new PrimaryEndpoint(span.isEntry(), span.getOperationName());
+        } else {
+            primaryEndpoint.set(span.isEntry(), span.getOperationName());
         }
         activeSpanStack.addLast(span);
         this.extensionContext.handle(span);
@@ -543,10 +544,6 @@ public class TracingContext implements AbstractTracerContext {
             return null;
         }
         return activeSpanStack.getLast();
-    }
-
-    private AbstractSpan first() {
-        return firstSpan;
     }
 
     private boolean isLimitMechanismWorking() {
@@ -571,5 +568,32 @@ public class TracingContext implements AbstractTracerContext {
 
     public ProfileStatusReference profileStatus() {
         return this.profileStatus;
+    }
+
+    /**
+     * Primary endpoint name is used for endpoint dependency. The name pick policy according to priority is
+     * 1. Use the first entry span's operation name
+     * 2. Use the first span's operation name
+     *
+     * @since 8.10.0
+     */
+    private class PrimaryEndpoint {
+        private boolean isEntry;
+        @Getter
+        private String name;
+
+        private PrimaryEndpoint(final boolean isEntry, final String name) {
+            this.isEntry = isEntry;
+            this.name = name;
+        }
+
+        /**
+         * Set endpoint name according to priority
+         */
+        private void set(final boolean isEntry, final String name) {
+            if (!this.isEntry && isEntry) {
+                this.name = name;
+            }
+        }
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/context/TracingContext.java
@@ -527,9 +527,9 @@ public class TracingContext implements AbstractTracerContext {
      */
     private AbstractSpan push(AbstractSpan span) {
         if (primaryEndpoint == null) {
-            primaryEndpoint = new PrimaryEndpoint(span.isEntry(), span.getOperationName());
+            primaryEndpoint = new PrimaryEndpoint(span.isEntry(), span);
         } else {
-            primaryEndpoint.set(span.isEntry(), span.getOperationName());
+            primaryEndpoint.set(span.isEntry(), span);
         }
         activeSpanStack.addLast(span);
         this.extensionContext.handle(span);
@@ -580,20 +580,24 @@ public class TracingContext implements AbstractTracerContext {
     private class PrimaryEndpoint {
         private boolean isEntry;
         @Getter
-        private String name;
+        private AbstractSpan span;
 
-        private PrimaryEndpoint(final boolean isEntry, final String name) {
+        private PrimaryEndpoint(final boolean isEntry, final AbstractSpan span) {
             this.isEntry = isEntry;
-            this.name = name;
+            this.span = span;
         }
 
         /**
          * Set endpoint name according to priority
          */
-        private void set(final boolean isEntry, final String name) {
+        private void set(final boolean isEntry, final AbstractSpan span) {
             if (!this.isEntry && isEntry) {
-                this.name = name;
+                this.span = span;
             }
+        }
+
+        private String getName() {
+            return span.getOperationName();
         }
     }
 }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

In MQ and some fetching cases, the first span may not be an entry span. This bug exists for years, sorry I forgot to fix this but known this bug for a long time.