### PR TITLE
[Bug #9598] Apache ShenYu agent Tid is null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Release Notes.
 * Support to set the value of Map/List field to an empty map/list.
 * Add plugin to support [Impala JDBC](https://www.cloudera.com/downloads/connectors/impala/jdbc/2-6-29.html) 2.6.x.
 * Update guava-cache, jedis, memcached, ehcache plugins to adopt uniform tags.
-* Fix Apache ShenYu plugin traceId empty string value. 
+* Fix `Apache ShenYu` plugin traceId empty string value. 
 #### Documentation
 
 * Update `configuration` doc about overriding default value as empty map/list accordingly.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 * Add plugin to support [Impala JDBC](https://www.cloudera.com/downloads/connectors/impala/jdbc/2-6-29.html) 2.6.x.
 * Update guava-cache, jedis, memcached, ehcache plugins to adopt uniform tags.
 * Fix `Apache ShenYu` plugin traceId empty string value. 
+
 #### Documentation
 
 * Update `configuration` doc about overriding default value as empty map/list accordingly.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Release Notes.
 * Support to set the value of Map/List field to an empty map/list.
 * Add plugin to support [Impala JDBC](https://www.cloudera.com/downloads/connectors/impala/jdbc/2-6-29.html) 2.6.x.
 * Update guava-cache, jedis, memcached, ehcache plugins to adopt uniform tags.
-
+* Fix Apache ShenYu plugin traceId empty string value. 
 #### Documentation
 
 * Update `configuration` doc about overriding default value as empty map/list accordingly.

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
@@ -77,7 +77,7 @@ public class GlobalPluginExecuteMethodInterceptor implements InstanceMethodsArou
 
         ContextSnapshot snapshot = ContextManager.capture();
         exchange.getAttributes().put(SHENYU_AGENT_TRACE_ID,
-                Optional.ofNullable(snapshot.getTraceId()).map(DistributedTraceId::getId).orElse(""));
+                Optional.ofNullable(snapshot.getTraceId()).map(DistributedTraceId::getId).orElse(ContextManager.getGlobalTraceId()));
         EnhancedInstance instance = getInstance(allArguments[0]);
         instance.setSkyWalkingDynamicField(snapshot);
         span.prepareForAsync();

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/shenyu/v24x/GlobalPluginExecuteMethodInterceptor.java
@@ -98,7 +98,8 @@ public class GlobalPluginExecuteMethodInterceptor implements InstanceMethodsArou
         }
         Mono<Void> monoReturn = (Mono<Void>) ret;
 
-        // add skywalking context snapshot to reactor context. webclient plugin need to use SKYWALKING_CONTEXT_SNAPSHOT
+        // add skywalking context snapshot to reactor context.
+        // webclient plugin need to use SKYWALKING_CONTEXT_SNAPSHOT
         EnhancedInstance instance = getInstance(allArguments[0]);
         if (instance != null && instance.getSkyWalkingDynamicField() != null) {
             monoReturn = monoReturn.subscriberContext(


### PR DESCRIPTION


### Fix <Apache ShenYu agent Tid is null #9598>

- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
When the implementation class of GlobalPluginExecuteMethodInterceptor#beforeMethod, The traceId result perhaps return empty string value, '.orElse("")' method should be set global traceId to default value.




Fix https://github.com/apache/skywalking/issues/9598