### PR TITLE
Correct the duration of the transaction span for Neo4J 4.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Release Notes.
 * Update `compose-start-script.template` to make compatible with new version docker compose
 * Bump up grpc to 1.50.0 to fix CVE-2022-3171
 * Polish up nats plugin to unify MQ related tags  
-* Fix transaction spans for Neo4J 4.x.
+* Accurate duration of the transaction span for Neo4J 4.x.
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Release Notes.
 * Update `compose-start-script.template` to make compatible with new version docker compose
 * Bump up grpc to 1.50.0 to fix CVE-2022-3171
 * Polish up nats plugin to unify MQ related tags  
-* Accurate duration of the transaction span for Neo4J 4.x.
+* Correct the duration of the transaction span for Neo4J 4.x.
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Release Notes.
 * Update `compose-start-script.template` to make compatible with new version docker compose
 * Bump up grpc to 1.50.0 to fix CVE-2022-3171
 * Polish up nats plugin to unify MQ related tags  
+* Fix transaction spans for Neo4J 4.x.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/neo4j-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/neo4j/v4x/TransactionRunInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/neo4j-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/neo4j/v4x/TransactionRunInterceptor.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.plugin.neo4j.v4x;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
@@ -61,13 +62,15 @@ public class TransactionRunInterceptor implements InstanceMethodsAroundIntercept
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
             Object ret) throws Throwable {
-        SessionRequiredInfo requiredInfo = (SessionRequiredInfo) objInst.getSkyWalkingDynamicField();
-        if (requiredInfo == null || requiredInfo.getSpan() == null) {
-            return ret;
-        }
+        return ((CompletionStage<?>) ret).thenApply(resultCursor -> {
+            SessionRequiredInfo requiredInfo = (SessionRequiredInfo) objInst.getSkyWalkingDynamicField();
+            if (requiredInfo == null || requiredInfo.getSpan() == null) {
+                return resultCursor;
+            }
 
-        requiredInfo.getSpan().asyncFinish();
-        return ret;
+            requiredInfo.getSpan().asyncFinish();
+            return resultCursor;
+        });
     }
 
     @Override


### PR DESCRIPTION
Wait until the end of the transaction before closing the transaction span, like it is done for NetworkSession.asyncRun calls.

### Fix #9800 https://github.com/apache/skywalking/issues/9800
- [ ] Add a unit test to verify that the fix works.
  - not really possible without adding sleeps, comparing timestamps, etc.
- [X] Explain briefly why the bug exists and how to fix it.

- [X] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
