### PR TITLE
Fix peer when configured as domain for rabbitmq plugin.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 * Support customization for the length limitation of string configurations
 * Add max length configurations in `agent.config` file for service_name and instance_name
 * Optimize spring-cloud-gateway 2.1.x, 3.x witness class.
+* Fix peer when configured as domain for rabbitmq plugin.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/src/main/java/org/apache/skywalking/apm/plugin/rabbitmq/ChannelNConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/src/main/java/org/apache/skywalking/apm/plugin/rabbitmq/ChannelNConstructorInterceptor.java
@@ -28,12 +28,12 @@ public class ChannelNConstructorInterceptor implements InstanceConstructorInterc
     public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
         Connection connection = (Connection) allArguments[0];
 
-        String[] segments = connection.getAddress().toString().split("/");
+        String[] parts = connection.getAddress().toString().split("/");
         String address;
-        if (StringUtil.isNotEmpty(segments[0])) {
-            address = segments[0];
-        } else if (segments.length >= 2 && StringUtil.isNotEmpty(segments[1])) {
-            address = segments[1];
+        if (StringUtil.isNotEmpty(parts[0])) {
+            address = parts[0];
+        } else if (parts.length >= 2 && StringUtil.isNotEmpty(parts[1])) {
+            address = parts[1];
         } else {
             address = "";
         }

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/src/main/java/org/apache/skywalking/apm/plugin/rabbitmq/ChannelNConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/src/main/java/org/apache/skywalking/apm/plugin/rabbitmq/ChannelNConstructorInterceptor.java
@@ -21,12 +21,24 @@ package org.apache.skywalking.apm.plugin.rabbitmq;
 import com.rabbitmq.client.Connection;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
+import org.apache.skywalking.apm.util.StringUtil;
 
 public class ChannelNConstructorInterceptor implements InstanceConstructorInterceptor {
     @Override
     public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
         Connection connection = (Connection) allArguments[0];
-        String url = connection.getAddress().toString().replace("/", "") + ":" + connection.getPort();
+
+        String[] segments = connection.getAddress().toString().split("/");
+        String address;
+        if (StringUtil.isNotEmpty(segments[0])) {
+            address = segments[0];
+        } else if (segments.length >= 2 && StringUtil.isNotEmpty(segments[1])) {
+            address = segments[1];
+        } else {
+            address = "";
+        }
+        String url = address + ":" + connection.getPort();
+
         objInst.setSkyWalkingDynamicField(url);
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/src/test/java/org/apache/skywalking/apm/plugin/rabbitmq/ChannelNConstructorInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/src/test/java/org/apache/skywalking/apm/plugin/rabbitmq/ChannelNConstructorInterceptorTest.java
@@ -60,10 +60,16 @@ public class ChannelNConstructorInterceptorTest {
 
     public class TestConnection implements Connection {
 
+        String address;
+
+        public TestConnection(String address) {
+            this.address = address;
+        }
+
         @Override
         public InetAddress getAddress() {
             try {
-                return InetAddress.getByName("127.0.0.1");
+                return InetAddress.getByName(address);
             } catch (UnknownHostException e) {
                 e.printStackTrace();
                 return null;
@@ -217,18 +223,23 @@ public class ChannelNConstructorInterceptorTest {
         }
     }
 
-    private Connection testConnection;
+    private Connection testConnection1;
+    private Connection testConnection2;
 
     @Before
     public void setUp() throws Exception {
-        testConnection = new TestConnection();
-
+        testConnection1 = new TestConnection("127.0.0.1");
+        testConnection2 = new TestConnection("localhost");
     }
 
     @Test
     public void TestRabbitMQConsumerAndProducerConstructorInterceptor() {
         channelNConstructorInterceptor = new ChannelNConstructorInterceptor();
-        channelNConstructorInterceptor.onConstruct(enhancedInstance, new Object[] {testConnection});
+        channelNConstructorInterceptor.onConstruct(enhancedInstance, new Object[] {testConnection1});
         assertThat((String) enhancedInstance.getSkyWalkingDynamicField(), is("127.0.0.1:5672"));
+
+        channelNConstructorInterceptor = new ChannelNConstructorInterceptor();
+        channelNConstructorInterceptor.onConstruct(enhancedInstance, new Object[] {testConnection2});
+        assertThat((String) enhancedInstance.getSkyWalkingDynamicField(), is("localhost:5672"));
     }
 }


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

Previous rabbitmq plugin get peer by `InetAddress.toString().replace("/", "")`, The format of `InetAddress.toString()` is `DOMAIN/IP`, so, when the rabbitmq address configured as IP, it's ok, but when the address configured as Domain, isn't ok, the peer will become `DOMAINIP:PORT`, such as `localhost127.0.0.1:5672`.