### PR TITLE
string "/eureka" should match pattern "/eureka/*" or "/eureka/**"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Release Notes.
 * Support `-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector` in gRPC log report.
 * Fix tcnative libraries relocation for aarch64.
 * Add `plugin.jdbc.trace_sql_parameters` into Configuration Discovery Service.
+* Enhance TracePathMatcher, "/eureka/*" or "/eureka/**" can match "/eureka".
 
 #### Documentation
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/main/java/org/apache/skywalking/apm/plugin/trace/ignore/matcher/FastPathMatcher.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/main/java/org/apache/skywalking/apm/plugin/trace/ignore/matcher/FastPathMatcher.java
@@ -70,6 +70,19 @@ public class FastPathMatcher implements TracePathMatcher {
                 continue;
             }
 
+            // pattern: a/*   a/**
+            //          ↓     ↓
+            //string:   a     a
+            if(pc=='/' && sc == 0){
+                p++;
+                if (safeCharAt(pat, p) == '*') {
+                    p++;
+                    return multiWildcardMatch(pat, p, str, s);
+                }else{
+                    return false;
+                }
+            }
+
             // Not matched.
             //            ↓
             // pattern: a/b

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TracePathMatcherTest.java
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/src/test/java/org/apache/skywalking/apm/plugin/trace/ignore/TracePathMatcherTest.java
@@ -35,11 +35,17 @@ public class TracePathMatcherTest {
         path = "/eureka/";
         match = pathMatcher.match(pattern, path);
         Assert.assertTrue(match);
+        path = "/eureka";
+        match = pathMatcher.match(pattern, path);
+        Assert.assertTrue(match);
         path = "/eureka/apps/";
         match = pathMatcher.match(pattern, path);
         Assert.assertTrue(match);
 
         pattern = "/eureka/**";
+        path = "/eureka";
+        match = pathMatcher.match(pattern, path);
+        Assert.assertTrue(match);
         path = "/eureka/apps/";
         match = pathMatcher.match(pattern, path);
         Assert.assertTrue(match);


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->


###  string "/eureka" should match pattern "/eureka/*" or "/eureka/**"


