### PR TITLE
Fix the issue of createSpan failure caused by invalid request URL in HttpClient 4.x/5.x plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Release Notes.
 ------------------
 
 * Fix hbase onConstruct NPE in the file configuration scenario
+* Fix the issue of createSpan failure caused by invalid request URL in HttpClient 4.x/5.x plugin
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpClient/v4/HttpClientExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpClient/v4/HttpClientExecuteInterceptor.java
@@ -42,6 +42,7 @@ import org.apache.skywalking.apm.plugin.httpclient.HttpClientPluginConfig;
 import org.apache.skywalking.apm.util.StringUtil;
 
 public class HttpClientExecuteInterceptor implements InstanceMethodsAroundInterceptor {
+    private static final String ERROR_URI = "/_blank";
 
     @Override
     public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
@@ -60,7 +61,9 @@ public class HttpClientExecuteInterceptor implements InstanceMethodsAroundInterc
         String requestURI = getRequestURI(uri);
         String operationName = requestURI;
         AbstractSpan span = ContextManager.createExitSpan(operationName, contextCarrier, remotePeer);
-
+        if (ERROR_URI.equals(requestURI)) {
+            span.errorOccurred();
+        }
         span.setComponent(ComponentsDefine.HTTPCLIENT);
         Tags.URL.set(span, buildSpanValue(httpHost, uri));
         Tags.HTTP.METHOD.set(span, httpRequest.getRequestLine().getMethod());
@@ -118,7 +121,7 @@ public class HttpClientExecuteInterceptor implements InstanceMethodsAroundInterc
             try {
                 requestPath = new URL(uri).getPath();
             } catch (MalformedURLException e) {
-                requestPath = uri;
+                return ERROR_URI;
             }
             return requestPath != null && requestPath.length() > 0 ? requestPath : "/";
         } else {

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpClient/v4/HttpClientExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpClient/v4/HttpClientExecuteInterceptor.java
@@ -112,9 +112,14 @@ public class HttpClientExecuteInterceptor implements InstanceMethodsAroundInterc
         activeSpan.log(t);
     }
 
-    private String getRequestURI(String uri) throws MalformedURLException {
+    private String getRequestURI(String uri) {
         if (isUrl(uri)) {
-            String requestPath = new URL(uri).getPath();
+            String requestPath;
+            try {
+                requestPath = new URL(uri).getPath();
+            } catch (MalformedURLException e) {
+                requestPath = uri;
+            }
             return requestPath != null && requestPath.length() > 0 ? requestPath : "/";
         } else {
             return uri;

--- a/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpclient/v5/HttpClientDoExecuteInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpclient/v5/HttpClientDoExecuteInterceptor.java
@@ -101,9 +101,14 @@ public class HttpClientDoExecuteInterceptor implements InstanceMethodsAroundInte
         activeSpan.log(t);
     }
 
-    private String getRequestURI(String uri) throws MalformedURLException {
+    private String getRequestURI(String uri) {
         if (isUrl(uri)) {
-            String requestPath = new URL(uri).getPath();
+            String requestPath;
+            try {
+                requestPath = new URL(uri).getPath();
+            } catch (MalformedURLException e) {
+                requestPath = uri;
+            }
             return requestPath != null && requestPath.length() > 0 ? requestPath : "/";
         } else {
             return uri;


### PR DESCRIPTION
### Fix the issue of createSpan failure caused by invalid request URL in HttpClient 4.x/5.x plugin
**bad case:**
uri=http://localhost:8080:8080
In HttpClient 4.x/5.x plugin, isUrl(uri) will return true, but new URL(uri) will throw Exception which will interrupt createSpan.


- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
