### PR TITLE
Fix a step in trace-ignore-plugin doc

### DIFF
--- a/docs/en/setup/service-agent/java-agent/agent-optional-plugins/trace-ignore-plugin.md
+++ b/docs/en/setup/service-agent/java-agent/agent-optional-plugins/trace-ignore-plugin.md
@@ -13,7 +13,7 @@ Sampling still works when the trace ignores plug-in activation.
 ## How to configure
 There are two ways to configure ignore patterns. Settings through system env has higher priority.
  1. Set through the system environment variable,you need to add `skywalking.trace.ignore_path` to the system variables, the value is the path that you need to ignore, multiple paths should be separated by `,`
- 2. Copy`/agent/optional-plugins/apm-trace-ignore-plugin/apm-trace-ignore-plugin.config` to `/agent/config/` dir, and add rules to filter traces
+ 2. Create file named as `apm-trace-ignore-plugin.config` in `/agent/config/` dir, and add rules to filter traces
 ```
 trace.ignore_path=/your/path/1/**,/your/path/2/**
 ```


### PR DESCRIPTION
Doc outdated, File `/agent/optional-plugins/apm-trace-ignore-plugin/apm-trace-ignore-plugin.config` not exist anymore, But still reference it in this doc.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
