### PR TITLE
Fix Grpc 1.x plugin could leak context due to gRPC cancelled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,7 +35,7 @@ Release Notes.
 * [Breaking Change] Remove the namespace from `cross process propagation` key.
 * Make sure the parent endpoint in tracing context from existing first ENTRY span, rather than first span only.
 * Fix the bug that maybe causing memory leak and repeated traceId when use gateway-2.1.x-plugin or gateway-3.x-plugin.
-* Fix Grpc 1.x plugin's tracing problem
+* Fix Grpc 1.x plugin could leak context due to gRPC cancelled.
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Release Notes.
 * [Breaking Change] Remove the namespace from `cross process propagation` key.
 * Make sure the parent endpoint in tracing context from existing first ENTRY span, rather than first span only.
 * Fix the bug that maybe causing memory leak and repeated traceId when use gateway-2.1.x-plugin or gateway-3.x-plugin.
+* Fix Grpc 1.x plugin's tracing problem
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/TracingServerCallListener.java
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/TracingServerCallListener.java
@@ -73,6 +73,9 @@ public class TracingServerCallListener<REQUEST> extends ForwardingServerCallList
 
     @Override
     public void onCancel() {
+        if (contextSnapshot == null) {
+            return;
+        }
         final AbstractSpan span = ContextManager.createLocalSpan(operationPrefix + REQUEST_ON_CANCEL_OPERATION_NAME);
         span.setComponent(ComponentsDefine.GRPC);
         span.setLayer(SpanLayer.RPC_FRAMEWORK);


### PR DESCRIPTION
### Fix <bug description or the bug issue number or bug issue link>
- [x] Explain briefly why the bug exists and how to fix it.

When the onCancel method is called,The `contextSnapshot` and `asyncSpan` fields can be all null in the `org.apache.skywalking.apm.plugin.grpc.v1.server.TracingServerCallListener`.  this results in the span operation chain is not completed.



- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes https://github.com/apache/skywalking/issues/8820
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
