### PR TITLE
support mysql when useServerPrepStmts

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v5/define/PreparedStatementInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v5/define/PreparedStatementInstrumentation.java
@@ -19,11 +19,11 @@
 package org.apache.skywalking.apm.plugin.jdbc.mysql.v5.define;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
 
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.MultiClassNameMatch;
 import org.apache.skywalking.apm.plugin.jdbc.mysql.Constants;
 
 import net.bytebuddy.description.method.MethodDescription;
@@ -38,6 +38,7 @@ public class PreparedStatementInstrumentation extends AbstractMysqlInstrumentati
 
     private static final String SERVICE_METHOD_INTERCEPTOR = Constants.PREPARED_STATEMENT_EXECUTE_METHODS_INTERCEPTOR;
     public static final String MYSQL_PREPARED_STATEMENT_CLASS_NAME = "com.mysql.jdbc.PreparedStatement";
+    public static final String MYSQL_SERVER_PREPARED_STATEMENT_CLASS_NAME = "com.mysql.jdbc.ServerPreparedStatement";
 
     @Override
     public final ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
@@ -70,7 +71,7 @@ public class PreparedStatementInstrumentation extends AbstractMysqlInstrumentati
 
     @Override
     protected ClassMatch enhanceClass() {
-        return byName(MYSQL_PREPARED_STATEMENT_CLASS_NAME);
+        return MultiClassNameMatch.byMultiClassMatch(MYSQL_PREPARED_STATEMENT_CLASS_NAME, MYSQL_SERVER_PREPARED_STATEMENT_CLASS_NAME);
     }
 
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v6/define/PreparedStatementInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/v6/define/PreparedStatementInstrumentation.java
@@ -23,9 +23,9 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.MultiClassNameMatch;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
 
 /**
  * {@link PreparedStatementInstrumentation} define that the mysql-6.x plugin intercepts the following methods in the
@@ -36,6 +36,7 @@ public class PreparedStatementInstrumentation extends AbstractMysqlInstrumentati
 
     private static final String SERVICE_METHOD_INTERCEPTOR = org.apache.skywalking.apm.plugin.jdbc.mysql.Constants.PREPARED_STATEMENT_EXECUTE_METHODS_INTERCEPTOR;
     public static final String MYSQL6_PREPARED_STATEMENT_CLASS_NAME = "com.mysql.cj.jdbc.PreparedStatement";
+    public static final String MYSQL6_SERVER_PREPARED_STATEMENT_CLASS_NAME = "com.mysql.cj.jdbc.ServerPreparedStatement";
 
     @Override
     public final ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
@@ -68,7 +69,7 @@ public class PreparedStatementInstrumentation extends AbstractMysqlInstrumentati
 
     @Override
     protected ClassMatch enhanceClass() {
-        return byName(MYSQL6_PREPARED_STATEMENT_CLASS_NAME);
+        return MultiClassNameMatch.byMultiClassMatch(MYSQL6_PREPARED_STATEMENT_CLASS_NAME, MYSQL6_SERVER_PREPARED_STATEMENT_CLASS_NAME);
     }
 
 }

--- a/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/mysql-scenario/config/expectedData.yaml
@@ -44,6 +44,7 @@ segmentItems:
       - {key: db.type, value: Mysql}
       - {key: db.instance, value: test}
       - {key: db.statement, value: 'INSERT INTO test_007(id, value) VALUES(?,?)'}
+      - {key: db.sql.parameters, value: '[1,1]'}
       logs: []
       startTime: nq 0
       endTime: nq 0
@@ -107,6 +108,7 @@ segmentItems:
         - {key: db.type, value: Mysql}
         - {key: db.instance, value: test}
         - {key: db.statement, value: "call testProcedure( ? )"}
+        - {key: db.sql.parameters, value: '[nihao]'}
       logs: []
       startTime: nq 0
       endTime: nq 0

--- a/test/plugin/scenarios/mysql-scenario/configuration.yml
+++ b/test/plugin/scenarios/mysql-scenario/configuration.yml
@@ -30,3 +30,4 @@ dependencies:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=test
+      - SW_JDBC_TRACE_SQL_PARAMETERS=true

--- a/test/plugin/scenarios/mysql-scenario/configuration.yml
+++ b/test/plugin/scenarios/mysql-scenario/configuration.yml
@@ -19,6 +19,7 @@ entryService: http://localhost:8080/mysql-scenario/case/mysql-scenario
 healthCheck: http://localhost:8080/mysql-scenario/case/healthCheck
 startScript: ./bin/startup.sh
 environment:
+  - SW_JDBC_TRACE_SQL_PARAMETERS=true
 depends_on:
   - mysql-server
 dependencies:
@@ -30,4 +31,4 @@ dependencies:
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=test
-      - SW_JDBC_TRACE_SQL_PARAMETERS=true
+

--- a/test/plugin/scenarios/mysql-scenario/src/main/resources/jdbc.properties
+++ b/test/plugin/scenarios/mysql-scenario/src/main/resources/jdbc.properties
@@ -13,6 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-mysql.url=jdbc:mysql://mysql-server:3306/test?serverTimezone=CST&enabledTLSProtocols=TLSv1.2&useSSL=false
+mysql.url=jdbc:mysql://mysql-server:3306/test?serverTimezone=CST&enabledTLSProtocols=TLSv1.2&useSSL=false&useServerPrepStmts=true
 mysql.username=root
 mysql.password=root


### PR DESCRIPTION
### <support mysql trace sql param when useServerPrepStmts>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<10589>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
