### PR TITLE
[DOCS] Corrected an issue using misspelled words in Native Tracer

### DIFF
--- a/docs/en/setup/service-agent/java-agent/Application-toolkit-tracer.md
+++ b/docs/en/setup/service-agent/java-agent/Application-toolkit-tracer.md
@@ -6,7 +6,7 @@
   import org.apache.skywalking.apm.toolkit.trace.Tracer;
   ...
     
-  SpanRef spanRef = Tracer.createEnteySpan("${operationName}", null);
+  SpanRef spanRef = Tracer.createEntrySpan("${operationName}", null);
   ```
 
 * Use `Tracer.createLocalSpan()` API to create local span, the only parameter is the operation name of span.


### PR DESCRIPTION
In order to solve the problem of misleading documentation errors for novices, it is now necessary to correct the current online error codes.