### PR TITLE
Fix the apm-jdk-threadpool-plugin does not work in certain scenarios

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/FileWriter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/FileWriter.java
@@ -97,7 +97,6 @@ public class FileWriter implements IWriter {
             public void handle(Throwable t) {
             }
         }), "SkywalkingAgent-LogFileWriter");
-        logFlusherThread.setDaemon(true);
         logFlusherThread.start();
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/FileWriter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/FileWriter.java
@@ -18,6 +18,10 @@
 
 package org.apache.skywalking.apm.agent.core.logging.core;
 
+import org.apache.skywalking.apm.agent.core.conf.Config;
+import org.apache.skywalking.apm.agent.core.conf.Constants;
+import org.apache.skywalking.apm.util.RunnableWithExceptionProtection;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -30,13 +34,8 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import org.apache.skywalking.apm.agent.core.boot.DefaultNamedThreadFactory;
-import org.apache.skywalking.apm.agent.core.conf.Config;
-import org.apache.skywalking.apm.agent.core.conf.Constants;
-import org.apache.skywalking.apm.util.RunnableWithExceptionProtection;
 
 /**
  * The <code>FileWriter</code> support async file output, by using a queue as buffer.


### PR DESCRIPTION
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [ ] Closes #10925.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

**why the bug exists:**
apm-jdk-threadpool-plugin does not work when instrumented target had been loaded and used in the FileWriter(kernel) before the instrumentation.

**how to fix it**
The solution is to remove the dependency on ThreadPoolExecutor in the FileWriter and use a simple Thread and a Loop to make this work.