### PR TITLE
fix: Fix an issue with the httpasyncclient component where the isErro…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Release Notes.
 * Fix hbase onConstruct NPE in the file configuration scenario
 * Fix the issue of createSpan failure caused by invalid request URL in HttpClient 4.x/5.x plugin
 * Optimize ElasticSearch 6.x 7.x plugin compatibility
+* Fix an issue with the httpasyncclient component where the isError state is incorrect.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpasyncclient/v4/wrapper/HttpAsyncResponseConsumerWrapper.java
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/httpasyncclient/v4/wrapper/HttpAsyncResponseConsumerWrapper.java
@@ -46,7 +46,7 @@ public class HttpAsyncResponseConsumerWrapper<T> implements HttpAsyncResponseCon
     public void responseReceived(HttpResponse response) throws IOException, HttpException {
         if (ContextManager.isActive()) {
             int statusCode = response.getStatusLine().getStatusCode();
-            AbstractSpan span = ContextManager.activeSpan().errorOccurred();
+            AbstractSpan span = ContextManager.activeSpan();
             Tags.HTTP_RESPONSE_STATUS_CODE.set(span, statusCode);
             if (statusCode >= 400) {
                 span.errorOccurred();

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/httpasyncclient/v4/HttpAsyncClientInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/httpasyncclient/v4/HttpAsyncClientInterceptorTest.java
@@ -348,6 +348,7 @@ public class HttpAsyncClientInterceptorTest {
         assertThat(tags.get(0).getValue(), is("http://localhost:8081/original/test"));
         assertThat(tags.get(1).getValue(), is("GET"));
         assertThat(tags.get(2).getValue(), is("a=1&b=test"));
+        assertThat(span.transform().getIsError(), is(false));
         assertThat(span.isExit(), is(true));
     }
 

--- a/test/plugin/scenarios/httpasyncclient-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/httpasyncclient-scenario/config/expectedData.yaml
@@ -60,7 +60,7 @@ segmentItems:
       startTime: nq 0
       endTime: nq 0
       componentId: 26
-      isError: true
+      isError: false
       spanType: Exit
       peer: 127.0.0.1:8080
       tags:


### PR DESCRIPTION
### Fix <Fix an issue with the httpasyncclient component where the isError state is incorrect.>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
Normally, HTTP status codes below 400 should be marked as isError=false. However, due to a previous code migration, the isError state in the httpasyncclient component became inaccurate. It incorrectly marked isError=true even for HTTP status codes below 400.



