### PR TITLE
Add tags `mq.message.keys` and `mq.message.tags` for RocketMQ producer span

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Release Notes.
 * Report the agent version to OAP as an instance attribute
 * Polish jedis-4.x-plugin to change command to lowercase, which is consistent with jedis-2.x-3.x-plugin
 * Add micronauthttpclient,micronauthttpserver,memcached,ehcache,guavacache,jedis,redisson plugin config properties to agent.config
+* Add tags `message.keys` and `message.tags` for RocketMQ producer span
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Release Notes.
 * Report the agent version to OAP as an instance attribute
 * Polish jedis-4.x-plugin to change command to lowercase, which is consistent with jedis-2.x-3.x-plugin
 * Add micronauthttpclient,micronauthttpserver,memcached,ehcache,guavacache,jedis,redisson plugin config properties to agent.config
-* Add tags `message.keys` and `message.tags` for RocketMQ producer span
+* Add tags `mq.message.keys` and `mq.message.tags` for RocketMQ producer span
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v3/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v3/MessageSendInterceptor.java
@@ -59,6 +59,9 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         span.setComponent(ComponentsDefine.ROCKET_MQ_PRODUCER);
         Tags.MQ_BROKER.set(span, (String) allArguments[0]);
         Tags.MQ_TOPIC.set(span, message.getTopic());
+        span.tag(Tags.ofKey("message.keys"), message.getKeys());
+        span.tag(Tags.ofKey("message.tags"), message.getTags());
+
         contextCarrier.extensionInjector().injectSendingTimestamp();
         SpanLayer.asMQ(span);
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v3/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v3/MessageSendInterceptor.java
@@ -61,11 +61,11 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         Tags.MQ_TOPIC.set(span, message.getTopic());
         String keys = message.getKeys();
         if (StringUtil.isNotBlank(keys)) {
-            span.tag(Tags.ofKey("message.keys"), keys);
+            span.tag(Tags.ofKey("mq.message.keys"), keys);
         }
         String tags = message.getTags();
         if (StringUtil.isNotBlank(tags)) {
-            span.tag(Tags.ofKey("message.tags"), tags);
+            span.tag(Tags.ofKey("mq.message.tags"), tags);
         }
 
         contextCarrier.extensionInjector().injectSendingTimestamp();

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v3/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v3/MessageSendInterceptor.java
@@ -59,8 +59,14 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         span.setComponent(ComponentsDefine.ROCKET_MQ_PRODUCER);
         Tags.MQ_BROKER.set(span, (String) allArguments[0]);
         Tags.MQ_TOPIC.set(span, message.getTopic());
-        span.tag(Tags.ofKey("message.keys"), message.getKeys());
-        span.tag(Tags.ofKey("message.tags"), message.getTags());
+        String keys = message.getKeys();
+        if (StringUtil.isNotBlank(keys)) {
+            span.tag(Tags.ofKey("message.keys"), keys);
+        }
+        String tags = message.getTags();
+        if (StringUtil.isNotBlank(tags)) {
+            span.tag(Tags.ofKey("message.tags"), tags);
+        }
 
         contextCarrier.extensionInjector().injectSendingTimestamp();
         SpanLayer.asMQ(span);

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rocketmq-client.version>4.3.1</rocketmq-client.version>
+        <rocketmq-client.version>4.1.0-incubating</rocketmq-client.version>
     </properties>
 
     <dependencies>

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rocketmq-client.version>4.1.0-incubating</rocketmq-client.version>
+        <rocketmq-client.version>4.3.1</rocketmq-client.version>
     </properties>
 
     <dependencies>

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
@@ -59,6 +59,9 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         span.setComponent(ComponentsDefine.ROCKET_MQ_PRODUCER);
         Tags.MQ_BROKER.set(span, (String) allArguments[0]);
         Tags.MQ_TOPIC.set(span, message.getTopic());
+        span.tag(Tags.ofKey("message.keys"), message.getKeys());
+        span.tag(Tags.ofKey("message.tags"), message.getTags());
+
         contextCarrier.extensionInjector().injectSendingTimestamp();
         SpanLayer.asMQ(span);
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
@@ -61,11 +61,11 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         Tags.MQ_TOPIC.set(span, message.getTopic());
         String keys = message.getKeys();
         if (StringUtil.isNotBlank(keys)) {
-            span.tag(Tags.ofKey("message.keys"), keys);
+            span.tag(Tags.ofKey("mq.message.keys"), keys);
         }
         String tags = message.getTags();
         if (StringUtil.isNotBlank(tags)) {
-            span.tag(Tags.ofKey("message.tags"), tags);
+            span.tag(Tags.ofKey("mq.message.tags"), tags);
         }
 
         contextCarrier.extensionInjector().injectSendingTimestamp();

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/rocketMQ/v4/MessageSendInterceptor.java
@@ -59,8 +59,14 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         span.setComponent(ComponentsDefine.ROCKET_MQ_PRODUCER);
         Tags.MQ_BROKER.set(span, (String) allArguments[0]);
         Tags.MQ_TOPIC.set(span, message.getTopic());
