### PR TITLE
fix: agent goes into non-reconnect loop on network error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,9 @@ Release Notes.
 
 8.12.0
 ------------------
-* Fix `Shenyu plugin`'s NPE in reading read trace ID when IgnoredTracerContext is used in the context.
+* Fix `Shenyu plugin`'s NPE in reading trace ID when IgnoredTracerContext is used in the context.
 * Update witness class in elasticsearch-6.x-plugin, avoid throw NPE.
-* Fix `onHalfClose` using span operation name `/Request/onComplete` instead of the worng name `/Request/onHalfClose`.
+* Fix `onHalfClose` using span operation name `/Request/onComplete` instead of the wrong name `/Request/onHalfClose`.
 * Add plugin to support RESTeasy 4.x.
 * Add plugin to support hutool-http 5.x.
 * Add plugin to support Tomcat 10.x.
@@ -14,6 +14,7 @@ Release Notes.
 * Upgrade byte-buddy to 1.12.13, and adopt byte-buddy APIs changes.
 * Upgrade gson to 2.8.9.
 * Upgrade netty-codec-http2 to 4.1.79.Final.
+* Fix race condition causing agent to not reconnect after network error
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/remote/GRPCChannelManager.java
@@ -146,16 +146,16 @@ public class GRPCChannelManager implements BootService, Runnable {
                                                     .addChannelDecorator(new AgentIDDecorator())
                                                     .addChannelDecorator(new AuthenticationDecorator())
                                                     .build();
-                        notify(GRPCChannelStatus.CONNECTED);
                         reconnectCount = 0;
                         reconnect = false;
+                        notify(GRPCChannelStatus.CONNECTED);
                     } else if (managedChannel.isConnected(++reconnectCount > Config.Agent.FORCE_RECONNECTION_PERIOD)) {
                         // Reconnect to the same server is automatically done by GRPC,
                         // therefore we are responsible to check the connectivity and
                         // set the state and notify listeners
                         reconnectCount = 0;
-                        notify(GRPCChannelStatus.CONNECTED);
                         reconnect = false;
+                        notify(GRPCChannelStatus.CONNECTED);
                     }
 
                     return;


### PR DESCRIPTION
### Fix reconnection race condition

The agent can be made to go into a loop where it won't try to reconnect. I'm not entirely sure this completely solves the race condition but it feels like it logically does. I haven't been able to recreate the bug since I've applied the changes in this PR.

Before this PR, I could recreate this non-reconnection loop by placing a thread breakpoint on `reconnect = false` and waiting for all the listeners to call `reportError`. Once they all called `reportError` I would resume the paused thread which would put it into this non-reconnection loop.

