### PR TITLE
[fix] In the higher version of mysql-connector-java 8x, there is an error in the value of db.instance.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 * Add [Micrometer Observation](https://github.com/micrometer-metrics/micrometer/) support
 * Add tags `mq.message.keys` and `mq.message.tags` for RocketMQ producer span
 * Clean the trace context which injected into Pulsar MessageImpl after the instance recycled
+* Fix In the higher version of mysql-connector-java 8x, there is an error in the value of db.instance.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v8/define/ConnectionInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v8/define/ConnectionInstrumentation.java
@@ -119,6 +119,22 @@ public class ConnectionInstrumentation extends AbstractMysqlInstrumentation {
                 public boolean isOverrideArgs() {
                     return false;
                 }
+            },
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("setDatabase");
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return org.apache.skywalking.apm.plugin.jdbc.mysql.Constants.SET_CATALOG_INTERCEPTOR;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
             }
         };
 


### PR DESCRIPTION
Starting from MySQL 8.0.20, the `databaseTerm` feature allows you to use the `setCatalog` and `setSchema` methods to switch databases

The code is from 8.0.20 `ConnectionImpl`
![image](https://user-images.githubusercontent.com/13183021/209071012-579acaa3-ee59-4d9d-bc62-0f9536d49590.png)

![image](https://user-images.githubusercontent.com/13183021/209071109-e8b50718-b0a1-4501-8393-6a6ee5bf6f4e.png)

- [ ]  In the higher version of `mysql-connector-java`8x, there is an error in the value of db.instance.
