### PR TITLE
Fix NoSuchMethodError in mvc-annotation-commons&change deprecated method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Release Notes.
 9.2.0
 ------------------
 
+* Fix NoSuchMethodError in mvc-annotation-commons and change deprecated method 
+
 
 #### Documentation
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/commons/interceptor/AbstractMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/src/main/java/org/apache/skywalking/apm/plugin/spring/mvc/commons/interceptor/AbstractMethodInterceptor.java
@@ -168,11 +168,11 @@ public abstract class AbstractMethodInterceptor implements InstanceMethodsAround
                         next.setHeadValue(serverHttpRequest.getHeaders().getFirst(next.getHeadKey()));
                     }
 
-                    String operationName = this.buildOperationName(method, serverHttpRequest.getMethodValue(),
+                    String operationName = this.buildOperationName(method, serverHttpRequest.getMethod().name(),
                                                                    (EnhanceRequireObjectCache) objInst.getSkyWalkingDynamicField());
                     AbstractSpan span = ContextManager.createEntrySpan(operationName, contextCarrier);
                     Tags.URL.set(span, serverHttpRequest.getURI().toString());
-                    Tags.HTTP.METHOD.set(span, serverHttpRequest.getMethodValue());
+                    Tags.HTTP.METHOD.set(span, serverHttpRequest.getMethod().name());
                     span.setComponent(ComponentsDefine.SPRING_MVC_ANNOTATION);
                     SpanLayer.asHttp(span);
 

--- a/test/plugin/scenarios/spring-6.x-scenario/pom.xml
+++ b/test/plugin/scenarios/spring-6.x-scenario/pom.xml
@@ -29,8 +29,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.version>1.8</compiler.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <compiler.version>17</compiler.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <test.framework.version>6.0.0</test.framework.version>
         <test.framework>spring</test.framework>
     </properties>
@@ -62,30 +62,36 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.3</version>
+            <version>2.14.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.2</version>
+            <version>2.9.1</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.0.0</version>
+            <version>4.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8.1</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8.1</version>
+            <version>2.19.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
         </dependency>
     </dependencies>
 
@@ -101,6 +107,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
+                    <parameters>true</parameters>
                     <source>${compiler.version}</source>
                     <target>${compiler.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>

--- a/test/plugin/scenarios/spring-6.x-scenario/support-version.list
+++ b/test/plugin/scenarios/spring-6.x-scenario/support-version.list
@@ -15,3 +15,5 @@
 # limitations under the License.
 
 6.0.4
+6.1.0
+6.1.1


### PR DESCRIPTION
### Fix [NoSuchMethodError in mvc-annotation-commons&change deprecated method](https://github.com/apache/skywalking/issues/11652)
- [x] Add a unit test to verify that the fix works. 
current test scenarios(spring-4.3.x-scenario, spring-6.x-scenario) passed.
- [x] Explain briefly why the bug exists and how to fix it.


- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes https://github.com/apache/skywalking/issues/11652.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
