### PR TITLE
Remove redundant 'shade.package' property(#8904)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Release Notes.
 
 * Fix `cluster` and `namespace` value duplicated(`namespace` value) in properties report.
 * Add layer field to event when reporting.
+* Remove redundant `shade.package` property.
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -37,7 +37,6 @@
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
-        <shade.package>org.apache.skywalking.apm.dependencies</shade.package>
         <shade.com.google.source>com.google</shade.com.google.source>
         <shade.com.google.target>${shade.package}.${shade.com.google.source}</shade.com.google.target>
         <shade.io.grpc.source>io.grpc</shade.io.grpc.source>


### PR DESCRIPTION


### Fix <bug description or the bug issue number or bug issue link>
- [x] Explain briefly why the bug exists and how to fix it.
The `shade.package`  property in `apm-sniffer/apm-agent-core/pom.xml` is redundant due to a legacy history reason. there weren't separate plugins jars, They were in the agent.jar as a whole in the past.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes https://github.com/apache/skywalking/issues/8904.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
