### PR TITLE
Report the agent version to OAP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Release Notes.
 * Upgrade agent test tools
 * [Breaking Change] Compatible with 3.x and 4.x RabbitMQ Client, rename `rabbitmq-5.x-plugin` to `rabbitmq-plugin`
 * Polish JDBC plugins to make DBType accurate
-* Support the agent version to report to OAP as an instance attribute
+* Report the agent version to OAP as an instance attribute
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 * Upgrade agent test tools
 * [Breaking Change] Compatible with 3.x and 4.x RabbitMQ Client, rename `rabbitmq-5.x-plugin` to `rabbitmq-plugin`
 * Polish JDBC plugins to make DBType accurate
+* Support the agent version to report to OAP as an instance attribute
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -33,10 +33,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <generateGitPropertiesFilename>${generateGitPropertiesFilename}</generateGitPropertiesFilename>
         <guava.version>30.1.1-jre</guava.version>
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
+        <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <shade.com.google.source>com.google</shade.com.google.source>
         <shade.com.google.target>${shade.package}.${shade.com.google.source}</shade.com.google.target>
         <shade.io.grpc.source>io.grpc</shade.io.grpc.source>
@@ -170,6 +172,31 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>${git-commit-id-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <generateGitPropertiesFilename>${generateGitPropertiesFilename}</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <dateFormat>yyMMdd</dateFormat>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -187,15 +187,16 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${generateGitPropertiesFilename}</generateGitPropertiesFilename>
+                    <dateFormat>yyyyMMddHHmmss</dateFormat>
+                    <dateFormatTimeZone>UTC</dateFormatTimeZone>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
                     <includeOnlyProperties>
                         <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
                         <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
                     </includeOnlyProperties>
-                    <commitIdGenerationMode>full</commitIdGenerationMode>
-                    <dateFormat>yyMMdd</dateFormat>
                 </configuration>
             </plugin>
             <plugin>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <generateGitPropertiesFilename>${generateGitPropertiesFilename}</generateGitPropertiesFilename>
+        <generateGitPropertiesFilename>${project.build.outputDirectory}/skywalking-agent-version.properties</generateGitPropertiesFilename>
         <guava.version>30.1.1-jre</guava.version>
         <wiremock.version>2.6.0</wiremock.version>
         <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -190,11 +190,9 @@
                     <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
                     <generateGitPropertiesFilename>${generateGitPropertiesFilename}</generateGitPropertiesFilename>
-                    <dateFormat>yyyyMMddHHmmss</dateFormat>
-                    <dateFormatTimeZone>UTC</dateFormatTimeZone>
                     <commitIdGenerationMode>full</commitIdGenerationMode>
                     <includeOnlyProperties>
-                        <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                        <includeOnlyProperty>git.build.version</includeOnlyProperty>
                         <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
                     </includeOnlyProperties>
                 </configuration>

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/util/InstanceJsonPropertiesUtil.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/util/InstanceJsonPropertiesUtil.java
@@ -20,24 +20,15 @@ package org.apache.skywalking.apm.agent.core.util;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-
 import org.apache.skywalking.apm.agent.core.conf.Config;
-import org.apache.skywalking.apm.agent.core.logging.api.ILog;
-import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.version.Version;
 import org.apache.skywalking.apm.network.common.v3.KeyStringValuePair;
 import org.apache.skywalking.apm.util.StringUtil;
 
 public class InstanceJsonPropertiesUtil {
-
-    private static final ILog LOGGER = LogManager.getLogger(InstanceJsonPropertiesUtil.class);
-    private static final String GIT_PROPERTIES = "skywalking-agent-git.properties";
     private static final Gson GSON = new Gson();
 
     public static List<KeyStringValuePair> parseProperties() {
@@ -55,32 +46,8 @@ public class InstanceJsonPropertiesUtil {
 
         properties.add(KeyStringValuePair.newBuilder().setKey("namespace").setValue(Config.Agent.NAMESPACE).build());
         properties.add(KeyStringValuePair.newBuilder().setKey("cluster").setValue(Config.Agent.CLUSTER).build());
-        properties.add(KeyStringValuePair.newBuilder().setKey("version").setValue(getAgentVersion()).build());
+        properties.add(KeyStringValuePair.newBuilder().setKey("version").setValue(Version.CURRENT.toString()).build());
 
         return properties;
-    }
-
-    public static String getAgentVersion() {
-        try {
-            InputStream inStream = InstanceJsonPropertiesUtil.class.getClassLoader()
-                    .getResourceAsStream(GIT_PROPERTIES);
-            if (inStream != null) {
-                Properties gitProperties = new Properties();
-                gitProperties.load(inStream);
-                String commitIdAbbrev = gitProperties.getProperty("git.commit.id.abbrev");
-                String buildTime = gitProperties.getProperty("git.build.time");
-                String buildVersion = gitProperties.getProperty("git.build.version");
-                String version =  buildVersion + "-" + commitIdAbbrev + "-" + buildTime;
-
-                LOGGER.info("SkyWalking agent version: {}", version);
-                return version;
-            } else {
-                LOGGER.warn("{} not found, SkyWalking agent version: unknown", GIT_PROPERTIES);
-            }
-        } catch (IOException e) {
-            LOGGER.error("Failed to get agent version", e);
-        }
-
-        return "UNKNOWN";
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.core.version;
+
+import lombok.Getter;
+
+import java.io.IOException;
+import java.util.Properties;
+
+@Getter
+public enum Version {
+    CURRENT;
+
+    private static final String VERSION_FILE_NAME = "skywalking-agent-version.properties";
+    private final String buildVersion;
+    private final String commitIdAbbrev;
+    private final String buildTime;
+
+    Version() {
+        try {
+            Properties properties = new Properties();
+            properties.load(Version.class.getClassLoader().getResourceAsStream(VERSION_FILE_NAME));
+            buildVersion = properties.getProperty("git.build.version");
+            commitIdAbbrev = properties.getProperty("git.commit.id.abbrev");
+            buildTime = properties.getProperty("git.build.time");
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s-%s-%s", buildVersion, commitIdAbbrev, buildTime);
+    }
+}

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
@@ -19,14 +19,18 @@
 package org.apache.skywalking.apm.agent.core.version;
 
 import lombok.Getter;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 @Getter
 public enum Version {
     CURRENT;
 
+    private static final ILog LOGGER = LogManager.getLogger(Version.class);
     private static final String VERSION_FILE_NAME = "skywalking-agent-version.properties";
     private final String buildVersion;
     private final String commitIdAbbrev;
@@ -34,14 +38,22 @@ public enum Version {
 
     Version() {
         try {
+            InputStream inputStream = Version.class.getClassLoader().getResourceAsStream(VERSION_FILE_NAME);
+            if (inputStream == null) {
+                throw new IOException("Can't find " + VERSION_FILE_NAME);
+            }
             Properties properties = new Properties();
-            properties.load(Version.class.getClassLoader().getResourceAsStream(VERSION_FILE_NAME));
+            properties.load(inputStream);
             buildVersion = properties.getProperty("git.build.version");
             commitIdAbbrev = properties.getProperty("git.commit.id.abbrev");
             buildTime = properties.getProperty("git.build.time");
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new ExceptionInInitializerError(e);
         }
+    }
+
+    static {
+        LOGGER.info("SkyWalking agent version: {}", CURRENT);
     }
 
     @Override

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.agent.core.version;
 import lombok.Getter;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.util.StringUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,6 +59,8 @@ public enum Version {
 
     @Override
     public String toString() {
-        return String.format("%s-%s-%s", buildVersion, commitIdAbbrev, buildTime);
+        return StringUtil.isEmpty(buildTime) ?
+                String.format("%s-%s", buildVersion, commitIdAbbrev) :
+                String.format("%s-%s-%s", buildVersion, commitIdAbbrev, buildTime);
     }
 }

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/version/Version.java
@@ -21,7 +21,6 @@ package org.apache.skywalking.apm.agent.core.version;
 import lombok.Getter;
 import org.apache.skywalking.apm.agent.core.logging.api.ILog;
 import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
-import org.apache.skywalking.apm.util.StringUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,7 +34,6 @@ public enum Version {
     private static final String VERSION_FILE_NAME = "skywalking-agent-version.properties";
     private final String buildVersion;
     private final String commitIdAbbrev;
-    private final String buildTime;
 
     Version() {
         try {
@@ -47,7 +45,6 @@ public enum Version {
             properties.load(inputStream);
             buildVersion = properties.getProperty("git.build.version");
             commitIdAbbrev = properties.getProperty("git.commit.id.abbrev");
-            buildTime = properties.getProperty("git.build.time");
         } catch (Exception e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -59,8 +56,6 @@ public enum Version {
 
     @Override
     public String toString() {
-        return StringUtil.isEmpty(buildTime) ?
-                String.format("%s-%s", buildVersion, commitIdAbbrev) :
-                String.format("%s-%s-%s", buildVersion, commitIdAbbrev, buildTime);
+        return String.format("%s-%s", buildVersion, commitIdAbbrev);
     }
 }

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -67,6 +67,7 @@
                 </executions>
                 <configuration>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/skywalking-agent-git.properties</generateGitPropertiesFilename>
                     <includeOnlyProperties>
                         <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -53,31 +53,6 @@
         <finalName>skywalking-agent</finalName>
         <plugins>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.5</version>
-                <executions>
-                    <execution>
-                        <id>get-the-git-infos</id>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                    </execution>
-                </executions>
-                <configuration>
-                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
-                    <generateGitPropertiesFilename>${project.build.outputDirectory}/skywalking-agent-git.properties</generateGitPropertiesFilename>
-                    <includeOnlyProperties>
-                        <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
-                        <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
-                    </includeOnlyProperties>
-                    <commitIdGenerationMode>full</commitIdGenerationMode>
-                    <dateFormat>yyMMdd</dateFormat>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -53,6 +53,30 @@
         <finalName>skywalking-agent</finalName>
         <plugins>
             <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.5</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/skywalking-agent-git.properties</generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <dateFormat>yyMMdd</dateFormat>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,8 @@
                     </resourceIncludes>
                     <resourceExcludes>
                         **/.asf.yaml,
-                        **/.github/**
+                        **/.github/**,
+                        **/skywalking-agent-version.properties
                     </resourceExcludes>
                     <excludes>
                         **/target/generated-test-sources/**,

--- a/test/e2e/case/expected/service-instance.yml
+++ b/test/e2e/case/expected/service-instance.yml
@@ -36,6 +36,8 @@
     value: '{{ notEmpty .value }}'
   - name: ipv4s
     value: {{ notEmpty .value }}
+  - name: version
+    value: {{ notEmpty .value }}
     {{- end }}
   language: JAVA
   instanceuuid: {{ b64enc "e2e-service-provider" }}.1_{{ b64enc "provider1" }}

--- a/tools/releasing/create_release.sh
+++ b/tools/releasing/create_release.sh
@@ -59,6 +59,11 @@ git checkout ${TAG_NAME}
 git submodule init
 git submodule update
 
+# Generate a static version.properties and override the template when releasing source tar
+# because after that there is no Git information anymore.
+./mvnw -pl apm-sniffer/apm-agent-core initialize \
+       -DgenerateGitPropertiesFilename="$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/version.properties"
+
 cd ..
 # Build source code tar
 tar czf ${PRODUCT_NAME}-src.tgz \

--- a/tools/releasing/create_release.sh
+++ b/tools/releasing/create_release.sh
@@ -59,10 +59,10 @@ git checkout ${TAG_NAME}
 git submodule init
 git submodule update
 
-# Generate a static version.properties and override the template when releasing source tar
+# Generate a static skywalking-agent-version.properties and override the template when releasing source tar
 # because after that there is no Git information anymore.
 ./mvnw -pl apm-sniffer/apm-agent-core initialize \
-       -DgenerateGitPropertiesFilename="$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/version.properties"
+       -DgenerateGitPropertiesFilename="$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/skywalking-agent-version.properties"
 
 cd ..
 # Build source code tar

--- a/tools/releasing/create_release.sh
+++ b/tools/releasing/create_release.sh
@@ -62,9 +62,10 @@ git submodule update
 # Generate a static skywalking-agent-version.properties and override the template when releasing source tar
 # because after that there is no Git information anymore.
 GIT_PROPERTIES_PATH=$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/skywalking-agent-version.properties
-./mvnw -q -pl apm-sniffer/apm-agent-core initialize -DgenerateGitPropertiesFilename="${GIT_PROPERTIES_PATH}"
+./mvnw -q -pl apm-sniffer/apm-agent-core initialize -DgenerateGitPropertiesFilename="${GIT_PROPERTIES_PATH}.tmp"
 # Remove this line, because the `git.build.time` could not be overridden.
-sed '/git.build.time/d' ${GIT_PROPERTIES_PATH} > ${GIT_PROPERTIES_PATH}
+sed '/git.build.time/d' ${GIT_PROPERTIES_PATH}.tmp > ${GIT_PROPERTIES_PATH}
+rm -f ${GIT_PROPERTIES_PATH}.tmp
 
 cd ..
 # Build source code tar

--- a/tools/releasing/create_release.sh
+++ b/tools/releasing/create_release.sh
@@ -61,8 +61,10 @@ git submodule update
 
 # Generate a static skywalking-agent-version.properties and override the template when releasing source tar
 # because after that there is no Git information anymore.
-./mvnw -pl apm-sniffer/apm-agent-core initialize \
-       -DgenerateGitPropertiesFilename="$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/skywalking-agent-version.properties"
+GIT_PROPERTIES_PATH=$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/skywalking-agent-version.properties
+./mvnw -q -pl apm-sniffer/apm-agent-core initialize -DgenerateGitPropertiesFilename="${GIT_PROPERTIES_PATH}"
+# Remove this line, because the `git.build.time` could not be overridden.
+sed '/git.build.time/d' ${GIT_PROPERTIES_PATH} > ${GIT_PROPERTIES_PATH}
 
 cd ..
 # Build source code tar

--- a/tools/releasing/create_release.sh
+++ b/tools/releasing/create_release.sh
@@ -61,11 +61,8 @@ git submodule update
 
 # Generate a static skywalking-agent-version.properties and override the template when releasing source tar
 # because after that there is no Git information anymore.
-GIT_PROPERTIES_PATH=$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/skywalking-agent-version.properties
-./mvnw -q -pl apm-sniffer/apm-agent-core initialize -DgenerateGitPropertiesFilename="${GIT_PROPERTIES_PATH}.tmp"
-# Remove this line, because the `git.build.time` could not be overridden.
-sed '/git.build.time/d' ${GIT_PROPERTIES_PATH}.tmp > ${GIT_PROPERTIES_PATH}
-rm -f ${GIT_PROPERTIES_PATH}.tmp
+./mvnw -q -pl apm-sniffer/apm-agent-core initialize \
+       -DgenerateGitPropertiesFilename="$(pwd)/apm-sniffer/apm-agent-core/src/main/resources/skywalking-agent-version.properties"
 
 cd ..
 # Build source code tar


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

###  Report the agent version to OAP

Currently, the agent version used by all applications cannot be sensed, It is beneficial for agent developers to diagnose some problems, and help us find which applications haven't upgraded the agent. I use [git-commit-id-maven-plugin](https://github.com/git-commit-id/git-commit-id-maven-plugin) to generate the agent version, and report it to OAP when the agent starts.

The agent version is consist of three parts:
1. **build version**: the maven project version
2. **short commit id**: git commit short id
3. **date**: build date.

Here is the agent log from my local env with this feature:
```
INFO 2022-11-24 09:51:32.331 main InstanceJsonPropertiesUtil : SkyWalking agent version: 8.14.0-SNAPSHOT-add2bc4-221124
```
And the OAP server could show this agent version, too. What do you think of this feature? Any suggestions? @wu-sheng 
![image](https://user-images.githubusercontent.com/8198862/203692270-bdc95003-f8c8-4dde-9b92-2d4ef3ed5de0.png)


- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
