### PR TITLE
Fix Impala Jdbc URL (including schema without properties) parsing exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Release Notes.
 * Support collecting ZGC memory pool metrics. Require OAP 9.7.0 to support these new metrics.
 * Upgrade netty-codec-http2 to 4.1.100.Final
 * Add a netty-http 4.1.x plugin to trace HTTP requests.
+* Fix Impala Jdbc URL (including schema without properties) parsing exception.
 
 
 #### Documentation

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/ImpalaJdbcURLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/ImpalaJdbcURLParser.java
@@ -64,7 +64,7 @@ public class ImpalaJdbcURLParser extends AbstractURLParser {
         if (databaseStartTag == -1 && firstParamIndex == -1) {
             return null;
         } else {
-            if(firstParamIndex == -1){
+            if (firstParamIndex == -1) {
                 firstParamIndex = url.length();
             }
             String subUrl = url.substring(startSize, firstParamIndex);

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/ImpalaJdbcURLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/ImpalaJdbcURLParser.java
@@ -35,7 +35,10 @@ public class ImpalaJdbcURLParser extends AbstractURLParser {
     @Override
     protected URLLocation fetchDatabaseHostsIndexRange() {
         int hostLabelStartIndex = url.indexOf("//");
-        int hostLabelEndIndex = url.indexOf("/", hostLabelStartIndex + 2);
+        int hostLabelEndIndex = url.length();
+        if (url.indexOf("/", hostLabelStartIndex + 2) != -1) {
+            hostLabelEndIndex = url.indexOf("/", hostLabelStartIndex + 2);
+        }
         int hostLabelEndIndexWithParameter = url.indexOf(";", hostLabelStartIndex);
         if (hostLabelEndIndexWithParameter != -1) {
             String subUrl = url.substring(0, hostLabelEndIndexWithParameter);
@@ -102,7 +105,7 @@ public class ImpalaJdbcURLParser extends AbstractURLParser {
         } else {
             String[] hostAndPort = hostSegment[0].split(":");
             if (hostAndPort.length != 1) {
-                return new ConnectionInfo(component, DB_TYPE, hostAndPort[0], Integer.parseInt(hostAndPort[1]), fetchDatabaseNameFromURL(location
+                return new ConnectionInfo(component, DB_TYPE, hostAndPort[0], Integer.valueOf(hostAndPort[1]), fetchDatabaseNameFromURL(location
                         .endIndex()));
             } else {
                 return new ConnectionInfo(component, DB_TYPE, hostAndPort[0], DEFAULT_PORT, fetchDatabaseNameFromURL(location

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/ImpalaJdbcURLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/ImpalaJdbcURLParser.java
@@ -35,7 +35,7 @@ public class ImpalaJdbcURLParser extends AbstractURLParser {
     @Override
     protected URLLocation fetchDatabaseHostsIndexRange() {
         int hostLabelStartIndex = url.indexOf("//");
-        int hostLabelEndIndex = url.length();
+        int hostLabelEndIndex = url.indexOf("/", hostLabelStartIndex + 2);
         int hostLabelEndIndexWithParameter = url.indexOf(";", hostLabelStartIndex);
         if (hostLabelEndIndexWithParameter != -1) {
             String subUrl = url.substring(0, hostLabelEndIndexWithParameter);
@@ -64,6 +64,9 @@ public class ImpalaJdbcURLParser extends AbstractURLParser {
         if (databaseStartTag == -1 && firstParamIndex == -1) {
             return null;
         } else {
+            if(firstParamIndex == -1){
+                firstParamIndex = url.length();
+            }
             String subUrl = url.substring(startSize, firstParamIndex);
             int schemaIndex = subUrl.indexOf("/");
             if (schemaIndex == -1) {
@@ -99,7 +102,7 @@ public class ImpalaJdbcURLParser extends AbstractURLParser {
         } else {
             String[] hostAndPort = hostSegment[0].split(":");
             if (hostAndPort.length != 1) {
-                return new ConnectionInfo(component, DB_TYPE, hostAndPort[0], Integer.valueOf(hostAndPort[1]), fetchDatabaseNameFromURL(location
+                return new ConnectionInfo(component, DB_TYPE, hostAndPort[0], Integer.parseInt(hostAndPort[1]), fetchDatabaseNameFromURL(location
                         .endIndex()));
             } else {
                 return new ConnectionInfo(component, DB_TYPE, hostAndPort[0], DEFAULT_PORT, fetchDatabaseNameFromURL(location

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
@@ -185,4 +185,18 @@ public class URLParserTest {
         assertThat(connectionInfo.getDatabasePeer(), is("localhost:8123"));
     }
 
+    @Test
+    public void testParseImpalaJDBCURLWithSchema() {
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050/test");
+        assertThat(connectionInfo.getDBType(), is("Impala"));
+        assertThat(connectionInfo.getDatabaseName(), is("test"));
+        assertThat(connectionInfo.getDatabasePeer(), is("localhost:21050"));
+    }
+
+    @Test
+    public void testParseImpalaJDBCURL() {
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050;AuthMech=3;UID=UserName;PWD=Password");
+        assertThat(connectionInfo.getDBType(), is("Impala"));
+        assertThat(connectionInfo.getDatabasePeer(), is("localhost:21050"));
+    }
 }

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
@@ -187,7 +187,7 @@ public class URLParserTest {
 
     @Test
     public void testParseImpalaJDBCURL() {
-        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050/demo;AuthMech=3;UID=UserName;PWD=Password");
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050/test;AuthMech=3;UID=UserName;PWD=Password");
         assertThat(connectionInfo.getDBType(), is("Impala"));
         assertThat(connectionInfo.getDatabaseName(), is("test"));
         assertThat(connectionInfo.getDatabasePeer(), is("localhost:21050"));

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/test/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParserTest.java
@@ -186,16 +186,24 @@ public class URLParserTest {
     }
 
     @Test
-    public void testParseImpalaJDBCURLWithSchema() {
-        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050/test");
+    public void testParseImpalaJDBCURL() {
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050/demo;AuthMech=3;UID=UserName;PWD=Password");
         assertThat(connectionInfo.getDBType(), is("Impala"));
         assertThat(connectionInfo.getDatabaseName(), is("test"));
         assertThat(connectionInfo.getDatabasePeer(), is("localhost:21050"));
     }
 
     @Test
-    public void testParseImpalaJDBCURL() {
-        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050;AuthMech=3;UID=UserName;PWD=Password");
+    public void testParseImpalaJDBCURLWithSchema() {
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050/test");
+        assertThat(connectionInfo.getDBType(), is("Impala"));
+        assertThat(connectionInfo.getDatabaseName(), is("test"));
+        assertThat(connectionInfo.getDatabasePeer(), is("localhost:21050"));
+    }
+    
+    @Test
+    public void testParseImpalaJDBCURLWithoutSchema() {
+        ConnectionInfo connectionInfo = new URLParser().parser("jdbc:impala://localhost:21050");
         assertThat(connectionInfo.getDBType(), is("Impala"));
         assertThat(connectionInfo.getDatabasePeer(), is("localhost:21050"));
     }


### PR DESCRIPTION
### Fix Impala Jdbc URL (including schema without properties) parsing exception
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
When set up Impala jdbc url like `jdbc:impala://localhost:21050/test` without properties behind, it may cause exception `java.lang.NumberFormatException: For input string: "21050/test"`. To avoid conversion exceptions, optimized the positioning of URL params.

- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
