### PR TITLE
Feature msg business consumer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
     3. Cross Process Propagation Header's value addressUsedAtClient[index=8] (Target address of this request used on the
        client end).
 * Support Undertow thread pool metrics collecting.
+* support record the real result of kafka message processing at the business side.
 * Support Tomcat thread pool metric collect.
 * Remove plugin for ServiceComb Java Chassis 0.x
 * Add Guava EventBus plugin.

--- a/apm-application-toolkit/apm-toolkit-trace/src/main/java/org/apache/skywalking/apm/toolkit/trace/msg/TraceMsg.java
+++ b/apm-application-toolkit/apm-toolkit-trace/src/main/java/org/apache/skywalking/apm/toolkit/trace/msg/TraceMsg.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+package org.apache.skywalking.apm.toolkit.trace.msg;
+
+
+
+public interface TraceMsg {
+
+
+    /**
+     * set the traceData into the message
+     */
+    void setTraceData(String trace);
+
+
+    /**
+     * get the traceData from the message
+     *
+     * @return traceData
+     */
+    String getTraceData();
+
+
+}

--- a/apm-application-toolkit/apm-toolkit-trace/src/main/java/org/apache/skywalking/apm/toolkit/trace/msg/TraceMsgContext.java
+++ b/apm-application-toolkit/apm-toolkit-trace/src/main/java/org/apache/skywalking/apm/toolkit/trace/msg/TraceMsgContext.java
@@ -1,0 +1,45 @@
+package org.apache.skywalking.apm.toolkit.trace.msg;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+public class TraceMsgContext {
+
+
+    /**
+     * Message business logic processing success.
+     *
+     * @param trace the Context Trace information for the message association
+     */
+    public static void ConsumerMsgSucceed(String trace) {
+
+    }
+
+
+    /**
+     * Message business logic processing failed
+     *
+     * @param trace     the Context Trace information for the message association
+     * @param throwable the Context Trace information for the message association
+     */
+    public static void ConsumerMsgFailure(String trace, Throwable throwable) {
+
+    }
+
+
+}

