### PR TITLE
Fix oracle url parser ignoring actual port

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Release Notes.
 * Refactor pipeline in jedis-plugin.
 * Enhance kotlin coroutine plugin for stack tracing.
 * Add plugin to support ClickHouse JDBC driver (0.3.2.*).
+* Fix OracleURLParser ignoring actual port when :SID is absent.
 
 #### Documentation
 * Update docs of Tracing APIs, reorganize the API docs into six parts.

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/OracleURLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/OracleURLParser.java
@@ -27,8 +27,8 @@ import org.apache.skywalking.apm.util.StringUtil;
 /**
  * {@link OracleURLParser} presents that how to parse oracle connection url.
  * <p>
- * Note: {@link OracleURLParser} can parse the commons connection url. the commons connection url is of the form:
- * <code>jdbc:oracle:(drivertype):@(database)</code>,the other the form of connection url cannot be parsed success.
+ * Note: {@link OracleURLParser} can parse the commons/TNS connection url. the commons connection url is of the form:
+ * <code>jdbc:oracle:(drivertype):@(database)</code>, the other the form of connection url cannot be parsed successfully.
  */
 public class OracleURLParser extends AbstractURLParser {
 
@@ -49,7 +49,14 @@ public class OracleURLParser extends AbstractURLParser {
         } else {
             hostLabelStartIndex = url.indexOf("@") + 1;
         }
-        int hostLabelEndIndex = url.lastIndexOf(":");
+
+        String urlTrimmed = url.substring(hostLabelStartIndex);
+
+        // When /service/<property> exists, check the first slash in trimmed url
+        // otherwise use the last colon to locate the port number
+        int hostLabelEndIndex = urlTrimmed.contains("/") ?
+                hostLabelStartIndex + urlTrimmed.indexOf("/") : url.lastIndexOf(":");
+
         return new URLLocation(hostLabelStartIndex, hostLabelEndIndex);
     }
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
@@ -99,10 +99,10 @@ public class URLParserTest {
 
     @Test
     public void testParseOracleServiceName() {
-        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:oracle:thin:@//localhost:1521/orcl");
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:oracle:thin:@//localhost:1531/orcl");
         assertThat(connectionInfo.getDBType(), is("Oracle"));
         assertThat(connectionInfo.getDatabaseName(), is("orcl"));
-        assertThat(connectionInfo.getDatabasePeer(), is("localhost:1521"));
+        assertThat(connectionInfo.getDatabasePeer(), is("localhost:1531"));
     }
 
     @Test


### PR DESCRIPTION
According to a user report from QQ group, when SID is not given instead of /service</anything>, the parser ignores the provided port. Previous test was flawed.
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
