### PR TITLE
Fix ArgumentTypeNameMatch doesn't work for array argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Release Notes.
 * Support `-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector` in gRPC log report.
 * Fix tcnative libraries relocation for aarch64.
 * Add `plugin.jdbc.trace_sql_parameters` into Configuration Discovery Service.
+* Fix ArgumentTypeNameMatch doesn't work for array argument
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bytebuddy/ArgumentTypeNameMatch.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/bytebuddy/ArgumentTypeNameMatch.java
@@ -60,7 +60,7 @@ public class ArgumentTypeNameMatch implements ElementMatcher<MethodDescription> 
     public boolean matches(MethodDescription target) {
         ParameterList<?> parameters = target.getParameters();
         if (parameters.size() > index) {
-            return parameters.get(index).getType().asErasure().getName().equals(argumentTypeName);
+            return parameters.get(index).getType().getActualName().equals(argumentTypeName);
         }
 
         return false;

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/plugin/bytebuddy/ArgumentTypeNameMatchTest.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/plugin/bytebuddy/ArgumentTypeNameMatchTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.plugin.bytebuddy;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ArgumentTypeNameMatchTest {
+
+    @Test
+    public void testMatch() throws Exception {
+        final ElementMatcher<MethodDescription> matcher1 = ArgumentTypeNameMatch.takesArgumentWithType(0, "org.apache.skywalking.apm.agent.core.plugin.bytebuddy.Person");
+        Assert.assertTrue(matcher1.matches(new MethodDescription.ForLoadedMethod(Person.class.getMethod("isOlderThan", Person.class))));
+        Assert.assertFalse(matcher1.matches(new MethodDescription.ForLoadedMethod(Person.class.getMethod("setAge", int.class))));
+
+        final ElementMatcher<MethodDescription> matcher2 = ArgumentTypeNameMatch.takesArgumentWithType(0, "org.apache.skywalking.apm.agent.core.plugin.bytebuddy.Person[]");
+        Assert.assertTrue(matcher2.matches(new MethodDescription.ForLoadedMethod(Person.class.getMethod("isMemberOf", Person[].class))));
+        Assert.assertFalse(matcher2.matches(new MethodDescription.ForLoadedMethod(Person.class.getMethod("isOlderThan", Person.class))));
+    }
+
+}

--- a/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/plugin/bytebuddy/Person.java
+++ b/apm-sniffer/apm-agent-core/src/test/java/org/apache/skywalking/apm/agent/core/plugin/bytebuddy/Person.java
@@ -40,4 +40,21 @@ public class Person {
         return age;
     }
 
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public boolean isOlderThan(Person anotherPerson) {
+        return this.age > anotherPerson.age;
+    }
+
+    public boolean isMemberOf(Person[] persons) {
+        for (Person person: persons) {
+            if (person == this) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/docs/en/contribution/compiling.md
+++ b/docs/en/contribution/compiling.md
@@ -7,6 +7,8 @@ Prepare JDK 8+.
 ```shell
 git clone https://github.com/apache/skywalking-java.git
 cd skywalking-java
+git submodule init
+git submodule update
 ./mvnw clean package -Pall
 ```
 


### PR DESCRIPTION
I found ArgumentTypeNameMatch doesn't work for array argument (e.g. the STRING_ARRAY_ARGUMENT_TYPE in org.apache.skywalking.apm.plugin.jdbc.postgresql.define.ConnectionInstrumentation )

Fix <ArgumentTypeNameMatch doesn't work for array argument>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
