### PR TITLE
Fix clickhouse0.3.2 plugin executeBatch method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 * Fix servicecomb plugin trace break.
 * Adapt Armeria's plugins to the latest version 1.22.x
 * Fix tomcat-10x-plugin and add test case to support tomcat7.x-8.x-9.x.
+* Fix clickhouse0.3.2 plugin executeBatch method
 
 #### Documentation
 * Update docs of Tracing APIs, reorganize the API docs into six parts.

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/v32/SWClickHousePreparedStatement.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/v32/SWClickHousePreparedStatement.java
@@ -273,7 +273,7 @@ public class SWClickHousePreparedStatement implements PreparedStatement {
 
     @Override
     public int[] executeBatch() throws SQLException {
-        return PreparedStatementTracing.execute(realStatement, connectInfo, "executeBatch", "", new PreparedStatementTracing.Executable<int[]>() {
+        return PreparedStatementTracing.execute(realStatement, connectInfo, "executeBatch", sql, new PreparedStatementTracing.Executable<int[]>() {
             @Override
             public int[] exe(PreparedStatement realStatement, String sql) throws SQLException {
                 return realStatement.executeBatch();

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/SWClickHousePreparedStatementTest.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/SWClickHousePreparedStatementTest.java
@@ -502,7 +502,7 @@ public class SWClickHousePreparedStatementTest extends AbstractStatementTest {
         TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
         List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
         assertThat(spans.size(), is(1));
-        assertDBSpan(spans.get(0), "ClickHouse/JDBC/PreparedStatement/executeBatch", "");
+        assertDBSpan(spans.get(0), "ClickHouse/JDBC/PreparedStatement/executeBatch", "UPDATE test SET a = ? WHERE b = ?");
 
     }
 


### PR DESCRIPTION
The executeBatch method of the current plugin does not record sql