### PR TITLE
Fix the profiling segment count not correct bug

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/profile/ProfileStatusContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/profile/ProfileStatusContext.java
@@ -31,11 +31,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ProfileStatusContext {
 
     private volatile ProfileStatus status;
+    private volatile boolean fromFirstSegment;
     private volatile long firstSegmentCreateTime;
     private volatile AtomicInteger subThreadProfilingCount;
 
     private ProfileStatusContext(ProfileStatus status, long firstSegmentCreateTime, AtomicInteger subThreadProfilingCount) {
         this.status = status;
+        this.fromFirstSegment = true;
         this.firstSegmentCreateTime = firstSegmentCreateTime;
         this.subThreadProfilingCount = subThreadProfilingCount;
     }
@@ -62,6 +64,10 @@ public class ProfileStatusContext {
         return this.firstSegmentCreateTime;
     }
 
+    public boolean isFromFirstSegment() {
+        return fromFirstSegment;
+    }
+
     /**
      * The profile monitoring is watching, wait for some profile conditions.
      */
@@ -83,6 +89,7 @@ public class ProfileStatusContext {
      */
     public boolean continued(ContextSnapshot snapshot) {
         this.status = snapshot.getProfileStatusContext().get();
+        this.fromFirstSegment = false;
         this.firstSegmentCreateTime = snapshot.getProfileStatusContext().firstSegmentCreateTime();
         this.subThreadProfilingCount = snapshot.getProfileStatusContext().subThreadProfilingCount;
         return this.isBeingWatched() &&

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/profile/ProfileTaskExecutionContext.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/profile/ProfileTaskExecutionContext.java
@@ -131,7 +131,7 @@ public class ProfileTaskExecutionContext {
 
         // update profiling status
         tracingContext.profileStatus()
-                      .updateStatus(attemptProfiling(tracingContext, traceSegmentId, firstSpanOPName));
+            .updateStatus(attemptProfiling(tracingContext, traceSegmentId, firstSpanOPName));
     }
 
     /**
@@ -147,7 +147,9 @@ public class ProfileTaskExecutionContext {
 
                 // setting stop running
                 currentProfiler.stopProfiling();
-                currentEndpointProfilingCount.addAndGet(-1);
+                if (currentProfiler.profilingStatus().isFromFirstSegment()) {
+                    currentEndpointProfilingCount.addAndGet(-1);
+                }
                 break;
             }
         }


### PR DESCRIPTION
While performing Trace Profiling, the child threads (Segments) also experience Profiling termination. Consequently, this leads to an update in the `currentEndpointProfilingCount` when the child threads are terminated, ultimately impacting the validation of the overall task Segment count.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
