### PR TITLE
Make the beforeMethod of DriverConnectInterceptor compatible with unk…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Release Notes.
 * Add a netty-http 4.1.x plugin to trace HTTP requests.
 * Fix Impala Jdbc URL (including schema without properties) parsing exception.
 * Optimize byte-buddy type description performance.
+* Make the beforeMethod of DriverConnectInterceptor compatible with unknown JDBC URLs.
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParser.java
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/src/main/java/org/apache/skywalking/apm/plugin/jdbc/connectionurl/parser/URLParser.java
@@ -60,7 +60,10 @@ public class URLParser {
             parser = new ImpalaJdbcURLParser(url);
         } else if (lowerCaseUrl.startsWith(CLICKHOUSE_JDBC_URK_PREFIX)) {
             parser = new ClickHouseURLParser(url);
+        } else {
+            return null;
         }
+
         return parser.parse();
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/ConnectionCache.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/ConnectionCache.java
@@ -38,6 +38,9 @@ public class ConnectionCache {
     }
 
     public static void save(ConnectionInfo connectionInfo) {
+        if (connectionInfo == null) {
+            return;
+        }
         for (String conn : connectionInfo.getDatabasePeer().split(CONNECTION_SPLIT_STR)) {
             if (!StringUtil.isEmpty(conn)) {
                 CONNECTIONS_MAP.putIfAbsent(conn + "/" + connectionInfo.getDatabaseName(), connectionInfo);


### PR DESCRIPTION
…nown JDBC URLs.

<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).


## problem
```java
ERROR 2023-11-06 16:46:59.170 defaultEventExecutorGroup-2-59 InstMethodsInter : class[class com.mysql.jdbc.Driver] before method[connect] intercept failure 
java.lang.NullPointerException
        at org.apache.skywalking.apm.plugin.jdbc.connectionurl.parser.URLParser.parser(URLParser.java:64)
        at org.apache.skywalking.apm.plugin.jdbc.mysql.DriverConnectInterceptor.beforeMethod(DriverConnectInterceptor.java:36)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:76)
        at com.mysql.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java)
        at java.sql.DriverManager.getConnection(DriverManager.java:664)
        at java.sql.DriverManager.getConnection(DriverManager.java:208)
        at org.apache.ibatis.datasource.unpooled.UnpooledDataSource.doGetConnection(UnpooledDataSource.java:201)
        at org.apache.ibatis.datasource.unpooled.UnpooledDataSource.doGetConnection(UnpooledDataSource.java:196)
        at org.apache.ibatis.datasource.unpooled.UnpooledDataSource.getConnection(UnpooledDataSource.java:93)
        at org.apache.ibatis.transaction.jdbc.JdbcTransaction.openConnection(JdbcTransaction.java:138)
        at org.apache.ibatis.transaction.jdbc.JdbcTransaction.getConnection(JdbcTransaction.java:60)
        at org.apache.ibatis.executor.BaseExecutor.getConnection(BaseExecutor.java:336)
```

## Causes
I used two JDBC drivers in a project, one of which was developed by NetEase and the other was mysql Driver.
At present, all connections are obtained by calling the [getConnection method of DriverManager](https://github.com/openjdk/jdk/blob/8fb94fd4fe46bc12885c7cc0c7ebbbc10fba47e5/src/java.sql/share/classes/java/sql/DriverManager.java#L676).

Therefore, when the self-developed jdbc url is parsed in the beforeMethod method of DriverConnectInterceptor, a null pointer exception occurs.

## how to fix it
Make the beforeMethod of DriverConnectInterceptor compatible with unknown JDBC URLs.

