### PR TITLE
Fix lettuce NullPointerException

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -153,6 +153,7 @@ Callable {
 * Support asynchronous invocation in jetty client 9.0 and 9.x plugin
 * Add nacos-client 2.x plugin
 * Staticize the tags for preventing synchronization in JDK 8 
+* Fix NullPointerException in lettuce-5.x-plugin.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisChannelWriterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisChannelWriterInterceptor.java
@@ -103,10 +103,10 @@ public class RedisChannelWriterInterceptor implements InstanceMethodsAroundInter
             return Constants.EMPTY_STRING;
         }
         ByteBuffer firstEncodedKey = args.getFirstEncodedKey();
-        if (firstEncodedKey == null){
+        if (firstEncodedKey == null) {
             return Constants.EMPTY_STRING;
         }
-        String key = STRING_CODEC.decodeKey(firstEncodedKey);    
+        String key = STRING_CODEC.decodeKey(firstEncodedKey);
         if (StringUtil.isNotEmpty(key) && key.length() > LettucePluginConfig.Plugin.Lettuce.REDIS_PARAMETER_MAX_LENGTH) {
             key = StringUtil.cut(key, LettucePluginConfig.Plugin.Lettuce.REDIS_PARAMETER_MAX_LENGTH) + ABBR;
         }

--- a/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisChannelWriterInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/lettuce/v5/RedisChannelWriterInterceptor.java
@@ -101,8 +101,11 @@ public class RedisChannelWriterInterceptor implements InstanceMethodsAroundInter
         CommandArgs<?, ?> args = redisCommand.getArgs();
         if (args == null) {
             return Constants.EMPTY_STRING;
-        } 
+        }
         ByteBuffer firstEncodedKey = args.getFirstEncodedKey();
+        if (firstEncodedKey == null){
+            return Constants.EMPTY_STRING;
+        }
         String key = STRING_CODEC.decodeKey(firstEncodedKey);    
         if (StringUtil.isNotEmpty(key) && key.length() > LettucePluginConfig.Plugin.Lettuce.REDIS_PARAMETER_MAX_LENGTH) {
             key = StringUtil.cut(key, LettucePluginConfig.Plugin.Lettuce.REDIS_PARAMETER_MAX_LENGTH) + ABBR;


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

## problem
```java
ERROR 2023-08-28 12:01:48.251 http-nio-0.0.0.0-80-exec-3 InstMethodsInter : class[class io.lettuce.core.protocol.DefaultEndpoint] before method[write] intercept failure 
java.lang.NullPointerException
        at io.netty.buffer.Unpooled.wrappedBuffer(Unpooled.java:184)
        at io.lettuce.core.codec.StringCodec.decodeKey(StringCodec.java:139)
        at org.apache.skywalking.apm.plugin.lettuce.v5.RedisChannelWriterInterceptor.getArgsKey(RedisChannelWriterInterceptor.java:106)
        at org.apache.skywalking.apm.plugin.lettuce.v5.RedisChannelWriterInterceptor.beforeMethod(RedisChannelWriterInterceptor.java:77)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:76)
        at io.lettuce.core.protocol.DefaultEndpoint.write(DefaultEndpoint.java)
        at io.lettuce.core.cluster.ClusterDistributionChannelWriter.writeCommand(ClusterDistributionChannelWriter.java:174)
        at io.lettuce.core.cluster.ClusterDistributionChannelWriter.sw$original$write$68ub3r3(ClusterDistributionChannelWriter.java:131)
        at io.lettuce.core.cluster.ClusterDistributionChannelWriter.sw$original$write$68ub3r3$accessor$sw$3vg0qg2(ClusterDistributionChannelWriter.java)
        at io.lettuce.core.cluster.ClusterDistributionChannelWriter$sw$auxiliary$614uli0.call(Unknown Source)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:86)
        at io.lettuce.core.cluster.ClusterDistributionChannelWriter.write(ClusterDistributionChannelWriter.java)
        at io.lettuce.core.RedisChannelHandler.dispatch(RedisChannelHandler.java:123)
        at io.lettuce.core.cluster.StatefulRedisClusterConnectionImpl.dispatch(StatefulRedisClusterConnectionImpl.java:213)
        at io.lettuce.core.AbstractRedisAsyncCommands.dispatch(AbstractRedisAsyncCommands.java:461)
        at io.lettuce.core.AbstractRedisAsyncCommands.command(AbstractRedisAsyncCommands.java:315)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
```

## Causes
The method  [args.getFirstEncodedKey()](https://github.com/lettuce-io/lettuce-core/blob/b48f75aefcb4619f7f9a4fac92dad759ec1768f3/src/main/java/io/lettuce/core/protocol/CommandArgs.java#L349) may return null.

## how to fix it
Add null check.




