### PR TITLE
Add support for RESTEasy 6.x

### DIFF
--- a/.github/workflows/plugins-jdk17-test.1.yaml
+++ b/.github/workflows/plugins-jdk17-test.1.yaml
@@ -56,6 +56,7 @@ jobs:
       matrix:
         case:
           - spring-6.x-scenario
+          - resteasy-6.x-scenario
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -148,6 +148,7 @@ Callable {
 * Upgrade netty-codec-http2 to 4.1.94.Final
 * Upgrade guava to 32.0.1
 * Fix issue with duplicate enhancement by ThreadPoolExecutor
+* Add plugin to support for RESTeasy 6.x.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
@@ -29,9 +29,9 @@
     <packaging>jar</packaging>
 
     <name>apm-resteasy-server-6.x-plugin</name>
-    <url>http://maven.apache.org</url>
 
     <properties>
+        <compiler.version>11</compiler.version>
         <resteasy.version>6.2.4.Final</resteasy.version>
     </properties>
 

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
@@ -31,7 +31,6 @@
     <name>apm-resteasy-server-6.x-plugin</name>
 
     <properties>
-        <compiler.version>11</compiler.version>
         <resteasy.version>6.2.4.Final</resteasy.version>
     </properties>
 

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
@@ -16,28 +16,31 @@
   ~ limitations under the License.
   ~
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
+        <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <artifactId>apm-sdk-plugin</artifactId>
         <version>9.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>resteasy-plugin</artifactId>
-    <modules>
-        <module>resteasy-server-3.x-plugin</module>
-        <module>resteasy-server-4.x-plugin</module>
-        <module>resteasy-server-6.x-plugin</module>
-    </modules>
+    <artifactId>resteasy-server-6.x-plugin</artifactId>
+    <packaging>jar</packaging>
 
-    <packaging>pom</packaging>
-
-    <name>resteasy-plugin</name>
+    <name>apm-resteasy-server-6.x-plugin</name>
     <url>http://maven.apache.org</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sdk.plugin.related.dir>/..</sdk.plugin.related.dir>
+        <resteasy.version>6.2.4.Final</resteasy.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+            <version>${resteasy.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherExceptionInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherExceptionInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.resteasy.v6.server;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.jboss.resteasy.spi.HttpRequest;
+
+import java.lang.reflect.Method;
+
+public class SynchronousDispatcherExceptionInterceptor implements InstanceMethodsAroundInterceptor {
+
+    @Override
+    public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                             MethodInterceptResult result) throws Throwable {
+        if (ContextManager.isActive() && !((HttpRequest) allArguments[0]).getAsyncContext().isSuspended()) {
+            ContextManager.activeSpan().log((Throwable) allArguments[2]);
+        }
+    }
+
+    @Override
+    public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                              Object ret) throws Throwable {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+                                      Class<?>[] argumentsTypes, Throwable t) {
+        ContextManager.activeSpan().log(t);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherExceptionInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherExceptionInterceptor.java
@@ -45,6 +45,8 @@ public class SynchronousDispatcherExceptionInterceptor implements InstanceMethod
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
                                       Class<?>[] argumentsTypes, Throwable t) {
-        ContextManager.activeSpan().log(t);
+        if (ContextManager.isActive()) {
+            ContextManager.activeSpan().log(t);
+        }
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherInterceptor.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.resteasy.v6.server;
+
+import org.apache.skywalking.apm.agent.core.context.CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+
+public class SynchronousDispatcherInterceptor implements InstanceMethodsAroundInterceptor {
+    private static final Logger LOG = LoggerFactory.getLogger(SynchronousDispatcherInterceptor.class);
+
+    @Override
+    public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                             MethodInterceptResult result) throws Throwable {
+        HttpRequest request = (HttpRequest) allArguments[0];
+
+        ContextCarrier contextCarrier = new ContextCarrier();
+        CarrierItem next = contextCarrier.items();
+        while (next.hasNext()) {
+            next = next.next();
+            next.setHeadValue(request.getHttpHeaders().getHeaderString(next.getHeadKey()));
+        }
+
+        String operationName = request.getHttpMethod() + ":" + request.getUri().getPath();
+        AbstractSpan span = ContextManager.createEntrySpan(operationName, contextCarrier);
+        span.tag(Tags.URL, toPath(request.getUri().getRequestUri().toString()));
+        span.tag(Tags.HTTP.METHOD, request.getHttpMethod());
+        span.setComponent(ComponentsDefine.RESTEASY);
+        SpanLayer.asHttp(span);
+    }
+
+    @Override
+    public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                              Object ret) throws Throwable {
+        HttpResponse response = (HttpResponse) allArguments[1];
+        AbstractSpan span = ContextManager.activeSpan();
+        if (response.getStatus() >= 400) {
+            span.errorOccurred();
+        }
+        Tags.HTTP_RESPONSE_STATUS_CODE.set(span, response.getStatus());
+        ContextManager.stopSpan();
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+                                      Class<?>[] argumentsTypes, Throwable t) {
+        ContextManager.activeSpan().log(t);
+    }
+
+    private static String toPath(String uri) {
+        int index = uri.indexOf("?");
+        if (index > -1) {
+            return uri.substring(0, index);
+        } else {
+            return uri;
+        }
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherInterceptor.java
@@ -61,6 +61,9 @@ public class SynchronousDispatcherInterceptor implements InstanceMethodsAroundIn
     @Override
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
                               Object ret) throws Throwable {
+        if (!ContextManager.isActive()) {
+            return ret;
+        }
         HttpResponse response = (HttpResponse) allArguments[1];
         AbstractSpan span = ContextManager.activeSpan();
         if (response.getStatus() >= 400) {
@@ -74,7 +77,9 @@ public class SynchronousDispatcherInterceptor implements InstanceMethodsAroundIn
     @Override
     public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
                                       Class<?>[] argumentsTypes, Throwable t) {
-        ContextManager.activeSpan().log(t);
+        if (ContextManager.isActive()) {
+            ContextManager.activeSpan().log(t);
+        }
     }
 
     private static String toPath(String uri) {

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/define/SynchronousDispatcherInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/define/SynchronousDispatcherInstrumentation.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.resteasy.v6.server.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class SynchronousDispatcherInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+
+    private static final String ENHANCE_CLASS = "org.jboss.resteasy.core.SynchronousDispatcher";
+
+    private static final String INVOKE_INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.resteasy.v6.server.SynchronousDispatcherInterceptor";
+    private static final String INVOKE_EXCEPTION_INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.resteasy.v6.server.SynchronousDispatcherExceptionInterceptor";
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return null;
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[] {
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("invoke").and(takesArguments(3));
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INVOKE_INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            },
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("writeException").and(takesArguments(3));
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INVOKE_EXCEPTION_INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/main/resources/skywalking-plugin.def
@@ -14,20 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# test all 4.x and 5.x version, with corresponding latest patch version
-5.0.7.Final
-5.0.6.Final
-5.0.5.Final
-5.0.4.Final
-5.0.3.Final
-5.0.2.Final
-5.0.1.Final
-5.0.0.Final
-4.7.6.Final
-4.6.2.Final
-4.5.12.Final
-4.4.3.Final
-4.3.1.Final
-4.2.0.Final
-4.1.1.Final
-4.0.0.Final
+resteasy-server-6.x=org.apache.skywalking.apm.plugin.resteasy.v6.server.define.SynchronousDispatcherInstrumentation

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/AssertTools.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/AssertTools.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.resteasy.v6.server;
+
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.context.trace.TraceSegmentRef;
+import org.apache.skywalking.apm.agent.test.helper.SegmentRefHelper;
+import org.apache.skywalking.apm.agent.test.tools.SpanAssert;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+
+import static org.apache.skywalking.apm.agent.test.tools.SpanAssert.assertComponent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AssertTools {
+
+    static void assertTraceSegmentRef(TraceSegmentRef ref) {
+        assertThat(SegmentRefHelper.getParentServiceInstance(ref), is("instance"));
+        assertThat(SegmentRefHelper.getSpanId(ref), is(3));
+        assertThat(SegmentRefHelper.getTraceSegmentId(ref).toString(), is("3.4.5"));
+    }
+
+    static void assertHttpSpan(AbstractTracingSpan span) {
+        assertThat(span.getOperationName(), is("GET:/test/testRequestURL"));
+        assertComponent(span, ComponentsDefine.RESTEASY);
+        SpanAssert.assertTag(span, 0, "http://localhost:8080/test/testRequestURL");
+        assertThat(span.isEntry(), is(true));
+        SpanAssert.assertLayer(span, SpanLayer.HTTP);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/resteasy/v6/server/SynchronousDispatcherInterceptorTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.resteasy.v6.server;
+
+import org.apache.skywalking.apm.agent.core.context.SW8CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.LogDataEntity;
+import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.agent.test.helper.SegmentHelper;
+import org.apache.skywalking.apm.agent.test.helper.SpanHelper;
+import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStorage;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStoragePoint;
+import org.apache.skywalking.apm.agent.test.tools.SpanAssert;
+import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
+import org.jboss.resteasy.specimpl.MultivaluedMapImpl;
+import org.jboss.resteasy.specimpl.ResteasyHttpHeaders;
+import org.jboss.resteasy.specimpl.ResteasyUriInfo;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResourceInvoker;
+import org.jboss.resteasy.spi.ResteasyAsynchronousContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(TracingSegmentRunner.class)
+public class SynchronousDispatcherInterceptorTest {
+
+    private SynchronousDispatcherInterceptor synchronousDispatcherInterceptor;
+    private SynchronousDispatcherExceptionInterceptor exceptionInterceptor;
+
+    @SegmentStoragePoint
+    private SegmentStorage segmentStorage;
+
+    @Rule
+    public AgentServiceRule serviceRule = new AgentServiceRule();
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    HttpRequest request;
+
+    @Mock
+    HttpResponse response;
+
+    @Mock
+    ResourceInvoker resourceInvoker;
+
+    @Mock
+    private MethodInterceptResult methodInterceptResult;
+
+    @Mock
+    private ResteasyAsynchronousContext resteasyAsynchronousContext;
+
+    @Mock
+    EnhancedInstance enhancedInstance;
+
+    private Object[] arguments;
+    private Class[] argumentType;
+
+    private Object[] exceptionArguments;
+    private Class[] exceptionArgumentType;
+
+    @Before
+    public void setup() throws URISyntaxException {
+        synchronousDispatcherInterceptor = new SynchronousDispatcherInterceptor();
+        exceptionInterceptor = new SynchronousDispatcherExceptionInterceptor();
+        when(request.getUri()).thenReturn(new ResteasyUriInfo(new URI("http://localhost:8080/test/testRequestURL")));
+        when(request.getHttpHeaders()).thenReturn(new ResteasyHttpHeaders(new MultivaluedMapImpl<String, String>()));
+        when(request.getHttpMethod()).thenReturn("GET");
+        when(response.getStatus()).thenReturn(200);
+        when(request.getAsyncContext()).thenReturn(resteasyAsynchronousContext);
+        when(request.getAsyncContext().isSuspended()).thenReturn(false);
+        arguments = new Object[] {
+            request,
+            response,
+            resourceInvoker
+        };
+        argumentType = new Class[] {
+            request.getClass(),
+            response.getClass(),
+            resourceInvoker.getClass()
+        };
+
+        exceptionArguments = new Object[] {
+            request,
+            response,
+            new RuntimeException()
+        };
+        exceptionArgumentType = new Class[] {
+            request.getClass(),
+            response.getClass(),
+            new RuntimeException().getClass()
+        };
+    }
+
+    @Test
+    public void testWithoutSerializedContextData() throws Throwable {
+        synchronousDispatcherInterceptor.beforeMethod(enhancedInstance, null, arguments, argumentType, methodInterceptResult);
+        synchronousDispatcherInterceptor.afterMethod(enhancedInstance, null, arguments, argumentType, null);
+
+        assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+        AssertTools.assertHttpSpan(spans.get(0));
+    }
+
+    @Test
+    public void testWithSW6SerializedContextData() throws Throwable {
+        MultivaluedMapImpl<String, String> multivaluedMap = new MultivaluedMapImpl<String, String>();
+        multivaluedMap.putSingle(SW8CarrierItem.HEADER_NAME, "1-My40LjU=-MS4yLjM=-3-c2VydmljZQ==-aW5zdGFuY2U=-L2FwcA==-MTI3LjAuMC4xOjgwODA=");
+        when(request.getHttpHeaders()).thenReturn(new ResteasyHttpHeaders(multivaluedMap));
+
+        synchronousDispatcherInterceptor.beforeMethod(enhancedInstance, null, arguments, argumentType, methodInterceptResult);
+        synchronousDispatcherInterceptor.afterMethod(enhancedInstance, null, arguments, argumentType, null);
+
+        assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+
+        AssertTools.assertHttpSpan(spans.get(0));
+        AssertTools.assertTraceSegmentRef(traceSegment.getRef());
+    }
+
+    @Test
+    public void testWithOccurException() throws Throwable {
+        synchronousDispatcherInterceptor.beforeMethod(enhancedInstance, null, arguments, argumentType, methodInterceptResult);
+        synchronousDispatcherInterceptor.handleMethodException(enhancedInstance, null, arguments, argumentType, new RuntimeException());
+        synchronousDispatcherInterceptor.afterMethod(enhancedInstance, null, arguments, argumentType, null);
+
+        assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+
+        AssertTools.assertHttpSpan(spans.get(0));
+        List<LogDataEntity> logDataEntities = SpanHelper.getLogs(spans.get(0));
+        assertThat(logDataEntities.size(), is(1));
+        SpanAssert.assertException(logDataEntities.get(0), RuntimeException.class);
+    }
+
+    @Test
+    public void testWithMainThreadOccurException() throws Throwable {
+        synchronousDispatcherInterceptor.beforeMethod(enhancedInstance, null, arguments, argumentType, methodInterceptResult);
+        exceptionInterceptor.beforeMethod(enhancedInstance, null, exceptionArguments, exceptionArgumentType, null);
+        synchronousDispatcherInterceptor.afterMethod(enhancedInstance, null, arguments, argumentType, null);
+
+        assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+
+        AssertTools.assertHttpSpan(spans.get(0));
+        List<LogDataEntity> logDataEntities = SpanHelper.getLogs(spans.get(0));
+        assertThat(logDataEntities.size(), is(1));
+        SpanAssert.assertException(logDataEntities.get(0), RuntimeException.class);
+    }
+}

--- a/docs/en/setup/service-agent/java-agent/Plugin-list.md
+++ b/docs/en/setup/service-agent/java-agent/Plugin-list.md
@@ -82,6 +82,7 @@
 - redisson-3.x
 - resteasy-server-3.x
 - resteasy-server-4.x
+- resteasy-server-6.x
 - rocketMQ-3.x
 - rocketMQ-4.x
 - rocketMQ-5.x

--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -17,7 +17,7 @@ metrics based on the tracing data.
   * [Jetty Server](http://www.eclipse.org/jetty/) 9.x -> 11.x
   * [Spring WebFlux](https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html) 5.x (Optional¹)
   * [Undertow](http://undertow.io/)  1.3.0.Final -> 2.0.27.Final
-  * [RESTEasy](https://resteasy.github.io/)  3.1.0.Final -> 4.7.6.Final
+  * [RESTEasy](https://resteasy.github.io/)  3.1.0.Final -> 6.2.4.Final
   * [Play Framework](https://www.playframework.com/) 2.6.x -> 2.8.x
   * [Light4J Microservices Framework](https://doc.networknt.com/) 1.6.x -> 2.x
   * [Netty SocketIO](https://github.com/mrniko/netty-socketio) 1.x

--- a/test/plugin/scenarios/resteasy-4.x-scenario/support-version.list
+++ b/test/plugin/scenarios/resteasy-4.x-scenario/support-version.list
@@ -16,13 +16,6 @@
 
 # test all 4.x and 5.x version, with corresponding latest patch version
 5.0.7.Final
-5.0.6.Final
-5.0.5.Final
-5.0.4.Final
-5.0.3.Final
-5.0.2.Final
-5.0.1.Final
-5.0.0.Final
 4.7.6.Final
 4.6.2.Final
 4.5.12.Final

--- a/test/plugin/scenarios/resteasy-6.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/config/expectedData.yaml
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+segmentItems:
+  - serviceName: resteasy-6.x-scenario
+    segmentSize: ge 6
+    segments:
+      - segmentId: not null
+        spans:
+          - operationName: HEAD:/resteasy-6.x-scenario/healthCheck
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/healthCheck' }
+              - { key: http.method, value: HEAD }
+              - { key: http.status_code, value: '200' }
+            skipAnalysis: 'false'
+      - segmentId: not null
+        spans:
+          - operationName: POST:/resteasy-6.x-scenario/create/
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/create/' }
+              - { key: http.method, value: POST }
+              - { key: http.status_code, value: '201' }
+            refs:
+              - { parentEndpoint: 'GET:/resteasy-6.x-scenario/case/resttemplate', networkAddress: 'localhost:8080', refType: CrossProcess,
+                parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
+                    null, parentService: resteasy-6.x-scenario, traceId: not null }
+            skipAnalysis: 'false'
+      - segmentId: not null
+        spans:
+          - operationName: GET:/resteasy-6.x-scenario/get/1
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/get/1' }
+              - { key: http.method, value: GET }
+              - { key: http.status_code, value: '200' }
+            refs:
+              - { parentEndpoint: 'GET:/resteasy-6.x-scenario/case/resttemplate', networkAddress: 'localhost:8080', refType: CrossProcess,
+                parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
+                    null, parentService: resteasy-6.x-scenario, traceId: not null }
+            skipAnalysis: 'false'
+      - segmentId: not null
+        spans:
+          - operationName: PUT:/resteasy-6.x-scenario/update/1
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/update/1' }
+              - { key: http.method, value: PUT }
+              - { key: http.status_code, value: '200' }
+            refs:
+              - { parentEndpoint: 'GET:/resteasy-6.x-scenario/case/resttemplate', networkAddress: 'localhost:8080', refType: CrossProcess,
+                parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
+                    null, parentService: resteasy-6.x-scenario, traceId: not null }
+            skipAnalysis: 'false'
+      - segmentId: not null
+        spans:
+          - operationName: DELETE:/resteasy-6.x-scenario/delete/1
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/delete/1' }
+              - { key: http.method, value: DELETE }
+              - { key: http.status_code, value: '204' }
+            refs:
+              - { parentEndpoint: 'GET:/resteasy-6.x-scenario/case/resttemplate', networkAddress: 'localhost:8080', refType: CrossProcess,
+                parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
+                    null, parentService: resteasy-6.x-scenario, traceId: not null }
+            skipAnalysis: 'false'
+      - segmentId: not null
+        spans:
+          - operationName: /resteasy-6.x-scenario/create/
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 2
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/create/' }
+              - { key: http.method, value: POST }
+              - { key: http.status_code, value: '201' }
+            skipAnalysis: 'false'
+          - operationName: /resteasy-6.x-scenario/get/1
+            parentSpanId: 0
+            spanId: 2
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 2
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/get/1' }
+              - { key: http.method, value: GET }
+              - { key: http.status_code, value: '200' }
+            skipAnalysis: 'false'
+          - operationName: /resteasy-6.x-scenario/update/1
+            parentSpanId: 0
+            spanId: 3
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 2
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/update/1' }
+              - { key: http.method, value: PUT }
+              - { key: http.status_code, value: '200' }
+            skipAnalysis: 'false'
+          - operationName: /resteasy-6.x-scenario/delete/1
+            parentSpanId: 0
+            spanId: 4
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 2
+            isError: false
+            spanType: Exit
+            peer: localhost:8080
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/delete/1' }
+              - { key: http.method, value: DELETE }
+              - { key: http.status_code, value: '204' }
+            skipAnalysis: 'false'
+          - operationName: GET:/resteasy-6.x-scenario/case/resttemplate
+            operationId: 0
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: nq 0
+            endTime: nq 0
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - { key: url, value: 'http://localhost:8080/resteasy-6.x-scenario/case/resttemplate' }
+              - { key: http.method, value: GET }
+              - { key: http.status_code, value: '200' }

--- a/test/plugin/scenarios/resteasy-6.x-scenario/configuration.yml
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/configuration.yml
@@ -14,20 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# test all 4.x and 5.x version, with corresponding latest patch version
-5.0.7.Final
-5.0.6.Final
-5.0.5.Final
-5.0.4.Final
-5.0.3.Final
-5.0.2.Final
-5.0.1.Final
-5.0.0.Final
-4.7.6.Final
-4.6.2.Final
-4.5.12.Final
-4.4.3.Final
-4.3.1.Final
-4.2.0.Final
-4.1.1.Final
-4.0.0.Final
+type: tomcat
+entryService: http://localhost:8080/resteasy-6.x-scenario/case/resttemplate
+healthCheck: http://localhost:8080/resteasy-6.x-scenario/healthCheck
+environment:
+  - CATALINA_OPTS="-Dskywalking.plugin.http.include_http_headers=mock_header"

--- a/test/plugin/scenarios/resteasy-6.x-scenario/pom.xml
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.skywalking</groupId>
+    <artifactId>resteasy-6.x-scenario</artifactId>
+    <version>1.0.0</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <compiler.version>17</compiler.version>
+        <test.framework.version>6.2.4.Final</test.framework.version>
+        <log4j.version>2.8.1</log4j.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxb-provider</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-servlet-initializer</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <finalName>resteasy-6.x-scenario</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${compiler.version}</source>
+                    <target>${compiler.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/RestTemplateController.java
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/RestTemplateController.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test.apache.skywalking.apm.testcase;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import test.apache.skywalking.apm.testcase.entity.User;
+
+@Path("/")
+public class RestTemplateController {
+
+    private static final String SUCCESS = "Success";
+
+    private static final String URL = "http://localhost:8080/resteasy-6.x-scenario";
+
+    @GET
+    @Path("case/resttemplate")
+    public Response restTemplate() {
+        Client client = ClientBuilder.newBuilder().build();
+
+        // Create user
+        User userEntity = new User(1, "a");
+        WebTarget target = client.target(URL + "/create/");
+        Response response = target.request().post(Entity.json(userEntity));
+        String value = response.readEntity(String.class);
+        response.close();
+
+        // Find User
+        response = client.target(URL + "/get/1").request().get();
+        response.close();
+
+        //Modify user
+        User updateUserEntity = new User(1, "b");
+        response = client.target(URL + "/update/1").request().put(Entity.json(updateUserEntity));
+        response.close();
+
+        //Delete user
+        response = client.target(URL + "/delete/1").request().delete();
+        response.close();
+
+        client.close();
+
+        return Response.ok(SUCCESS).build();
+    }
+
+    @GET
+    @Path("healthCheck")
+    public String healthCheck() {
+        return SUCCESS;
+    }
+
+}

--- a/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/UserApplication.java
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/UserApplication.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test.apache.skywalking.apm.testcase;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@ApplicationPath("/")
+public class UserApplication extends Application {
+    private final Set<Class<?>> classes = new HashSet<>();
+
+    public UserApplication() {
+        classes.add(UserResource.class);
+        classes.add(RestTemplateController.class);
+    }
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return classes;
+    }
+}

--- a/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/UserResource.java
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/UserResource.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test.apache.skywalking.apm.testcase;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import test.apache.skywalking.apm.testcase.entity.User;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Path("/")
+public class UserResource {
+
+    private static final Map<Integer, User> USERS = new ConcurrentHashMap<>();
+
+    @GET
+    @Path("/get/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getUser(@PathParam("id") int id) {
+        User currentUser = new User(id, "a");
+        return Response.ok(currentUser).build();
+    }
+
+    @POST
+    @Path("/create/")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response createUser(User user) {
+        USERS.put(user.getId(), user);
+        return Response.created(URI.create("")).build();
+    }
+
+    @PUT
+    @Path("/update/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response updateUser(@PathParam("id") int id, User user) {
+        User currentUser = new User(id, user.getUserName());
+        return Response.ok(currentUser).build();
+    }
+
+    @DELETE
+    @Path("/delete/{id}")
+    public Response deleteUser(@PathParam("id") int id) {
+        User currentUser = USERS.get(id);
+        if (currentUser == null) {
+            return Response.noContent().build();
+        }
+        USERS.remove(id);
+        return Response.noContent().build();
+    }
+}

--- a/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/entity/User.java
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/src/main/java/test/apache/skywalking/apm/testcase/entity/User.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package test.apache.skywalking.apm.testcase.entity;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+
+    private int id;
+    private String userName;
+
+    public User(int id) {
+        this.id = id;
+    }
+
+    public User(int id, String userName) {
+        this.id = id;
+        this.userName = userName;
+    }
+
+    public User() {
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/test/plugin/scenarios/resteasy-6.x-scenario/src/main/resources/log4j2.xml
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/src/main/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <PatternLayout charset="UTF-8" pattern="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%p] - %l - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="WARN">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/test/plugin/scenarios/resteasy-6.x-scenario/src/main/webapp/WEB-INF/web.xml
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,39 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		 http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <display-name>resteasy-server-6.x</display-name>
+    <servlet>
+        <servlet-name>resteasy-server-6.x</servlet-name>
+        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
+            <param-value>test.apache.skywalking.apm.testcase.UserApplication</param-value>
+        </init-param>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>resteasy-server-6.x</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/test/plugin/scenarios/resteasy-6.x-scenario/support-version.list
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/support-version.list
@@ -16,12 +16,5 @@
 
 # test all 6.x version, with corresponding latest patch version
 6.2.4.Final
-6.2.3.Final
-6.2.2.Final
-6.2.1.Final
-6.2.0.Final
 6.1.0.Final
 6.0.3.Final
-6.0.2.Final
-6.0.1.Final
-6.0.0.Final

--- a/test/plugin/scenarios/resteasy-6.x-scenario/support-version.list
+++ b/test/plugin/scenarios/resteasy-6.x-scenario/support-version.list
@@ -14,20 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# test all 4.x and 5.x version, with corresponding latest patch version
-5.0.7.Final
-5.0.6.Final
-5.0.5.Final
-5.0.4.Final
-5.0.3.Final
-5.0.2.Final
-5.0.1.Final
-5.0.0.Final
-4.7.6.Final
-4.6.2.Final
-4.5.12.Final
-4.4.3.Final
-4.3.1.Final
-4.2.0.Final
-4.1.1.Final
-4.0.0.Final
+# test all 6.x version, with corresponding latest patch version
+6.2.4.Final
+6.2.3.Final
+6.2.2.Final
+6.2.1.Final
+6.2.0.Final
+6.1.0.Final
+6.0.3.Final
+6.0.2.Final
+6.0.1.Final
+6.0.0.Final


### PR DESCRIPTION
### Add an agent plugin to support RESTEasy 6.x

- [x] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)  
- [x] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)  
- [x] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)  

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes : NO
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).


Skywalking already supports Resteasy 3.x and 4.x. Referrers to [RESTEASY-3007](https://issues.redhat.com/browse/RESTEASY-3007), Resteasy 6 has migrated from Jakarta REST 2.1 to Jakarta REST 3.0.  
Therefore, when applying skywalking's Resteasy 4.x javaagent to a Resteasy 6.x application, it throws `NoSuchMethodError` like belows:

```
java.lang.NoSuchMethodError: 'javax.ws.rs.core.HttpHeaders org.jboss.resteasy.spi.HttpRequest.getHttpHeaders()'
	at org.apache.skywalking.apm.plugin.resteasy.v4.server.SynchronousDispatcherInterceptor.beforeMethod(SynchronousDispatcherInterceptor.java:50)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:76)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$invoke$4(SynchronousDispatcher.java:240)
	at org.jboss.resteasy.core.SynchronousDispatcher.lambda$preprocess$0(SynchronousDispatcher.java:154)
	at org.jboss.resteasy.core.interception.jaxrs.PreMatchContainerRequestContext.filter(PreMatchContainerRequestContext.java:321)
	at org.jboss.resteasy.core.SynchronousDispatcher.preprocess(SynchronousDispatcher.java:157)
	at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:229)
	at io.quarkus.resteasy.runtime.standalone.RequestDispatcher.service(RequestDispatcher.java:82)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler.dispatch(VertxRequestHandler.java:147)
	at io.quarkus.resteasy.runtime.standalone.VertxRequestHandler$1.run(VertxRequestHandler.java:93)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:576)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

this PR:

1. Add support for RESTEasy 6.x
2. Test skywalking's RESTEasy 4.x javaagent (#265 ) for application with RESTEasy 5.x framework (add 5.x versions in `support-version.list`)
3. Add RESTEasy 6.x tests into github workflow; according to [Apache Tomcat Versions](https://tomcat.apache.org/whichversion.html), we choose jdk17+tomcat10 for jakarta REST 3.0 supporting