--- a/apm-protocol/apm-network/src/main/java/org/apache/skywalking/apm/network/trace/component/ComponentsDefine.java
+++ b/apm-protocol/apm-network/src/main/java/org/apache/skywalking/apm/network/trace/component/ComponentsDefine.java
@@ -220,4 +220,8 @@ public class ComponentsDefine {
     public static final OfficialComponent APACHE_KYLIN_JDBC_DRIVER = new OfficialComponent(121, "apache-kylin-jdbc-driver");
 
     public static final OfficialComponent GUAVA_EVENT_BUS = new OfficialComponent(123, "GuavaEventBus");
+
+    public static final OfficialComponent MSG_BUSINESS_CONSUMER = new OfficialComponent(124, "msg-business-consumer");
+
+
 }

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
@@ -32,6 +32,14 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.apache.skywalking</groupId>
+            <artifactId>apm-toolkit-trace</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.skywalking</groupId>
             <artifactId>apm-kafka-commons</artifactId>

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/threadpool/AsyncThreadFactory.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/threadpool/AsyncThreadFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.threadpool;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+public class AsyncThreadFactory implements ThreadFactory {
+    private final AtomicInteger poolNumber = new AtomicInteger(1);
+    private final ThreadGroup group;
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+    private final String namePrefix;
+
+
+    public AsyncThreadFactory(String name) {
+        SecurityManager s = System.getSecurityManager();
+        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        namePrefix = name + "-" + poolNumber.getAndIncrement() + "-thread-";
+    }
+
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
+        if (t.isDaemon()) {
+            t.setDaemon(false);
+        }
+        if (t.getPriority() != Thread.NORM_PRIORITY) {
+            t.setPriority(Thread.NORM_PRIORITY);
+        }
+        return t;
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/trace/TraceMsgContextActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/trace/TraceMsgContextActivation.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.trace;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassStaticMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+/**
+ * Active the toolkit class "TraceContext". Should not dependency or import any class in
+ * "skywalking-toolkit-trace-context" module. Activation's classloader is diff from "TraceContext", using direct will
+ * trigger classloader issue.
+ * <p>
+ */
+public class TraceMsgContextActivation extends ClassStaticMethodsEnhancePluginDefine {
+
+    public static final String ENHANCE_CLASS = "org.apache.skywalking.apm.toolkit.trace.msg.TraceMsgContext";
+    public static final String ENHANCE_CONSUMER_MSG_SUCCEED_METHOD = "ConsumerMsgSucceed";
+    public static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.toolkit.activation.trace.TraceMsgContextInterceptor";
+    public static final String ENHANCE_CONSUMER_MSG_FAILURE_METHOD = "ConsumerMsgFailure";
+
+    /**
+     * @return the target class, which needs active.
+     */
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+
+    /**
+     * @return the collection of {@link StaticMethodsInterceptPoint}, represent the intercepted methods and their
+     * interceptors.
+     */
+    @Override
+    public StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
+        return new StaticMethodsInterceptPoint[]{
+                new StaticMethodsInterceptPoint() {
+                    @Override
+                    public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                        return named(ENHANCE_CONSUMER_MSG_SUCCEED_METHOD).or(named(ENHANCE_CONSUMER_MSG_FAILURE_METHOD));
+                    }
+
+                    @Override
+                    public String getMethodsInterceptor() {
+                        return INTERCEPT_CLASS;
+                    }
+
+                    @Override
+                    public boolean isOverrideArgs() {
+                        return false;
+                    }
+                }
+        };
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/trace/TraceMsgContextInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/trace/TraceMsgContextInterceptor.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.trace;
+
+import com.google.gson.Gson;
+import org.apache.skywalking.apm.agent.core.context.CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.os.OSUtil;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.toolkit.activation.threadpool.AsyncThreadFactory;
+import org.apache.skywalking.apm.toolkit.trace.TraceContext;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.*;
+
+public class TraceMsgContextInterceptor implements StaticMethodsAroundInterceptor {
+
+    private static ILog logger = LogManager.getLogger(TraceMsgContextInterceptor.class);
+
+    private static final String OPERATE_NAME_PREFIX = "MsgBusinessConsumer";
+    private static final String CONSUMER_TRACE_ID = "ConsumerTraceID";
+    private static final String CONSUMER_POD_IP = "ConsumerPodIp";
+    private static final Gson GSON = new Gson();
+    private static final int THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 4;
+    private static final int THREAD_POOL_QUEUE_SIZE = 10000;
+    private static ArrayBlockingQueue<Runnable> blockingQueue = new ArrayBlockingQueue<>(THREAD_POOL_QUEUE_SIZE);
+    private static final ExecutorService executor = new ThreadPoolExecutor(THREAD_POOL_SIZE, THREAD_POOL_SIZE,
+            60, TimeUnit.SECONDS, blockingQueue,
+            new AsyncThreadFactory("TraceMsgContextPool"), new CustomRejectedExecutionHandler());
+
+    private static class CustomRejectedExecutionHandler implements RejectedExecutionHandler {
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            logger.warn("TraceMsgContextInterceptor AsyncTrace thread pool is full, rejecting the task");
+        }
+    }
+
+    @Override
+    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+    }
+
+    @Override
+    public Object afterMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                              Object ret) {
+        String currentTraceId = TraceContext.traceId();
+        executor.execute(() -> {
+            String context = (String) allArguments[0];
+            Throwable throwable = null;
+            if (allArguments.length > 1) {
+                throwable = (Throwable) allArguments[1];
+            }
+            Map<String, String> values = GSON.fromJson(context, Map.class);
+            ContextCarrier contextCarrier = new ContextCarrier();
+            CarrierItem next = contextCarrier.items();
+            while (next.hasNext()) {
+                next = next.next();
+                String headKey = next.getHeadKey();
+                next.setHeadValue(values.get(headKey));
+            }
+            if (contextCarrier.isValid()) {
+                AbstractSpan activeSpan = ContextManager.createEntrySpan(OPERATE_NAME_PREFIX,
+                        contextCarrier);
+                if (throwable != null) {
+                    activeSpan.errorOccurred();
+                    activeSpan.log(throwable);
+                }
+                activeSpan.tag(Tags.ofKey(CONSUMER_TRACE_ID), currentTraceId);
+                activeSpan.tag(Tags.ofKey(CONSUMER_POD_IP), OSUtil.getIPV4());
+                activeSpan.setComponent(ComponentsDefine.MSG_BUSINESS_CONSUMER);
+                SpanLayer.asMQ(activeSpan);
+                ContextManager.stopSpan();
+            }
+        });
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                                      Throwable t) {
+        logger.error("Failed to getDefault trace Id.", t);
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/src/main/resources/skywalking-plugin.def
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+toolkit-trace=org.apache.skywalking.apm.toolkit.activation.trace.TraceMsgContextActivation
 toolkit-trace=org.apache.skywalking.apm.toolkit.activation.trace.ActiveSpanActivation
 toolkit-trace=org.apache.skywalking.apm.toolkit.activation.trace.TraceAnnotationActivation
 toolkit-trace=org.apache.skywalking.apm.toolkit.activation.trace.TraceContextActivation


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

### support trace the real result of kafka message processing at the business side
- [x] If this is non-trivial feature, paste the links/URLs to the design doc.
- [x] Update the documentation to include this new feature.
- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] If it's UI related, attach the screenshots below.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<no>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).


### instruction
Previously, kafka and other message consumers could only trace the messages pulled by the clients, but the actual processing results of the business could not be traced. Our project had a large number of message processing scenarios, Tracking business message processing results can improved our troubleshooting efficiency~
1.before:
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/17202572/160971559-6fc47eda-58fd-403b-a02b-0f6c72b76685.png">
2. after
<img width="898" alt="image" src="https://user-images.githubusercontent.com/17202572/160972465-e46cbd18-46e3-4bdb-8e86-24383fa8bdf2.png">
After the message is processed by the business side, can customize record the processing results
-- methods as follows
TraceMsgContext.ConsumerMsgSucceed
TraceMsgContext.ConsumerMsgFailure
<img width="1866" alt="image" src="https://user-images.githubusercontent.com/17202572/160975084-b7340bfa-c954-4537-9cc8-65005c64026c.png">

It is my honor to contribute to the skywalking. Thank you for taking the time to read it, and I hope you can give me some suggestions. If there is any mistake, I will adjust it in time
