### PR TITLE
Chore: fix exclusion rules in maven-shade-plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Release Notes.
 * Support monitor jetty server work thread pool metric
 * Support Jersey REST framework
 * Fix ClassCastException when SQLServer inserts data 
+* [Chore] Fix org.checkerframework exclusion in maven-shade-plugin
 
 #### Documentation
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@ Release Notes.
 * Support monitor jetty server work thread pool metric
 * Support Jersey REST framework
 * Fix ClassCastException when SQLServer inserts data 
-* [Chore] Fix org.checkerframework exclusion in maven-shade-plugin
+* [Chore] Exclude org.checkerframework:checker-qual and com.google.j2objc:j2objc-annotations
+* [Chore] Exclude proto files in the generated jar
 
 #### Documentation
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -214,6 +214,7 @@
                                     <exclude>com.google.android:annotations:jar:</exclude>
                                     <exclude>com.google.api.grpc:proto-google-common-protos:jar:</exclude>
                                     <exclude>org.checkerframework:checker-compat-qual:jar:</exclude>
+                                    <exclude>org.checkerframework:checker-qual:jar:</exclude>
                                     <exclude>org.codehaus.mojo:animal-sniffer-annotations:jar:</exclude>
                                 </excludes>
                             </artifactSet>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -212,6 +212,7 @@
                                     <exclude>com.google.errorprone:error_prone_annotations:jar:</exclude>
                                     <exclude>com.google.code.findbugs:jsr305:jar:</exclude>
                                     <exclude>com.google.android:annotations:jar:</exclude>
+                                    <exclude>com.google.j2objc:j2objc-annotations:jar:</exclude>
                                     <exclude>com.google.api.grpc:proto-google-common-protos:jar:</exclude>
                                     <exclude>org.checkerframework:checker-compat-qual:jar:</exclude>
                                     <exclude>org.checkerframework:checker-qual:jar:</exclude>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -83,6 +83,7 @@
                                     <exclude>com.google.*:*</exclude>
                                     <exclude>com.google.guava:guava</exclude>
                                     <exclude>org.checkerframework:checker-compat-qual</exclude>
+                                    <exclude>org.checkerframework:checker-qual</exclude>
                                     <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
                                     <exclude>io.perfmark:*</exclude>
                                     <exclude>org.slf4j:*</exclude>
@@ -99,6 +100,12 @@
                                     <artifact>net.bytebuddy:byte-buddy</artifact>
                                     <excludes>
                                         <exclude>META-INF/versions/9/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>**/*.proto</exclude>
                                     </excludes>
                                 </filter>
                             </filters>


### PR DESCRIPTION
This PR fixes breaking exclusion rules for `org.checkerframework:checker-qual` and `com.google.j2objc:j2objc-annotations` which should have done excluded in the generated jar.

Besides, all proto files are excluded.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

Current folder structure:

![image](https://user-images.githubusercontent.com/2568208/236726950-065b1701-eafd-46d2-ba0e-dafe6aa6e2b9.png)
