### PR TITLE
Possible bug fix + logging grammar improvement

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
@@ -75,7 +75,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         if (witnessClasses != null) {
             for (String witnessClass : witnessClasses) {
                 if (!finder.exist(witnessClass, classLoader)) {
-                    LOGGER.warn("enhance class {} by plugin {} is not working. Because witness class {} is not existed.", transformClassName, interceptorDefineClassName, witnessClass);
+                    LOGGER.warn("enhance class {} by plugin {} is not activated. Witness class {} does not exist.", transformClassName, interceptorDefineClassName, witnessClass);
                     return null;
                 }
             }
@@ -84,7 +84,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         if (!CollectionUtil.isEmpty(witnessMethods)) {
             for (WitnessMethod witnessMethod : witnessMethods) {
                 if (!finder.exist(witnessMethod, classLoader)) {
-                    LOGGER.warn("enhance class {} by plugin {} is not working. Because witness method {} is not existed.", transformClassName, interceptorDefineClassName, witnessMethod);
+                    LOGGER.warn("enhance class {} by plugin {} is not activated. Witness method {} does not exist.", transformClassName, interceptorDefineClassName, witnessMethod);
                     return null;
                 }
             }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/util/InstanceJsonPropertiesUtil.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/util/InstanceJsonPropertiesUtil.java
@@ -44,7 +44,7 @@ public class InstanceJsonPropertiesUtil {
         }
 
         properties.add(KeyStringValuePair.newBuilder().setKey("namespace").setValue(Config.Agent.NAMESPACE).build());
-        properties.add(KeyStringValuePair.newBuilder().setKey("cluster").setValue(Config.Agent.NAMESPACE).build());
+        properties.add(KeyStringValuePair.newBuilder().setKey("cluster").setValue(Config.Agent.CLUSTER).build());
 
         return properties;
     }


### PR DESCRIPTION
I'm unsure if this is a legit bug but it looked strange that `Config.Agent.NAMESPACE` is being used for `namespace` and `cluster` when `Config.Agent.CLUSTER` also exists.

If that's not a bug I can remove it. Also improved logging grammar.