### PR TITLE
Support  log4j2 contextSelector as AsyncLoggerContextSelector  in gRPC log report

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Release Notes.
 * Enhance Apache ShenYu (incubating) plugin: support trace `grpc`,`sofarpc`,`motan`,`tars` rpc proxy.
 * Add primary endpoint name to log events.
 * Fix Span not finished in gateway plugin when the gateway request timeout.
+* Support `-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector` in gRPC log report.
 
 #### Documentation
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/log/log4j/v2/x/log/GRPCLogAppenderInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/log/log4j/v2/x/log/GRPCLogAppenderInterceptor.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.async.RingBufferLogEvent;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
 import org.apache.skywalking.apm.agent.core.conf.Config;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
@@ -37,6 +38,7 @@ import org.apache.skywalking.apm.network.logging.v3.LogDataBody;
 import org.apache.skywalking.apm.network.logging.v3.LogTags;
 import org.apache.skywalking.apm.network.logging.v3.TextLog;
 import org.apache.skywalking.apm.network.logging.v3.TraceContext;
+import org.apache.skywalking.apm.toolkit.logging.common.log.SkyWalkingContext;
 import org.apache.skywalking.apm.toolkit.logging.common.log.ToolkitConfig;
 
 public class GRPCLogAppenderInterceptor implements InstanceMethodsAroundInterceptor {
@@ -114,12 +116,22 @@ public class GRPCLogAppenderInterceptor implements InstanceMethodsAroundIntercep
             builder.setEndpoint(primaryEndpointName);
         }
 
-        return -1 == ContextManager.getSpanId() ? builder.build()
-                : builder.setTraceContext(TraceContext.newBuilder()
-                .setTraceId(ContextManager.getGlobalTraceId())
-                .setSpanId(ContextManager.getSpanId())
-                .setTraceSegmentId(ContextManager.getSegmentId())
-                .build()).build();
+        if (event instanceof RingBufferLogEvent) {
+            EnhancedInstance instance = (EnhancedInstance) event;
+            SkyWalkingContext context = (SkyWalkingContext) instance.getSkyWalkingDynamicField();
+            return builder.setTraceContext(TraceContext.newBuilder()
+                    .setTraceId(context.getTraceId())
+                    .setSpanId(context.getSpanId())
+                    .setTraceSegmentId(context.getTraceSegmentId())
+                    .build()).build();
+        } else {
+            return -1 == ContextManager.getSpanId() ? builder.build()
+                    : builder.setTraceContext(TraceContext.newBuilder()
+                    .setTraceId(ContextManager.getGlobalTraceId())
+                    .setSpanId(ContextManager.getSpanId())
+                    .setTraceSegmentId(ContextManager.getSegmentId())
+                    .build()).build();
+        }
     }
 
     private String transformLogText(final AbstractAppender appender, final LogEvent event) {

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logging-common/src/main/java/org/apache/skywalking/apm/toolkit/logging/common/log/SkyWalkingContext.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logging-common/src/main/java/org/apache/skywalking/apm/toolkit/logging/common/log/SkyWalkingContext.java
@@ -38,6 +38,14 @@ public class SkyWalkingContext {
         return traceId;
     }
 
+    public String getTraceSegmentId() {
+        return traceSegmentId;
+    }
+
+    public int getSpanId() {
+        return spanId;
+    }
+
     @Override
     public String toString() {
         if (-1 == spanId) {

--- a/docs/en/setup/service-agent/java-agent/Application-toolkit-log4j-2.x.md
+++ b/docs/en/setup/service-agent/java-agent/Application-toolkit-log4j-2.x.md
@@ -128,6 +128,7 @@ The gRPC report could forward the collected logs to SkyWalking OAP server, or [S
 log.max_message_size=${SW_GRPC_LOG_MAX_MESSAGE_SIZE:10485760}
 ```
 
+* Support `-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector` in gRPC log report.
 
 ## Transmitting un-formatted messages
 


### PR DESCRIPTION
==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====

Fix https://github.com/apache/skywalking/discussions/9113
[✅] Fix the problem that traceid cannot be reported when log4j2 global is modified to asynchronous log
==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ====

[✅] Update the [CHANGES log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
[✅] Update the [Log4j2 log](`application-toolkit-log4j-2.x.md`).