### PR TITLE
Could org.apache.skywalking.apm.testcase:thrift-dist:1.0.0 drop off redundant dependencies?

### DIFF
--- a/test/plugin/scenarios/thrift-scenario/thrift-dist/pom.xml
+++ b/test/plugin/scenarios/thrift-scenario/thrift-dist/pom.xml
@@ -51,4 +51,13 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.12.0</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
Hi! I found the pom file of project **_org.apache.skywalking.apm.testcase:thrift-dist:1.0.0_** introduced **_7_** dependencies. However, among them, **_6_** libraries (**_85%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.slf4j:slf4j-api:jar:1.7.25:compile
commons-logging:commons-logging:jar:1.2:compile
org.apache.httpcomponents:httpcore:jar:4.4.1:compile
org.apache.httpcomponents:httpclient:jar:4.5.6:compile
org.apache.thrift:libthrift:jar:0.12.0:compile
commons-codec:commons-codec:jar:1.10:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.apache.thrift:libthrift:jar:0.12.0:compile_** incorporates a high-level vulnerability SNYK-JAVA-ORGAPACHETHRIFT-1074898. one of the redundant dependencies **_org.apache.httpcomponents:httpclient:jar:4.5.6:compile_** incorporates a medium-level vulnerability SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-1048058. As such, I suggest a refactoring operation for **_org.apache.skywalking.apm.testcase:thrift-dist:1.0.0_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.apache.skywalking.apm.testcase:thrift-dist:1.0.0_**’s maven tests.

Best regards