-        span.tag(Tags.ofKey("message.keys"), message.getKeys());
-        span.tag(Tags.ofKey("message.tags"), message.getTags());
+        String keys = message.getKeys();
+        if (StringUtil.isNotBlank(keys)) {
+            span.tag(Tags.ofKey("message.keys"), keys);
+        }
+        String tags = message.getTags();
+        if (StringUtil.isNotBlank(tags)) {
+            span.tag(Tags.ofKey("message.tags"), tags);
+        }
 
         contextCarrier.extensionInjector().injectSendingTimestamp();
         SpanLayer.asMQ(span);

--- a/test/plugin/scenarios/rocketmq-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/rocketmq-scenario/config/expectedData.yaml
@@ -32,8 +32,8 @@ segmentItems:
             tags:
               - {key: mq.broker, value: not null}
               - {key: mq.topic, value: TopicTest}
-              - {key: message.tags, value: TagA}
               - {key: message.keys, value: KeyA}
+              - {key: message.tags, value: TagA}
             skipAnalysis: 'false'
           - operationName: GET:/case/rocketmq-scenario
             parentSpanId: -1

--- a/test/plugin/scenarios/rocketmq-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/rocketmq-scenario/config/expectedData.yaml
@@ -32,8 +32,8 @@ segmentItems:
             tags:
               - {key: mq.broker, value: not null}
               - {key: mq.topic, value: TopicTest}
-              - {key: message.keys, value: KeyA}
-              - {key: message.tags, value: TagA}
+              - {key: mq.message.keys, value: KeyA}
+              - {key: mq.message.tags, value: TagA}
             skipAnalysis: 'false'
           - operationName: GET:/case/rocketmq-scenario
             parentSpanId: -1

--- a/test/plugin/scenarios/rocketmq-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/rocketmq-scenario/config/expectedData.yaml
@@ -32,6 +32,8 @@ segmentItems:
             tags:
               - {key: mq.broker, value: not null}
               - {key: mq.topic, value: TopicTest}
+              - {key: message.tags, value: TagA}
+              - {key: message.keys, value: KeyA}
             skipAnalysis: 'false'
           - operationName: GET:/case/rocketmq-scenario
             parentSpanId: -1

--- a/test/plugin/scenarios/rocketmq-scenario/pom.xml
+++ b/test/plugin/scenarios/rocketmq-scenario/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <compiler.version>1.8</compiler.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <test.framework.version>4.9.4</test.framework.version>
         <spring.boot.version>2.1.6.RELEASE</spring.boot.version>
         <lombok.version>1.18.20</lombok.version>
@@ -97,6 +98,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${compiler.version}</source>
                     <target>${compiler.version}</target>

--- a/test/plugin/scenarios/rocketmq-scenario/src/main/java/test/apache/skywalking/apm/testcase/rocketmq/controller/CaseController.java
+++ b/test/plugin/scenarios/rocketmq-scenario/src/main/java/test/apache/skywalking/apm/testcase/rocketmq/controller/CaseController.java
@@ -60,6 +60,7 @@ public class CaseController {
             // send msg
             Message msg = new Message("TopicTest",
                     "TagA",
+                    "KeyA",
                     ("Hello RocketMQ sendMsg " + new Date()).getBytes(RemotingHelper.DEFAULT_CHARSET)
             );
             SendResult sendResult = producer.send(msg);

--- a/test/plugin/scenarios/rocketmq-scenario/src/main/java/test/apache/skywalking/apm/testcase/rocketmq/controller/CaseController.java
+++ b/test/plugin/scenarios/rocketmq-scenario/src/main/java/test/apache/skywalking/apm/testcase/rocketmq/controller/CaseController.java
@@ -59,10 +59,10 @@ public class CaseController {
 
             // send msg
             Message msg = new Message("TopicTest",
-                    "TagA",
-                    "KeyA",
                     ("Hello RocketMQ sendMsg " + new Date()).getBytes(RemotingHelper.DEFAULT_CHARSET)
             );
+            msg.setTags("TagA");
+            msg.setKeys("KeyA");
             SendResult sendResult = producer.send(msg);
             System.out.printf("%s send msg: %s%n", new Date(), sendResult);
             

--- a/test/plugin/scenarios/rocketmq-scenario/src/main/java/test/apache/skywalking/apm/testcase/rocketmq/controller/CaseController.java
+++ b/test/plugin/scenarios/rocketmq-scenario/src/main/java/test/apache/skywalking/apm/testcase/rocketmq/controller/CaseController.java
@@ -103,14 +103,6 @@ public class CaseController {
         producer.setNamesrvAddr(namerServer);
         producer.start();
         System.out.printf("HealthCheck Provider Started.%n");
-
-        // send msg
-        Message msg = new Message("HealthCheckTopicTest",
-                "TagA",
-                ("Hello RocketMQ sendMsg " + new Date()).getBytes(RemotingHelper.DEFAULT_CHARSET)
-        );
-        SendResult sendResult = producer.send(msg);
-        System.out.printf("healthCheck %s send msg: %s%n", new Date(), sendResult);
         return SUCCESS;
     }
 


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

RocketMQ message has `tags` and `keys` concept. 
See https://rocketmq.apache.org/docs/4.x/producer/04concept1#message

* Add span tag `message.tags` to help developers identify messages.
* Add span tag `message.keys` to help developers search messages by key in the RocketMQ console.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
