### PR TITLE
Fix gRPC plugin not working for server side in some case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 * Add plugin to support ClickHouse JDBC driver (0.3.2.*).
 * Refactor kotlin coroutine plugin with CoroutineContext.
 * Fix OracleURLParser ignoring actual port when :SID is absent.
+* Change gRPC instrumentation point to fix plugin not working for server side.
 
 #### Documentation
 * Update docs of Tracing APIs, reorganize the API docs into six parts.

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/define/AbstractServerImplBuilderInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/define/AbstractServerImplBuilderInstrumentation.java
@@ -26,15 +26,14 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInst
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static org.apache.skywalking.apm.agent.core.plugin.bytebuddy.ArgumentTypeNameMatch.takesArgumentWithType;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
 
 public class AbstractServerImplBuilderInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
 
     public static final String ENHANCE_CLASS = "io.grpc.internal.AbstractServerImplBuilder";
-    public static final String ENHANCE_METHOD = "addService";
+    public static final String ENHANCE_METHOD = "build";
     public static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.grpc.v1.server.AbstractServerImplBuilderInterceptor";
-    public static final String ARGUMENT_TYPE = "io.grpc.ServerServiceDefinition";
 
     @Override
     public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
@@ -47,7 +46,7 @@ public class AbstractServerImplBuilderInstrumentation extends ClassInstanceMetho
             new InstanceMethodsInterceptPoint() {
                 @Override
                 public ElementMatcher<MethodDescription> getMethodsMatcher() {
-                    return named(ENHANCE_METHOD).and(takesArgumentWithType(0, ARGUMENT_TYPE));
+                    return named(ENHANCE_METHOD).and(takesNoArguments());
                 }
 
                 @Override

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/AbstractServerImplBuilderInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/AbstractServerImplBuilderInterceptor.java
@@ -18,8 +18,7 @@
 
 package org.apache.skywalking.apm.plugin.grpc.v1.server;
 
-import io.grpc.ServerInterceptors;
-import io.grpc.ServerServiceDefinition;
+import io.grpc.ServerBuilder;
 
 import java.lang.reflect.Method;
 
@@ -34,7 +33,12 @@ public class AbstractServerImplBuilderInterceptor implements InstanceMethodsArou
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
         MethodInterceptResult result) {
-        allArguments[0] = ServerInterceptors.intercept((ServerServiceDefinition) allArguments[0], new ServerInterceptor());
+        if (objInst.getSkyWalkingDynamicField() == null) {
+            ServerBuilder<?> builder = (ServerBuilder) objInst;
+            ServerInterceptor interceptor = new ServerInterceptor();
+            builder.intercept(interceptor);
+            objInst.setSkyWalkingDynamicField(interceptor);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/ServerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/ServerInterceptor.java
@@ -32,6 +32,8 @@ import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.util.StringUtil;
 
+import static org.apache.skywalking.apm.plugin.grpc.v1.OperationNameFormatUtil.formatOperationName;
+
 public class ServerInterceptor implements io.grpc.ServerInterceptor {
 
     static final Context.Key<ContextSnapshot> CONTEXT_SNAPSHOT_KEY = Context.key("skywalking-grpc-context-snapshot");
@@ -51,7 +53,7 @@ public class ServerInterceptor implements io.grpc.ServerInterceptor {
         }
 
         final AbstractSpan span = ContextManager
-                .createEntrySpan(call.getMethodDescriptor().getFullMethodName(), contextCarrier);
+                .createEntrySpan(formatOperationName(call.getMethodDescriptor()), contextCarrier);
         span.setComponent(ComponentsDefine.GRPC);
         span.setLayer(SpanLayer.RPC_FRAMEWORK);
         ContextSnapshot contextSnapshot = ContextManager.capture();

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/ServerInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/ServerInterceptor.java
@@ -18,14 +18,25 @@
 
 package org.apache.skywalking.apm.plugin.grpc.v1.server;
 
+import io.grpc.Context;
+import io.grpc.Contexts;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import org.apache.skywalking.apm.agent.core.context.CarrierItem;
 import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.util.StringUtil;
 
 public class ServerInterceptor implements io.grpc.ServerInterceptor {
+
+    static final Context.Key<ContextSnapshot> CONTEXT_SNAPSHOT_KEY = Context.key("skywalking-grpc-context-snapshot");
+    static final Context.Key<AbstractSpan> ACTIVE_SPAN_KEY = Context.key("skywalking-grpc-active-span");
+
     @Override
     public <REQUEST, RESPONSE> ServerCall.Listener<REQUEST> interceptCall(ServerCall<REQUEST, RESPONSE> call,
         Metadata headers, ServerCallHandler<REQUEST, RESPONSE> handler) {
@@ -38,7 +49,26 @@ public class ServerInterceptor implements io.grpc.ServerInterceptor {
                 next.setHeadValue(contextValue);
             }
         }
-        return new TracingServerCallListener<>(handler.startCall(new TracingServerCall<>(call), headers), call
-                .getMethodDescriptor(), contextCarrier);
+
+        final AbstractSpan span = ContextManager
+                .createEntrySpan(call.getMethodDescriptor().getFullMethodName(), contextCarrier);
+        span.setComponent(ComponentsDefine.GRPC);
+        span.setLayer(SpanLayer.RPC_FRAMEWORK);
+        ContextSnapshot contextSnapshot = ContextManager.capture();
+        AbstractSpan asyncSpan = span.prepareForAsync();
+
+        Context context = Context.current().withValues(CONTEXT_SNAPSHOT_KEY, contextSnapshot, ACTIVE_SPAN_KEY, asyncSpan);
+
+        ServerCall.Listener<REQUEST> listener = Contexts.interceptCall(
+                context,
+                new TracingServerCall<>(call),
+                headers,
+                (serverCall, metadata) -> new TracingServerCallListener<>(
+                        handler.startCall(serverCall, metadata),
+                        serverCall.getMethodDescriptor()
+                )
+        );
+        ContextManager.stopSpan(asyncSpan);
+        return listener;
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/TracingServerCall.java
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/grpc/v1/server/TracingServerCall.java
@@ -49,7 +49,7 @@ public class TracingServerCall<REQUEST, RESPONSE> extends ForwardingServerCall.S
             final AbstractSpan span = ContextManager.createLocalSpan(operationPrefix + RESPONSE_ON_MESSAGE_OPERATION_NAME);
             span.setComponent(ComponentsDefine.GRPC);
             span.setLayer(SpanLayer.RPC_FRAMEWORK);
-
+            ContextManager.continued(ServerInterceptor.CONTEXT_SNAPSHOT_KEY.get());
             try {
                 super.sendMessage(message);
             } catch (Throwable t) {
@@ -68,6 +68,7 @@ public class TracingServerCall<REQUEST, RESPONSE> extends ForwardingServerCall.S
         final AbstractSpan span = ContextManager.createLocalSpan(operationPrefix + RESPONSE_ON_CLOSE_OPERATION_NAME);
         span.setComponent(ComponentsDefine.GRPC);
         span.setLayer(SpanLayer.RPC_FRAMEWORK);
+        ContextManager.continued(ServerInterceptor.CONTEXT_SNAPSHOT_KEY.get());
         switch (status.getCode()) {
             case OK:
                 break;
@@ -93,6 +94,7 @@ public class TracingServerCall<REQUEST, RESPONSE> extends ForwardingServerCall.S
                 break;
         }
         Tags.RPC_RESPONSE_STATUS_CODE.set(span, status.getCode().name());
+        ServerInterceptor.ACTIVE_SPAN_KEY.get().asyncFinish();
 
         try {
             super.close(status, trailers);


### PR DESCRIPTION
# What's Changed?
1. Modify the Instrumentation point to the `build` function for server builder, it can make sure the tracing interceptor has been added as latest interceptor which been called as first one, and fix the server interceptor not working with fallbackHandler or BindableService.
2. Change the span creating timing from call ready to new call and store the snapshot to call context, it will make the spans created during the entire call process be associated

# TODO
- [x] Fix the test