### PR TITLE
fix: rocketMQ-4.x-plugin NPE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Release Notes.
 * Grpc plugin support trace client async generic call(without grpc stubs), support Method type: `UNARY`、`SERVER_STREAMING`.
 * Enhance Apache ShenYu (incubating) plugin: support trace `grpc`,`sofarpc`,`motan`,`tars` rpc proxy.
 * Add primary endpoint name to log events.
+* Fix NPE in rocketMQ-4.x-plugin.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
@@ -49,6 +49,8 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
 
     public static final String ASYNC_SEND_OPERATION_NAME_PREFIX = "RocketMQ/";
 
+    public static final String DEFAULT_TOPIC = "no_topic";
+
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         MethodInterceptResult result) throws Throwable {

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/OnExceptionInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/OnExceptionInterceptor.java
@@ -34,13 +34,12 @@ import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 public class OnExceptionInterceptor implements InstanceMethodsAroundInterceptor {
 
     public static final String CALLBACK_OPERATION_NAME_PREFIX = "RocketMQ/";
-    private static final String DEFAULT_TOPIC = "no_topic";
 
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         MethodInterceptResult result) throws Throwable {
         SendCallBackEnhanceInfo enhanceInfo = (SendCallBackEnhanceInfo) objInst.getSkyWalkingDynamicField();
-        String topicId = DEFAULT_TOPIC;
+        String topicId = MessageSendInterceptor.DEFAULT_TOPIC;
         // The SendCallBackEnhanceInfo could be null when there is an internal exception in the client API,
         // such as MQClientException("no route info of this topic")
         if (enhanceInfo != null) {

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/OnExceptionInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/OnExceptionInterceptorTest.java
@@ -40,6 +40,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -57,7 +58,6 @@ public class OnExceptionInterceptorTest {
 
     @Mock
     private ContextSnapshot contextSnapshot;
-    private SendCallBackEnhanceInfo enhanceInfo;
 
     @Mock
     private EnhancedInstance enhancedInstance;
@@ -69,7 +69,7 @@ public class OnExceptionInterceptorTest {
 
     @Test
     public void testOnException() throws Throwable {
-        enhanceInfo = new SendCallBackEnhanceInfo("test", contextSnapshot);
+        SendCallBackEnhanceInfo enhanceInfo = new SendCallBackEnhanceInfo("test", contextSnapshot);
         when(enhancedInstance.getSkyWalkingDynamicField()).thenReturn(enhanceInfo);
 
         exceptionInterceptor.beforeMethod(enhancedInstance, null, new Object[] {new RuntimeException()}, null, null);
@@ -78,6 +78,7 @@ public class OnExceptionInterceptorTest {
         assertThat(segmentStorage.getTraceSegments().size(), is(1));
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+        assertThat(spans, notNullValue());
         assertThat(spans.size(), is(1));
 
         AbstractTracingSpan exceptionSpan = spans.get(0);
@@ -93,6 +94,7 @@ public class OnExceptionInterceptorTest {
         assertThat(segmentStorage.getTraceSegments().size(), is(1));
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+        assertThat(spans, notNullValue());
         assertThat(spans.size(), is(1));
 
         AbstractTracingSpan exceptionSpan = spans.get(0);


### PR DESCRIPTION
### Fix RocketMQ-4.x-plugin NPE

I have checked the history issue [#5311](https://github.com/apache/skywalking/issues/5311) and the PR [#5412](https://github.com/apache/skywalking/pull/5412), and this NPE is similar. Here are some error agent logs: 

```bash
ERROR 2022-05-12 21:19:09:119 NettyClientPublicExecutor_4 InstMethodsInter : class[class com...Producer$1] before method[onSuccess] intercept failure 
java.lang.NullPointerException
        at org.apache.skywalking.apm.plugin.rocketMQ.v4.OnSuccessInterceptor.beforeMethod(OnSuccessInterceptor.java:45)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:76)
        at com...Producer$1.onSuccess(Producer.java)
        at org.apache.rocketmq.client.impl.MQClientAPIImpl$1.operationComplete(MQClientAPIImpl.java:404)
        at org.apache.rocketmq.remoting.netty.ResponseFuture.executeInvokeCallback(ResponseFuture.java:54)
        at org.apache.rocketmq.remoting.netty.NettyRemotingAbstract$2.run(NettyRemotingAbstract.java:290)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
```


- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