### Bug Logs
```
DEBUG 2022-08-08 12:27:00.835 http-nio-9999-exec-2 AbstractClassEnhancePluginDefine : prepare to enhance class org.apache.catalina.core.ApplicationDispatcher by org.apache.skywalking.apm.plugin.tomcat78x.define.ApplicationDispatcherInstrumentation. 
DEBUG 2022-08-08 12:27:00.839 http-nio-9999-exec-2 AbstractClassEnhancePluginDefine : enhance class org.apache.catalina.core.ApplicationDispatcher by org.apache.skywalking.apm.plugin.tomcat78x.define.ApplicationDispatcherInstrumentation completely. 
DEBUG 2022-08-08 12:27:00.839 http-nio-9999-exec-2 SkyWalkingAgent : Finish the prepare stage for org.apache.catalina.core.ApplicationDispatcher. 
DEBUG 2022-08-08 12:27:00.854 http-nio-9999-exec-2 SkyWalkingAgent : On Transformation class org.apache.catalina.core.ApplicationDispatcher. 
DEBUG 2022-08-08 12:27:01.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:27:01.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:true. 
DEBUG 2022-08-08 12:27:01.854 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] OUTBOUND HEADERS: streamId=3 headers=GrpcHttp2OutboundHeaders[:authority: spp-platform:11800, :path: /skywalking.v3.TraceSegmentReportService/collect, :method: POST, :scheme: https, content-type: application/grpc, te: trailers, user-agent: grpc-java-netty/1.44.0, authentication: test-id:test-secret:tenant1, agent-version: 8.11.0, grpc-accept-encoding: gzip, grpc-timeout: 29984112u] streamDependency=0 weight=16 exclusive=false padding=0 endStream=false 
DEBUG 2022-08-08 12:27:01.875 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] OUTBOUND DATA: streamId=3 padding=0 endStream=true length=1657 bytes=00000002070a3532356134373262623233636434643630393130393031343062366363373839612e38322e313635393936313632313831333030303112353235... 
DEBUG 2022-08-08 12:27:01.935 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] OUTBOUND HEADERS: streamId=5 headers=GrpcHttp2OutboundHeaders[:authority: spp-platform:11800, :path: /skywalking.v3.LogReportService/collect, :method: POST, :scheme: https, content-type: application/grpc, te: trailers, user-agent: grpc-java-netty/1.44.0, authentication: test-id:test-secret:tenant1, agent-version: 8.11.0, grpc-accept-encoding: gzip, grpc-timeout: 29998848u] streamDependency=0 weight=16 exclusive=false padding=0 endStream=false 
DEBUG 2022-08-08 12:27:01.937 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] OUTBOUND DATA: streamId=5 padding=0 endStream=true length=229 bytes=00000000e008a5fbb0eba73012037370701a2b3336633935363566356264303465313939353732373761633138663263303263403137322e32342e302e342a1a... 
DEBUG 2022-08-08 12:27:02.220 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] INBOUND HEADERS: streamId=3 headers=GrpcHttp2ResponseHeaders[:status: 200, content-type: application/grpc, grpc-accept-encoding: gzip, grpc-status: 7, content-length: 0] streamDependency=0 weight=16 exclusive=false padding=0 endStream=true 
ERROR 2022-08-08 12:27:02.226 grpc-default-executor-2 TraceSegmentServiceClient : Send UpstreamSegment to collector fail with a grpc internal exception. 
org.apache.skywalking.apm.dependencies.io.grpc.StatusRuntimeException: PERMISSION_DENIED
	at org.apache.skywalking.apm.dependencies.io.grpc.Status.asRuntimeException(Status.java:535)
	at org.apache.skywalking.apm.dependencies.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:479)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:562)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:743)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:722)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

DEBUG 2022-08-08 12:27:02.227 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] INBOUND HEADERS: streamId=5 headers=GrpcHttp2ResponseHeaders[:status: 200, content-type: application/grpc, grpc-accept-encoding: gzip, grpc-status: 7, content-length: 0] streamDependency=0 weight=16 exclusive=false padding=0 endStream=true 
ERROR 2022-08-08 12:27:02.227 grpc-default-executor-2 LogReportServiceClient : Try to send 1 log data to collector, with unexpected exception. 
org.apache.skywalking.apm.dependencies.io.grpc.StatusRuntimeException: PERMISSION_DENIED
	at org.apache.skywalking.apm.dependencies.io.grpc.Status.asRuntimeException(Status.java:535)
	at org.apache.skywalking.apm.dependencies.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:479)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:562)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:743)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:722)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

DEBUG 2022-08-08 12:27:02.507 DataCarrier.DEFAULT.Consumer.0.Thread TraceSegmentServiceClient : 4 trace segments have been sent to collector. 
DEBUG 2022-08-08 12:27:11.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:27:31.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:27:31.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:27:31.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:true. 
DEBUG 2022-08-08 12:27:31.707 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] OUTBOUND HEADERS: streamId=7 headers=GrpcHttp2OutboundHeaders[:authority: spp-platform:11800, :path: /skywalking.v3.EventService/collect, :method: POST, :scheme: https, content-type: application/grpc, te: trailers, user-agent: grpc-java-netty/1.44.0, authentication: test-id:test-secret:tenant1, agent-version: 8.11.0, grpc-accept-encoding: gzip, grpc-timeout: 29999457u] streamDependency=0 weight=16 exclusive=false padding=0 endStream=false 
DEBUG 2022-08-08 12:27:31.710 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] INBOUND HEADERS: streamId=7 headers=GrpcHttp2ResponseHeaders[:status: 200, content-type: application/grpc, grpc-accept-encoding: gzip, grpc-status: 7, content-length: 0] streamDependency=0 weight=16 exclusive=false padding=0 endStream=true 
ERROR 2022-08-08 12:27:31.711 grpc-default-executor-2 EventReportServiceClient : Failed to report starting event. 
org.apache.skywalking.apm.dependencies.io.grpc.StatusRuntimeException: PERMISSION_DENIED
	at org.apache.skywalking.apm.dependencies.io.grpc.Status.asRuntimeException(Status.java:535)
	at org.apache.skywalking.apm.dependencies.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:479)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:562)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:70)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:743)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:722)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at org.apache.skywalking.apm.dependencies.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)

DEBUG 2022-08-08 12:27:31.712 grpc-nio-worker-ELG-1-1 org.apache.skywalking.apm.dependencies.io.grpc.netty.NettyClientHandler : [id: 0x54bfd279, L:/172.24.0.4:49010 - R:spp-platform/172.24.0.8:11800] OUTBOUND RST_STREAM: streamId=7 errorCode=8 
DEBUG 2022-08-08 12:27:51.698 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:28:01.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:28:01.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:false. 
DEBUG 2022-08-08 12:28:11.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:28:31.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:28:31.698 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:28:31.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:false. 
DEBUG 2022-08-08 12:28:51.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:29:01.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:29:01.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:false. 
DEBUG 2022-08-08 12:29:11.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:29:31.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:29:31.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:29:31.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:false. 
DEBUG 2022-08-08 12:29:51.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:30:01.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:30:01.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:false. 
DEBUG 2022-08-08 12:30:11.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:30:31.589 SkywalkingAgent-6-ServiceManagementClient-0 ServiceManagementClient : ServiceManagementClient running, status:DISCONNECT. 
DEBUG 2022-08-08 12:30:31.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 
DEBUG 2022-08-08 12:30:31.705 SkywalkingAgent-12-GRPCChannelManager-0 GRPCChannelManager : Selected collector grpc service running, reconnect:false. 
DEBUG 2022-08-08 12:30:51.697 SkywalkingAgent-11-ConfigurationDiscoveryService-0 ConfigurationDiscoveryService : ConfigurationDiscoveryService running, status:DISCONNECT. 

```
