### PR TITLE
[Bug #9250]shenyu plugin fix IgnoredTracerContext traceId NPE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Release Notes.
 
 8.12.0
 ------------------
-* Fix `Shenyu plugin` IgnoredTracerContext traceId NPE(Use with the apm-trace-ignore-plugin plugin will trigger)
+* Fix `Shenyu plugin`'s NPE in reading read trace ID when IgnoredTracerContext is used in the context.
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Release Notes.
 
 8.12.0
 ------------------
-
+* Fix `Shenyu plugin` IgnoredTracerContext traceId NPE(Use with the apm-trace-ignore-plugin plugin will trigger)
 
 #### Documentation
 

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
@@ -18,10 +18,18 @@
 
 package org.apache.skywalking.apm.plugin.shenyu.v24x;
 
+import static org.apache.skywalking.apm.plugin.shenyu.v24x.Constant.SKYWALKING_CONTEXT_SNAPSHOT;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
 import org.apache.skywalking.apm.agent.core.context.CarrierItem;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.context.ids.DistributedTraceId;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags.HTTP;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
@@ -34,14 +42,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebExchangeDecorator;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
+
 import reactor.core.publisher.Mono;
-
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import static org.apache.skywalking.apm.plugin.shenyu.v24x.Constant.SKYWALKING_CONTEXT_SNAPSHOT;
 
 /**
  * Apache shenyu global-plugin interceptor.
@@ -75,7 +77,8 @@ public class GlobalPluginExecuteMethodInterceptor implements InstanceMethodsArou
         HTTP.METHOD.set(span, exchange.getRequest().getMethodValue());
 
         ContextSnapshot snapshot = ContextManager.capture();
-        exchange.getAttributes().put(SHENYU_AGENT_TRACE_ID, snapshot.getTraceId().getId());
+        exchange.getAttributes().put(SHENYU_AGENT_TRACE_ID,
+                Optional.ofNullable(snapshot.getTraceId()).map(DistributedTraceId::getId).orElse(""));
         EnhancedInstance instance = getInstance(allArguments[0]);
         instance.setSkyWalkingDynamicField(snapshot);
         span.prepareForAsync();

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
@@ -18,13 +18,6 @@
 
 package org.apache.skywalking.apm.plugin.shenyu.v24x;
 
-import static org.apache.skywalking.apm.plugin.shenyu.v24x.Constant.SKYWALKING_CONTEXT_SNAPSHOT;
-
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
 import org.apache.skywalking.apm.agent.core.context.CarrierItem;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
@@ -42,8 +35,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.ServerWebExchangeDecorator;
 import org.springframework.web.server.adapter.DefaultServerWebExchange;
-
 import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.skywalking.apm.plugin.shenyu.v24x.Constant.SKYWALKING_CONTEXT_SNAPSHOT;
 
 /**
  * Apache shenyu global-plugin interceptor.


### PR DESCRIPTION
### Fix <Apache Shenyu plugin NPE #9250>  
- [ ] Add a unit test to verify that the fix works.

- [x] Explain briefly why the bug exists and how to fix it.
When the implementation class of AbstractTracerContext is IgnoredTracerContext, the DistributedTraceId obtained from the context is empty, resulting in a null pointer exception for obtaining the traceId

Fix https://github.com/apache/skywalking/issues/9250


