### PR TITLE
Update the endpoint name format of the `Undertow`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Release Notes.
 * Fix unexpected whitespace of the command catalogs in several Redis plugins.
 * Fix a thread leak in `SamplingService` when updated sampling policy in the runtime.
 * Support MySQL plugin tracing SQL parameters when useServerPrepStmts 
+* Update the endpoint name of `Undertow` plugin to `Method:Path`.
 
 #### Documentation
 * Update docs of Tracing APIs, reorganize the API docs into six parts.

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/v2x/handler/TracingHandler.java
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/v2x/handler/TracingHandler.java
@@ -59,7 +59,7 @@ public class TracingHandler implements HttpHandler {
         } else {
             operationName = template;
         }
-        final AbstractSpan span = ContextManager.createEntrySpan(operationName, carrier);
+        final AbstractSpan span = ContextManager.createEntrySpan(exchange.getRequestMethod() + ":" + operationName, carrier);
         Tags.URL.set(span, exchange.getRequestURL());
         Tags.HTTP.METHOD.set(span, exchange.getRequestMethod().toString());
         span.setComponent(ComponentsDefine.UNDERTOW);

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/undertow/v2x/RoutingHandlerInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/undertow/v2x/RoutingHandlerInterceptorTest.java
@@ -75,6 +75,7 @@ public class RoutingHandlerInterceptorTest {
     private EnhancedInstance enhancedInstance;
     private String template = "/projects/{projectId}/users";
     private String uri = "/projects/{projectId}/users";
+    private String endpoint = "GET:/projects/{projectId}/users";
 
     @Before
     public void setUp() throws Exception {
@@ -134,7 +135,7 @@ public class RoutingHandlerInterceptorTest {
     }
 
     private void assertHttpSpan(AbstractTracingSpan span) {
-        assertThat(span.getOperationName(), is(template));
+        assertThat(span.getOperationName(), is(endpoint));
         assertComponent(span, ComponentsDefine.UNDERTOW);
         SpanAssert.assertTag(span, 0, "http://localhost:8080" + uri);
         assertThat(span.isEntry(), is(true));

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/undertow/v2x/TracingHandlerTest.java
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/undertow/v2x/TracingHandlerTest.java
@@ -68,6 +68,7 @@ public class TracingHandlerTest {
 
     private String template = "/projects/{projectId}/users";
     private String uri = "/projects/{projectId}/users";
+    private String endpoint = "GET:/projects/{projectId}/users";
 
     @Test
     public void testStatusCodeIsOk() throws Throwable {
@@ -125,7 +126,7 @@ public class TracingHandlerTest {
     }
 
     private void assertHttpSpan(AbstractTracingSpan span) {
-        assertThat(span.getOperationName(), is(template));
+        assertThat(span.getOperationName(), is(endpoint));
         assertComponent(span, ComponentsDefine.UNDERTOW);
         SpanAssert.assertTag(span, 0, "http://localhost:8080" + uri);
         assertThat(span.isEntry(), is(true));

--- a/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/undertow-scenario/config/expectedData.yaml
@@ -19,7 +19,7 @@ segmentItems:
   segments:
   - segmentId: not null
     spans:
-    - operationName: /undertow-scenario/case/undertow
+    - operationName: GET:/undertow-scenario/case/undertow
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -36,7 +36,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /undertow-routing-scenario/case/{context}
+    - operationName: GET:/undertow-routing-scenario/case/{context}
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -57,7 +57,7 @@ segmentItems:
       skipAnalysis: 'false'
   - segmentId: not null
     spans:
-    - operationName: /undertow-scenario/case/undertow1
+    - operationName: GET:/undertow-scenario/case/undertow1
       parentSpanId: -1
       spanId: 0
       spanLayer: Http
@@ -104,7 +104,7 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: /undertow-scenario/case/undertow, networkAddress: '', refType: CrossThread,
+      - {parentEndpoint: GET:/undertow-scenario/case/undertow, networkAddress: '', refType: CrossThread,
         parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: not null, traceId: not null}
       skipAnalysis: 'false'
@@ -136,7 +136,7 @@ segmentItems:
       spanType: Local
       peer: ''
       refs:
-      - {parentEndpoint: '/undertow-routing-scenario/case/{context}', networkAddress: '',
+      - {parentEndpoint: 'GET:/undertow-routing-scenario/case/{context}', networkAddress: '',
         refType: CrossThread, parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
           null, parentService: undertow-scenario, traceId: not null}
       skipAnalysis: 'false'


### PR DESCRIPTION
Fix the entry endpoint name in the `Undertow` as different from other web containers.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
