### PR TITLE
Fix flaky test caused by .toArray()

### DIFF
--- a/apm-commons/apm-util/src/test/java/org/apache/skywalking/apm/util/ConfigInitializerTest.java
+++ b/apm-commons/apm-util/src/test/java/org/apache/skywalking/apm/util/ConfigInitializerTest.java
@@ -67,8 +67,12 @@ public class ConfigInitializerTest {
         Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, TestPropertiesObject.Level1Object.LIST_INT_ATTR_ED2.toArray());
         Assert.assertArrayEquals(new String[]{}, TestPropertiesObject.Level1Object.SET_STR_EMPTY_ATTR.toArray());
         Assert.assertArrayEquals(new Boolean[]{true, false}, TestPropertiesObject.Level1Object.LIST_BOOL_ATTR.toArray());
-        Assert.assertArrayEquals(new String[]{"a", "b", "c", "d"}, TestPropertiesObject.Level1Object.SET_STR_ATTR.toArray());
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, TestPropertiesObject.Level1Object.SET_INT_ATTR.toArray());
+        Object[] setStrAttrArray = TestPropertiesObject.Level1Object.SET_STR_ATTR.toArray();
+        Arrays.sort(setStrAttrArray);
+        Assert.assertArrayEquals(new String[]{"a", "b", "c", "d"}, setStrAttrArray);
+        Object[] setIntAttrArray = TestPropertiesObject.Level1Object.SET_INT_ATTR.toArray();
+        Arrays.sort(setIntAttrArray);
+        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, setIntAttrArray);
         Assert.assertArrayEquals(new Boolean[]{true}, TestPropertiesObject.Level1Object.SET_BOOL_ATTR.toArray());
         Assert.assertEquals(TestColorEnum.RED, TestPropertiesObject.Level1Object.Level2Object.ENUM_ATTR);
         //make sure that when descs is empty,toString() work right;

--- a/apm-commons/apm-util/src/test/java/org/apache/skywalking/apm/util/ConfigInitializerTest.java
+++ b/apm-commons/apm-util/src/test/java/org/apache/skywalking/apm/util/ConfigInitializerTest.java
@@ -21,6 +21,7 @@ package org.apache.skywalking.apm.util;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.internal.util.collections.Sets;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -67,12 +68,8 @@ public class ConfigInitializerTest {
         Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, TestPropertiesObject.Level1Object.LIST_INT_ATTR_ED2.toArray());
         Assert.assertArrayEquals(new String[]{}, TestPropertiesObject.Level1Object.SET_STR_EMPTY_ATTR.toArray());
         Assert.assertArrayEquals(new Boolean[]{true, false}, TestPropertiesObject.Level1Object.LIST_BOOL_ATTR.toArray());
-        Object[] setStrAttrArray = TestPropertiesObject.Level1Object.SET_STR_ATTR.toArray();
-        Arrays.sort(setStrAttrArray);
-        Assert.assertArrayEquals(new String[]{"a", "b", "c", "d"}, setStrAttrArray);
-        Object[] setIntAttrArray = TestPropertiesObject.Level1Object.SET_INT_ATTR.toArray();
-        Arrays.sort(setIntAttrArray);
-        Assert.assertArrayEquals(new Integer[]{1, 2, 3, 4}, setIntAttrArray);
+        Assert.assertEquals(Sets.newSet("a", "b", "c", "d"), TestPropertiesObject.Level1Object.SET_STR_ATTR);
+        Assert.assertEquals(Sets.newSet(1, 2, 3, 4), TestPropertiesObject.Level1Object.SET_INT_ATTR);
         Assert.assertArrayEquals(new Boolean[]{true}, TestPropertiesObject.Level1Object.SET_BOOL_ATTR.toArray());
         Assert.assertEquals(TestColorEnum.RED, TestPropertiesObject.Level1Object.Level2Object.ENUM_ATTR);
         //make sure that when descs is empty,toString() work right;


### PR DESCRIPTION
## Description
Flaky Test found using [NonDex](https://github.com/TestingResearchIllinois/NonDex) by running the command -
`mvn -pl apm-commons/apm-util edu.illinois:nondex-maven-plugin:1.1.2:nondex  -Dtest=org.apache.skywalking.apm.util.ConfigInitializerTest#testInitialize`


The logged failure - 
```
[ERROR] Failures: 
[ERROR]   ConfigInitializerTest.testInitialize:70 arrays first differed at element [1]; expected:<[b]> but was:<[c]>

```

## Investigation
The test fails at `ConfigInitializerTest.testInitialize:70` with the error regarding a mismatch of elements of the expected array of Strings with the actual elements from the `TestPropertiesObject.Level1Object.SET_STR_ATTR.toArray()` on line 70. The SET_STR_ATTR is a SET and a set does not guarantee the order of its elements. According to the [documentation](https://docs.oracle.com/javase/8/docs/api/java/util/Set.html), the toArray() function follows the iterator's order and the iterator returns elements in no particular order (unless this set is an instance of some class that provides a guarantee). This makes the test outcome non-deterministic. To fix this, the actual array needs to be sorted so that it can guarantee the order of its elements. 
Similar fix is made for the line `ConfigInitializerTest.testInitialize:71` to remove the flakiness.

## Fix
Sorting the output returned by the toArray() function. This removes the non-determinism without needing any further changes and ensures that the flakiness of the test is removed.


- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
