### PR TITLE
Support for tracing Spring-Webflux request in Webflux 6.x plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@ Release Notes.
 9.2.0
 ------------------
 
-* Fix NoSuchMethodError in mvc-annotation-commons and change deprecated method 
-
+* Fix NoSuchMethodError in mvc-annotation-commons and change deprecated method
+* Support for tracing Spring-Webflux request in Webflux 6.x plugin.
 
 #### Documentation
 

--- a/apm-application-toolkit/apm-toolkit-webflux-6.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-webflux-6.x/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-application-toolkit</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>9.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-toolkit-webflux-6.x</artifactId>
+
+    <properties>
+        <spring-webflux.version>6.0.0</spring-webflux.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>${spring-webflux.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/apm-application-toolkit/apm-toolkit-webflux-6.x/src/main/java/org/apache/skywalking/apm/toolkit/webflux/v6/WebFluxSkyWalkingOperators.java
+++ b/apm-application-toolkit/apm-toolkit-webflux-6.x/src/main/java/org/apache/skywalking/apm/toolkit/webflux/v6/WebFluxSkyWalkingOperators.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.webflux.v6;
+
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Signal;
+import reactor.core.publisher.SignalType;
+import reactor.util.context.ContextView;
+
+/**
+ * WebFlux operators that are capable to reuse tracing context from Reactor's Context.
+ */
+public final class WebFluxSkyWalkingOperators {
+
+    private WebFluxSkyWalkingOperators() {
+        throw new IllegalStateException("You can't instantiate a utility class");
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param signalType - Reactor's signal type
+     * @param runnable   - lambda to execute within the tracing context
+     * @return consumer of a signal
+     */
+    public static Consumer<Signal<?>> continueTracing(SignalType signalType, Runnable runnable) {
+        return signal -> {
+            if (signalType != signal.getType()) {
+                return;
+            }
+            continueTracing(runnable).accept(signal);
+        };
+    }
+
+    /**
+     * Wraps a consumer with a local span and continue tracing context.
+     *
+     * @param signalType - Reactor's signal type
+     * @param consumer   - lambda to execute within the tracing context
+     * @return consumer of a signal
+     */
+    public static Consumer<Signal> continueTracing(SignalType signalType, Consumer<Signal> consumer) {
+        return signal -> {
+            if (signalType != signal.getType()) {
+                return;
+            }
+            continueTracing(signal.getContextView(), () -> consumer.accept(signal));
+        };
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param runnable - lambda to execute within the tracing context
+     * @return consumer of a signal
+     */
+    public static Consumer<Signal> continueTracing(Runnable runnable) {
+        return signal -> {
+            ContextView context = signal.getContextView();
+            continueTracing(context, runnable);
+        };
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param context  - Reactor context that contains the tracing context
+     * @param runnable - lambda to execute within the tracing context
+     */
+    public static void continueTracing(ContextView context, Runnable runnable) {
+        runnable.run();
+    }
+
+    /**
+     * Wraps a callable with a local span and continue tracing context.
+     *
+     * @param context  - Reactor context that contains the tracing context
+     * @param callable - lambda to execute within the tracing context
+     * @param <T>      callable's return type
+     * @return value from the callable
+     */
+    public static <T> T continueTracing(ContextView context, Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            return sneakyThrow(e);
+        }
+    }
+
+    /**
+     * Wraps a callable with a local span and continue tracing context.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @param callable          - lambda to execute within the tracing context
+     * @param <T>               callable's return type
+     * @return value from the callable
+     */
+    public static <T> T continueTracing(ServerWebExchange serverWebExchange, Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            return sneakyThrow(e);
+        }
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @param runnable          - lambda to execute within the tracing context
+     */
+    public static void continueTracing(ServerWebExchange serverWebExchange, Runnable runnable) {
+        runnable.run();
+    }
+
+    private static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
+}

--- a/apm-application-toolkit/apm-toolkit-webflux-6.x/src/main/java/org/apache/skywalking/apm/toolkit/webflux/v6/WebFluxSkyWalkingTraceContext.java
+++ b/apm-application-toolkit/apm-toolkit-webflux-6.x/src/main/java/org/apache/skywalking/apm/toolkit/webflux/v6/WebFluxSkyWalkingTraceContext.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.webflux.v6;
+
+import org.springframework.web.server.ServerWebExchange;
+
+import java.util.Optional;
+
+/**
+ * TraceContext for WebFlux.
+ */
+public class WebFluxSkyWalkingTraceContext {
+    /**
+     * Try to get the traceId of current trace context.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @return traceId, if it exists, or empty {@link String}.
+     */
+    public static String traceId(ServerWebExchange serverWebExchange) {
+        return "";
+    }
+
+    /**
+     * Try to get the segmentId of current trace context.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @return segmentId, if it exists, or empty {@link String}.
+     */
+    public static String segmentId(ServerWebExchange serverWebExchange) {
+        return "";
+    }
+
+    /**
+     * Try to get the spanId of current trace context. The spanId is a negative number when the trace context is
+     * missing.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @return spanId, if it exists, or empty {@link String}.
+     */
+    public static int spanId(ServerWebExchange serverWebExchange) {
+        return -1;
+    }
+
+    /**
+     * Try to get the custom value from trace context.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @return custom data value.
+     */
+    public static Optional<String> getCorrelation(ServerWebExchange serverWebExchange, String key) {
+        return Optional.empty();
+    }
+
+    /**
+     * Put the custom key/value into trace context.
+     *
+     * @param serverWebExchange - EnhancedInstance that contains the tracing context
+     * @return previous value if it exists.
+     */
+    public static Optional<String> putCorrelation(ServerWebExchange serverWebExchange, String key, String value) {
+        return Optional.empty();
+    }
+}

--- a/apm-application-toolkit/pom.xml
+++ b/apm-application-toolkit/pom.xml
@@ -37,5 +37,6 @@
         <module>apm-toolkit-micrometer-1.10</module>
         <module>apm-toolkit-kafka</module>
         <module>apm-toolkit-webflux</module>
+        <module>apm-toolkit-webflux-6.x</module>
     </modules>
 </project>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
@@ -44,6 +44,7 @@
         <module>scheduled-annotation-plugin</module>
         <module>spring-webflux-5.x-webclient-plugin</module>
         <module>resttemplate-commons</module>
+        <module>spring-webflux-6.x-webclient-plugin</module>
     </modules>
     <packaging>pom</packaging>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/webclient/define/WebFluxWebClientInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/webclient/define/WebFluxWebClientInstrumentation.java
@@ -18,8 +18,11 @@
 
 package org.apache.skywalking.apm.plugin.spring.webflux.v5.webclient.define;
 
+import java.util.Collections;
+import java.util.List;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.WitnessMethod;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.v2.InstanceMethodsInterceptV2Point;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
@@ -32,6 +35,8 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 public class WebFluxWebClientInstrumentation extends ClassInstanceMethodsEnhancePluginDefineV2 {
     private static final String ENHANCE_CLASS = "org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction";
     private static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.spring.webflux.v5.webclient.WebFluxWebClientInterceptor";
+    private static final String WEBFLUX_CONTEXT_WRITE_CLASS = "reactor.core.publisher.Mono";
+    private static final String WEBFLUX_CONTEXT_WRITE_METHOD = "subscriberContext";
 
     @Override
     protected ClassMatch enhanceClass() {
@@ -45,28 +50,34 @@ public class WebFluxWebClientInstrumentation extends ClassInstanceMethodsEnhance
 
     @Override
     public InstanceMethodsInterceptV2Point[] getInstanceMethodsInterceptV2Points() {
-        return new InstanceMethodsInterceptV2Point[]{
-                new InstanceMethodsInterceptV2Point() {
-                    @Override
-                    public ElementMatcher<MethodDescription> getMethodsMatcher() {
-                        return named("exchange");
-                    }
-
-                    @Override
-                    public String getMethodsInterceptorV2() {
-                        return INTERCEPT_CLASS;
-                    }
-
-                    @Override
-                    public boolean isOverrideArgs() {
-                        return false;
-                    }
+        return new InstanceMethodsInterceptV2Point[] {
+            new InstanceMethodsInterceptV2Point() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("exchange");
                 }
+
+                @Override
+                public String getMethodsInterceptorV2() {
+                    return INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
         };
     }
 
     @Override
     public StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
         return new StaticMethodsInterceptPoint[0];
+    }
+
+    @Override
+    protected List<WitnessMethod> witnessMethods() {
+        return Collections.singletonList(
+            new WitnessMethod(WEBFLUX_CONTEXT_WRITE_CLASS, named(WEBFLUX_CONTEXT_WRITE_METHOD)));
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>spring-plugins</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>9.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-webflux-6.x-webclient-plugin</artifactId>
+
+    <url>http://maven.apache.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/BodyInserterRequestInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/BodyInserterRequestInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient;
+
+import org.apache.skywalking.apm.agent.core.context.CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.springframework.http.client.reactive.ClientHttpRequest;
+
+import java.lang.reflect.Method;
+
+public class BodyInserterRequestInterceptor implements InstanceMethodsAroundInterceptor {
+
+    @Override
+    public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                             MethodInterceptResult result) throws Throwable {
+        ClientHttpRequest clientHttpRequest = (ClientHttpRequest) allArguments[0];
+        ContextCarrier contextCarrier = (ContextCarrier) objInst.getSkyWalkingDynamicField();
+        CarrierItem next = contextCarrier.items();
+        while (next.hasNext()) {
+            next = next.next();
+            clientHttpRequest.getHeaders().set(next.getHeadKey(), next.getHeadValue());
+        }
+    }
+
+    @Override
+    public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                              Object ret) throws Throwable {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+                                      Class<?>[] argumentsTypes, Throwable t) {
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/WebFluxWebClientInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/WebFluxWebClientInterceptor.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient;
+
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.v2.InstanceMethodsAroundInterceptorV2;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.v2.MethodInvocationContext;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.Optional;
+
+public class WebFluxWebClientInterceptor implements InstanceMethodsAroundInterceptorV2 {
+
+    @Override
+    public void beforeMethod(EnhancedInstance objInst,
+                             Method method,
+                             Object[] allArguments,
+                             Class<?>[] argumentsTypes,
+                             MethodInvocationContext context) throws Throwable {
+
+    }
+
+    @Override
+    public Object afterMethod(EnhancedInstance objInst,
+                              Method method,
+                              Object[] allArguments,
+                              Class<?>[] argumentsTypes,
+                              Object ret,
+                              MethodInvocationContext context) throws Throwable {
+        // fix the problem that allArgument[0] may be null
+        if (allArguments[0] == null) {
+            return ret;
+        }
+        Mono<ClientResponse> ret1 = (Mono<ClientResponse>) ret;
+        return Mono.deferContextual(ctx -> {
+
+            ClientRequest request = (ClientRequest) allArguments[0];
+            URI uri = request.url();
+            final String operationName = getRequestURIString(uri);
+            final String remotePeer = getIPAndPort(uri);
+            AbstractSpan span = ContextManager.createExitSpan(operationName, remotePeer);
+
+            // get ContextSnapshot from reactor context,  the snapshot is set to reactor context by any other plugin
+            // such as DispatcherHandlerHandleMethodInterceptor in spring-webflux-5.x-plugin
+            final Optional<Object> optional = ctx.getOrEmpty("SKYWALKING_CONTEXT_SNAPSHOT");
+            optional.ifPresent(snapshot -> ContextManager.continued((ContextSnapshot) snapshot));
+
+            //set components name
+            span.setComponent(ComponentsDefine.SPRING_WEBCLIENT);
+            Tags.URL.set(span, uri.toString());
+            Tags.HTTP.METHOD.set(span, request.method().toString());
+            SpanLayer.asHttp(span);
+
+            final ContextCarrier contextCarrier = new ContextCarrier();
+            ContextManager.inject(contextCarrier);
+            if (request instanceof EnhancedInstance) {
+                ((EnhancedInstance) request).setSkyWalkingDynamicField(contextCarrier);
+            }
+
+            //user async interface
+            span.prepareForAsync();
+            ContextManager.stopSpan();
+            return ret1.doOnSuccess(clientResponse -> {
+                HttpStatusCode httpStatus = clientResponse.statusCode();
+                if (httpStatus != null) {
+                    Tags.HTTP_RESPONSE_STATUS_CODE.set(span, httpStatus.value());
+                    if (httpStatus.isError()) {
+                        span.errorOccurred();
+                    }
+                }
+            }).doOnError(span::log).doFinally(s -> {
+                span.asyncFinish();
+            });
+        });
+    }
+
+    @Override
+    public void handleMethodException(EnhancedInstance objInst,
+                                      Method method,
+                                      Object[] allArguments,
+                                      Class<?>[] argumentsTypes,
+                                      Throwable t,
+                                      MethodInvocationContext context) {
+        AbstractSpan activeSpan = ContextManager.activeSpan();
+        activeSpan.errorOccurred();
+        activeSpan.log(t);
+    }
+
+    private String getRequestURIString(URI uri) {
+        String requestPath = uri.getPath();
+        return requestPath != null && requestPath.length() > 0 ? requestPath : "/";
+    }
+
+    // return ip:port
+    private String getIPAndPort(URI uri) {
+        return uri.getHost() + ":" + uri.getPort();
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/define/BodyInserterRequestInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/define/BodyInserterRequestInstrumentation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.skywalking.apm.agent.core.plugin.bytebuddy.ArgumentTypeNameMatch.takesArgumentWithType;
+import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
+public class BodyInserterRequestInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[0];
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[] {
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("writeTo").and(
+                        takesArgumentWithType(0, "org.springframework.http.client.reactive.ClientHttpRequest"));
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return "org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient.BodyInserterRequestInterceptor";
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName(
+            "org.springframework.web.reactive.function.client.DefaultClientRequestBuilder$BodyInserterRequest");
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/define/WebFluxWebClientInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/webclient/define/WebFluxWebClientInstrumentation.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.WitnessMethod;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.v2.InstanceMethodsInterceptV2Point;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.v2.ClassInstanceMethodsEnhancePluginDefineV2;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import java.util.Collections;
+import java.util.List;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class WebFluxWebClientInstrumentation extends ClassInstanceMethodsEnhancePluginDefineV2 {
+    private static final String ENHANCE_CLASS = "org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction";
+    private static final String INTERCEPT_CLASS = "org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient.WebFluxWebClientInterceptor";
+    private static final String WEBFLUX_CONTEXT_WRITE_CLASS = "reactor.core.publisher.Mono";
+    private static final String WEBFLUX_CONTEXT_WRITE_METHOD = "deferContextual";
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[0];
+    }
+
+    @Override
+    public InstanceMethodsInterceptV2Point[] getInstanceMethodsInterceptV2Points() {
+        return new InstanceMethodsInterceptV2Point[] {
+            new InstanceMethodsInterceptV2Point() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("exchange");
+                }
+
+                @Override
+                public String getMethodsInterceptorV2() {
+                    return INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    public StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
+        return new StaticMethodsInterceptPoint[0];
+    }
+
+    @Override
+    protected List<WitnessMethod> witnessMethods() {
+        return Collections.singletonList(
+            new WitnessMethod(WEBFLUX_CONTEXT_WRITE_CLASS, named(WEBFLUX_CONTEXT_WRITE_METHOD)));
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/src/main/resources/skywalking-plugin.def
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spring-webflux-6.x-webclient=org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient.define.BodyInserterRequestInstrumentation
+spring-webflux-6.x-webclient=org.apache.skywalking.apm.plugin.spring.webflux.v6.webclient.define.WebFluxWebClientInstrumentation

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-toolkit-activation</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>9.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-toolkit-webflux-6.x-activation</artifactId>
+
+    <properties>
+        <spring-webflux.version>6.0.0</spring-webflux.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>${spring-webflux.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingCorrelationContextGetInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingCorrelationContextGetInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class WebFluxSkyWalkingCorrelationContextGetInterceptor extends WebFluxSkyWalkingStaticMethodsAroundInterceptor {
+
+    @Override
+    public void beforeMethod(Class clazz,
+                             Method method,
+                             Object[] allArguments,
+                             Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+        final ContextSnapshot contextSnapshot = getContextSnapshot(allArguments[0]);
+        if (contextSnapshot == null || contextSnapshot.getCorrelationContext() == null) {
+            return;
+        }
+
+        final String key = (String) allArguments[1];
+        final Optional<String> data = contextSnapshot.getCorrelationContext().get(key);
+
+        result.defineReturnValue(data);
+    }
+
+    @Override
+    public Object afterMethod(Class clazz,
+                              Method method,
+                              Object[] allArguments,
+                              Class<?>[] parameterTypes,
+                              Object ret) {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz,
+                                      Method method,
+                                      Object[] allArguments,
+                                      Class<?>[] parameterTypes,
+                                      Throwable t) {
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingCorrelationContextPutInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingCorrelationContextPutInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class WebFluxSkyWalkingCorrelationContextPutInterceptor extends WebFluxSkyWalkingStaticMethodsAroundInterceptor {
+
+    @Override
+    public void beforeMethod(Class clazz,
+                             Method method,
+                             Object[] allArguments,
+                             Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+        final ContextSnapshot contextSnapshot = getContextSnapshot(allArguments[0]);
+        if (contextSnapshot == null || contextSnapshot.getCorrelationContext() == null) {
+            return;
+        }
+
+        final String key = (String) allArguments[1];
+        final String value = (String) allArguments[2];
+        final Optional<String> previous = contextSnapshot.getCorrelationContext().put(key, value);
+
+        result.defineReturnValue(previous);
+    }
+
+    @Override
+    public Object afterMethod(Class clazz,
+                              Method method,
+                              Object[] allArguments,
+                              Class<?>[] parameterTypes,
+                              Object ret) {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz,
+                                      Method method,
+                                      Object[] allArguments,
+                                      Class<?>[] parameterTypes,
+                                      Throwable t) {
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingOperatorsActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingOperatorsActivation.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassStaticMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
+/**
+ *
+ */
+public class WebFluxSkyWalkingOperatorsActivation extends ClassStaticMethodsEnhancePluginDefine {
+
+    public static final String INTERCEPT_CLASS =
+        "org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingOperatorsInterceptor";
+    
+    public static final String ENHANCE_CLASS =
+        "org.apache.skywalking.apm.toolkit.webflux.v6.WebFluxSkyWalkingOperators";
+    public static final String ENHANCE_METHOD = "continueTracing";
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName(ENHANCE_CLASS);
+    }
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return null;
+    }
+
+    @Override
+    public StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
+        return new StaticMethodsInterceptPoint[] {
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_METHOD).and(takesArguments(2))
+                                                .and(takesArgument(0, named("reactor.util.context.ContextView"))
+                                                         .or(takesArgument(0, named(
+                                                             "org.springframework.web.server.ServerWebExchange"))));
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[]{"reactor.util.context.ContextView"};
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingOperatorsInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingOperatorsInterceptor.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.lang.reflect.Method;
+import reactor.util.context.ContextView;
+
+/**
+ *
+ */
+public class WebFluxSkyWalkingOperatorsInterceptor extends WebFluxSkyWalkingStaticMethodsAroundInterceptor {
+
+    @Override
+    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+        // get ContextSnapshot from reactor context,  the snapshot is set to reactor context by any other plugin
+        // such as DispatcherHandlerHandleMethodInterceptor in spring-webflux-5.x-plugin
+        if (parameterTypes[0] == ContextView.class) {
+            ((ContextView) allArguments[0]).getOrEmpty("SKYWALKING_CONTEXT_SNAPSHOT")
+                                           .ifPresent(ctx -> {
+                                           ContextManager.createLocalSpan("WebFluxOperators/onNext")
+                                                         .setComponent(ComponentsDefine.SPRING_WEBFLUX);
+                                           ContextManager.continued((ContextSnapshot) ctx);
+                                       });
+        } else if (parameterTypes[0] == ServerWebExchange.class) {
+            EnhancedInstance instance = getInstance(allArguments[0]);
+            if (instance != null && instance.getSkyWalkingDynamicField() != null) {
+                ContextManager.createLocalSpan("WebFluxOperators/onNext").setComponent(ComponentsDefine.SPRING_WEBFLUX);
+                ContextManager.continued((ContextSnapshot) instance.getSkyWalkingDynamicField());
+            }
+        }
+    }
+
+    @Override
+    public Object afterMethod(Class clazz,
+                              Method method,
+                              Object[] allArguments,
+                              Class<?>[] parameterTypes,
+                              Object ret) {
+        ContextManager.stopSpan();
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                                      Throwable t) {
+        ContextManager.activeSpan().log(t);
+    }
+
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingSegmentIDInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingSegmentIDInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+
+import java.lang.reflect.Method;
+
+public class WebFluxSkyWalkingSegmentIDInterceptor extends WebFluxSkyWalkingStaticMethodsAroundInterceptor {
+
+    private static final ILog LOGGER = LogManager.getLogger(WebFluxSkyWalkingSegmentIDInterceptor.class);
+
+    @Override
+    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+        final ContextSnapshot contextSnapshot = getContextSnapshot(allArguments[0]);
+        if (contextSnapshot == null || contextSnapshot.getCorrelationContext() == null) {
+            return;
+        }
+        result.defineReturnValue(contextSnapshot.getTraceSegmentId());
+    }
+
+    @Override
+    public Object afterMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                              Object ret) {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                                      Throwable t) {
+        LOGGER.error("Failed to get segment Id.", t);
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingSpanIDInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingSpanIDInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+
+import java.lang.reflect.Method;
+
+public class WebFluxSkyWalkingSpanIDInterceptor extends WebFluxSkyWalkingStaticMethodsAroundInterceptor {
+
+    private static final ILog LOGGER = LogManager.getLogger(WebFluxSkyWalkingSpanIDInterceptor.class);
+
+    @Override
+    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+        final ContextSnapshot contextSnapshot = getContextSnapshot(allArguments[0]);
+        if (contextSnapshot == null || contextSnapshot.getCorrelationContext() == null) {
+            return;
+        }
+        result.defineReturnValue(contextSnapshot.getSpanId());
+    }
+
+    @Override
+    public Object afterMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                              Object ret) {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                                      Throwable t) {
+        LOGGER.error("Failed to getDefault span Id.", t);
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingStaticMethodsAroundInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingStaticMethodsAroundInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.StaticMethodsAroundInterceptor;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebExchangeDecorator;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
+
+import java.util.Optional;
+
+public abstract class WebFluxSkyWalkingStaticMethodsAroundInterceptor implements StaticMethodsAroundInterceptor {
+
+    protected EnhancedInstance getInstance(Object o) {
+        EnhancedInstance instance = null;
+        if (o instanceof DefaultServerWebExchange && o instanceof EnhancedInstance) {
+            instance = (EnhancedInstance) o;
+        } else if (o instanceof ServerWebExchangeDecorator) {
+            ServerWebExchange delegate = ((ServerWebExchangeDecorator) o).getDelegate();
+            return getInstance(delegate);
+        }
+        return instance;
+    }
+
+    protected ContextSnapshot getContextSnapshot(Object o) {
+        return Optional.ofNullable(getInstance(o))
+                       .map(EnhancedInstance::getSkyWalkingDynamicField)
+                       .filter(ContextSnapshot.class::isInstance)
+                       .map(ContextSnapshot.class::cast)
+                       .orElse(null);
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingTraceContextActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingTraceContextActivation.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassStaticMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+import org.apache.skywalking.apm.agent.core.plugin.match.NameMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class WebFluxSkyWalkingTraceContextActivation extends ClassStaticMethodsEnhancePluginDefine {
+
+    public static final String TRACE_ID_INTERCEPT_CLASS = "org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingTraceIDInterceptor";
+    public static final String SEGMENT_ID_INTERCEPT_CLASS = "org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingSegmentIDInterceptor";
+    public static final String SPAN_ID_INTERCEPT_CLASS = "org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingSpanIDInterceptor";
+    public static final String ENHANCE_CLASS = "org.apache.skywalking.apm.toolkit.webflux.v6.WebFluxSkyWalkingTraceContext";
+    public static final String ENHANCE_TRACE_ID_METHOD = "traceId";
+    public static final String ENHANCE_SEGMENT_ID_METHOD = "segmentId";
+    public static final String ENHANCE_SPAN_ID_METHOD = "spanId";
+    public static final String ENHANCE_GET_CORRELATION_METHOD = "getCorrelation";
+    public static final String INTERCEPT_GET_CORRELATION_CLASS = "org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingCorrelationContextGetInterceptor";
+    public static final String ENHANCE_PUT_CORRELATION_METHOD = "putCorrelation";
+    public static final String INTERCEPT_PUT_CORRELATION_CLASS = "org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingCorrelationContextPutInterceptor";
+
+    /**
+     * @return the target class, which needs active.
+     */
+    @Override
+    protected ClassMatch enhanceClass() {
+        return NameMatch.byName(ENHANCE_CLASS);
+    }
+
+    /**
+     * @return the collection of {@link StaticMethodsInterceptPoint}, represent the intercepted methods and their
+     * interceptors.
+     */
+    @Override
+    public StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
+        return new StaticMethodsInterceptPoint[] {
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_TRACE_ID_METHOD);
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return TRACE_ID_INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            },
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_SEGMENT_ID_METHOD);
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return SEGMENT_ID_INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            },
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_SPAN_ID_METHOD);
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return SPAN_ID_INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            },
+
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_GET_CORRELATION_METHOD);
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INTERCEPT_GET_CORRELATION_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            },
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_PUT_CORRELATION_METHOD);
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INTERCEPT_PUT_CORRELATION_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingTraceIDInterceptor.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/v6/WebFluxSkyWalkingTraceIDInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.activation.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+
+import java.lang.reflect.Method;
+
+public class WebFluxSkyWalkingTraceIDInterceptor extends WebFluxSkyWalkingStaticMethodsAroundInterceptor {
+
+    private static final ILog LOGGER = LogManager.getLogger(WebFluxSkyWalkingTraceIDInterceptor.class);
+
+    @Override
+    public void beforeMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                             MethodInterceptResult result) {
+        final ContextSnapshot contextSnapshot = getContextSnapshot(allArguments[0]);
+        if (contextSnapshot == null || contextSnapshot.getCorrelationContext() == null) {
+            return;
+        }
+        result.defineReturnValue(contextSnapshot.getTraceId().getId());
+    }
+
+    @Override
+    public Object afterMethod(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                              Object ret) {
+        return ret;
+    }
+
+    @Override
+    public void handleMethodException(Class clazz, Method method, Object[] allArguments, Class<?>[] parameterTypes,
+                                      Throwable t) {
+        LOGGER.error("Failed to getDefault trace Id.", t);
+    }
+}

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-6.x-activation/src/main/resources/skywalking-plugin.def
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+toolkit-webflux-6.x=org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingOperatorsActivation
+toolkit-webflux-6.x=org.apache.skywalking.apm.toolkit.activation.webflux.v6.WebFluxSkyWalkingTraceContextActivation

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/WebFluxSkyWalkingOperatorsActivation.java
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-activation/src/main/java/org/apache/skywalking/apm/toolkit/activation/webflux/WebFluxSkyWalkingOperatorsActivation.java
@@ -35,9 +35,9 @@ import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName
 public class WebFluxSkyWalkingOperatorsActivation extends ClassStaticMethodsEnhancePluginDefine {
 
     public static final String INTERCEPT_CLASS =
-            "org.apache.skywalking.apm.toolkit.activation.webflux.WebFluxSkyWalkingOperatorsInterceptor";
+        "org.apache.skywalking.apm.toolkit.activation.webflux.WebFluxSkyWalkingOperatorsInterceptor";
     public static final String ENHANCE_CLASS =
-            "org.apache.skywalking.apm.toolkit.webflux.WebFluxSkyWalkingOperators";
+        "org.apache.skywalking.apm.toolkit.webflux.WebFluxSkyWalkingOperators";
     public static final String ENHANCE_METHOD = "continueTracing";
 
     @Override
@@ -53,24 +53,29 @@ public class WebFluxSkyWalkingOperatorsActivation extends ClassStaticMethodsEnha
     @Override
     public StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
         return new StaticMethodsInterceptPoint[] {
-                new StaticMethodsInterceptPoint() {
-                    @Override
-                    public ElementMatcher<MethodDescription> getMethodsMatcher() {
-                        return named(ENHANCE_METHOD).and(takesArguments(2))
-                                .and(takesArgument(0, named("reactor.util.context.Context"))
-                                        .or(takesArgument(0, named("org.springframework.web.server.ServerWebExchange"))));
-                    }
-
-                    @Override
-                    public String getMethodsInterceptor() {
-                        return INTERCEPT_CLASS;
-                    }
-
-                    @Override
-                    public boolean isOverrideArgs() {
-                        return false;
-                    }
+            new StaticMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named(ENHANCE_METHOD).and(takesArguments(2))
+                                                .and(takesArgument(0, named("reactor.util.context.Context"))
+                                                         .or(takesArgument(0, named("org.springframework.web.server.ServerWebExchange"))));
                 }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return INTERCEPT_CLASS;
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
         };
+    }
+
+    @Override
+    protected String[] witnessClasses() {
+        return new String[]{"reactor.util.context.Context"};
     }
 }

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -36,6 +36,7 @@
         <module>apm-toolkit-micrometer-activation</module>
         <module>apm-toolkit-webflux-activation</module>
         <module>apm-toolkit-logging-common</module>
+        <module>apm-toolkit-webflux-6.x-activation</module>
     </modules>
 
     <artifactId>apm-toolkit-activation</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
@@ -35,6 +35,7 @@
         <module>spring-webflux-5.x-plugin</module>
         <module>resttemplate-6.x-plugin</module>
         <module>mvc-annotation-6.x-plugin</module>
+        <module>spring-webflux-6.x-plugin</module>
     </modules>
 
     <properties>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/define/DispatcherHandlerInstrumentation.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v5/define/DispatcherHandlerInstrumentation.java
@@ -18,8 +18,11 @@
 
 package org.apache.skywalking.apm.plugin.spring.webflux.v5.define;
 
+import java.util.Collections;
+import java.util.List;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.WitnessMethod;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
@@ -29,6 +32,9 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
 
 public class DispatcherHandlerInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+    private static final String WEBFLUX_CONTEXT_WRITE_CLASS = "reactor.core.publisher.Mono";
+    private static final String WEBFLUX_CONTEXT_WRITE_METHOD = "subscriberContext";
+
     @Override
     public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
         return new ConstructorInterceptPoint[0];
@@ -59,5 +65,11 @@ public class DispatcherHandlerInstrumentation extends ClassInstanceMethodsEnhanc
     @Override
     protected ClassMatch enhanceClass() {
         return byName("org.springframework.web.reactive.DispatcherHandler");
+    }
+
+    @Override
+    protected List<WitnessMethod> witnessMethods() {
+        return Collections.singletonList(
+            new WitnessMethod(WEBFLUX_CONTEXT_WRITE_CLASS, named(WEBFLUX_CONTEXT_WRITE_METHOD)));
     }
 }

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>optional-spring-plugins</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>9.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-spring-webflux-6.x-plugin</artifactId>
+
+    <url>http://maven.apache.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/DispatcherHandlerHandleMethodInterceptor.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/DispatcherHandlerHandleMethodInterceptor.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.context.CarrierItem;
+import org.apache.skywalking.apm.agent.core.context.ContextCarrier;
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags.HTTP;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebExchangeDecorator;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class DispatcherHandlerHandleMethodInterceptor implements InstanceMethodsAroundInterceptor {
+
+    @Override
+    public void beforeMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                             MethodInterceptResult result) throws Throwable {
+        EnhancedInstance instance = getInstance(allArguments[0]);
+
+        ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
+
+        ContextCarrier carrier = new ContextCarrier();
+        CarrierItem next = carrier.items();
+        HttpHeaders headers = exchange.getRequest().getHeaders();
+        while (next.hasNext()) {
+            next = next.next();
+            List<String> header = headers.get(next.getHeadKey());
+            if (header != null && header.size() > 0) {
+                next.setHeadValue(header.get(0));
+            }
+        }
+
+        AbstractSpan span = ContextManager.createEntrySpan(exchange.getRequest().getURI().getPath(), carrier);
+
+        if (instance != null && instance.getSkyWalkingDynamicField() != null) {
+            ContextManager.continued((ContextSnapshot) instance.getSkyWalkingDynamicField());
+        }
+        span.setComponent(ComponentsDefine.SPRING_WEBFLUX);
+        SpanLayer.asHttp(span);
+        Tags.URL.set(span, exchange.getRequest().getURI().toString());
+        HTTP.METHOD.set(span, exchange.getRequest().getMethod().name());
+        instance.setSkyWalkingDynamicField(ContextManager.capture());
+        span.prepareForAsync();
+        ContextManager.stopSpan(span);
+
+        exchange.getAttributes().put("SKYWALKING_SPAN", span);
+    }
+
+    private void maybeSetPattern(AbstractSpan span, ServerWebExchange exchange) {
+        if (span != null) {
+            PathPattern pathPattern = exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+            //check if the best matching pattern matches url in request
+            //to avoid operationName overwritten by fallback url
+            if (pathPattern != null && pathPattern.matches(exchange.getRequest().getPath().pathWithinApplication())) {
+                span.setOperationName(pathPattern.getPatternString());
+            }
+        }
+
+    }
+
+    @Override
+    public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes,
+                              Object ret) throws Throwable {
+
+        ServerWebExchange exchange = (ServerWebExchange) allArguments[0];
+
+        AbstractSpan span = (AbstractSpan) exchange.getAttributes().get("SKYWALKING_SPAN");
+        Mono<Void> monoReturn = (Mono<Void>) ret;
+
+        // add skywalking context snapshot to reactor context.
+        EnhancedInstance instance = getInstance(allArguments[0]);
+        if (instance != null && instance.getSkyWalkingDynamicField() != null) {
+            monoReturn = monoReturn.contextWrite(
+                c -> c.put("SKYWALKING_CONTEXT_SNAPSHOT", instance.getSkyWalkingDynamicField()));
+        }
+
+        return monoReturn.doFinally(s -> {
+
+            if (span != null) {
+                maybeSetPattern(span, exchange);
+                try {
+
+                    HttpStatusCode httpStatus = exchange.getResponse().getStatusCode();
+                    // fix webflux-2.0.0-2.1.0 version have bug. httpStatus is null. not support
+                    if (httpStatus != null) {
+                        Tags.HTTP_RESPONSE_STATUS_CODE.set(span, httpStatus.value());
+                        if (httpStatus.isError()) {
+                            span.errorOccurred();
+                        }
+                    }
+                } finally {
+                    span.asyncFinish();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void handleMethodException(EnhancedInstance objInst, Method method, Object[] allArguments,
+                                      Class<?>[] argumentsTypes, Throwable t) {
+    }
+
+    public static EnhancedInstance getInstance(Object o) {
+        EnhancedInstance instance = null;
+        if (o instanceof DefaultServerWebExchange) {
+            instance = (EnhancedInstance) o;
+        } else if (o instanceof ServerWebExchangeDecorator) {
+            ServerWebExchange delegate = ((ServerWebExchangeDecorator) o).getDelegate();
+            return getInstance(delegate);
+        }
+        return instance;
+    }
+
+}

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/ServerWebExchangeConstructorInterceptor.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/ServerWebExchangeConstructorInterceptor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6;
+
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
+
+public class ServerWebExchangeConstructorInterceptor implements InstanceConstructorInterceptor {
+    @Override
+    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    }
+}

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/define/DispatcherHandlerInstrumentation.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/define/DispatcherHandlerInstrumentation.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.WitnessMethod;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import java.util.Collections;
+import java.util.List;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
+public class DispatcherHandlerInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+    private static final String WEBFLUX_CONTEXT_WRITE_CLASS = "reactor.core.publisher.Mono";
+    private static final String WEBFLUX_CONTEXT_WRITE_METHOD = "contextWrite";
+
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[0];
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[] {
+            new InstanceMethodsInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getMethodsMatcher() {
+                    return named("handle");
+                }
+
+                @Override
+                public String getMethodsInterceptor() {
+                    return "org.apache.skywalking.apm.plugin.spring.webflux.v6.DispatcherHandlerHandleMethodInterceptor";
+                }
+
+                @Override
+                public boolean isOverrideArgs() {
+                    return false;
+                }
+            }
+        };
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName("org.springframework.web.reactive.DispatcherHandler");
+    }
+
+    @Override
+    protected List<WitnessMethod> witnessMethods() {
+        return Collections.singletonList(
+            new WitnessMethod(WEBFLUX_CONTEXT_WRITE_CLASS, named(WEBFLUX_CONTEXT_WRITE_METHOD)));
+    }
+}

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/define/ServerWebExchangeInstrumentation.java
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/spring/webflux/v6/define/ServerWebExchangeInstrumentation.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.spring.webflux.v6.define;
+
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassInstanceMethodsEnhancePluginDefine;
+import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
+public class ServerWebExchangeInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {
+    @Override
+    public ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
+        return new ConstructorInterceptPoint[] {
+            new ConstructorInterceptPoint() {
+                @Override
+                public ElementMatcher<MethodDescription> getConstructorMatcher() {
+                    return any();
+                }
+
+                @Override
+                public String getConstructorInterceptor() {
+                    return "org.apache.skywalking.apm.plugin.spring.webflux.v6.ServerWebExchangeConstructorInterceptor";
+                }
+            }
+        };
+    }
+
+    @Override
+    public InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
+        return new InstanceMethodsInterceptPoint[0];
+    }
+
+    @Override
+    protected ClassMatch enhanceClass() {
+        return byName("org.springframework.web.server.adapter.DefaultServerWebExchange");
+    }
+}

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/src/main/resources/skywalking-plugin.def
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spring-webflux-6.x=org.apache.skywalking.apm.plugin.spring.webflux.v6.define.DispatcherHandlerInstrumentation
+spring-webflux-6.x=org.apache.skywalking.apm.plugin.spring.webflux.v6.define.ServerWebExchangeInstrumentation

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,6 @@
                         <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                         <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
 <sourceDirectory>scenarios/resttemplate-6.x-scenario</sourceDirectory>
-<sourceDirectory>scenarios/spring-scenario</sourceDirectory>
                     </sourceDirectories>
                     <resourceIncludes>
                         **/*.properties,

--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,7 @@
                         <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
                         <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
 <sourceDirectory>scenarios/resttemplate-6.x-scenario</sourceDirectory>
+<sourceDirectory>scenarios/spring-scenario</sourceDirectory>
                     </sourceDirectories>
                     <resourceIncludes>
                         **/*.properties,

--- a/test/plugin/scenarios/webflux-6.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/config/expectedData.yaml
@@ -1,0 +1,452 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+segmentItems:
+- serviceName: webflux-projectB-scenario
+  segmentSize: nq 0
+  segments:
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/success
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/success'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/error
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: true
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/error'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '500'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 2, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/{test}
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/foo'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 3, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/{test}
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/loo'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 4, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/route/{test}
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/route/success'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 5, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/route/{test}
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: true
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/route/error'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '500'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 6, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /**
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: true
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/notFound'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '404'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 7, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/mono/hello
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/mono/hello'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 8, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'  
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/success
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      skipAnalysis: 'false'
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/success'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}    
+      refs:
+      - {parentEndpoint: WebFluxOperators/onNext, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 1, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/success
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: not null
+      skipAnalysis: 'false'
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/success'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+    - operationName: WebFluxOperators/onNext
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Unknown
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Local
+      peer: ''
+      refs:
+      - {parentEndpoint: /testcase/annotation/mono/onnext, networkAddress: '', refType: CrossThread,
+        parentSpanId: 0, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'       
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/mono/onnext
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/mono/onnext'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: 'GET:/projectA/testcase', networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 9, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'     
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/webclient/server
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 67
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/webclient/server'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      refs:
+      - {parentEndpoint: GET:/projectA/testcase, networkAddress: 'localhost:18080', refType: CrossProcess,
+        parentSpanId: 10, parentTraceSegmentId: not null, parentServiceInstance: not
+          null, parentService: not null, traceId: not null}
+      skipAnalysis: 'false'
+- serviceName: webflux-projectA-scenario
+  segmentSize: nq 0
+  segments:
+  - segmentId: not null
+    spans:
+    - operationName: /testcase/annotation/success
+      parentSpanId: 0
+      spanId: 1
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/annotation/error
+      parentSpanId: 0
+      spanId: 2
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: true
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '500'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/annotation/foo
+      parentSpanId: 0
+      spanId: 3
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: localhost:18080
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/foo'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/annotation/loo
+      parentSpanId: 0
+      spanId: 4
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: localhost:18080
+      tags:
+      - {key: url, value: 'http://localhost:18080/testcase/annotation/loo'}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/route/success
+      parentSpanId: 0
+      spanId: 5
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/route/error
+      parentSpanId: 0
+      spanId: 6
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: true
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '500'}
+      skipAnalysis: 'false'
+    - operationName: /notFound
+      parentSpanId: 0
+      spanId: 7
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: true
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '404'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/annotation/mono/hello
+      parentSpanId: 0
+      spanId: 8
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'
+    - operationName: /testcase/annotation/mono/onnext
+      parentSpanId: 0
+      spanId: 9
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 2
+      isError: false
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'  
+    - operationName: /testcase/webclient/server
+      parentSpanId: 0
+      spanId: 10
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 99
+      isError: false
+      spanType: Exit
+      peer: not null
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'
+    - operationName: GET:/projectA/testcase
+      parentSpanId: -1
+      spanId: 0
+      spanLayer: Http
+      startTime: not null
+      endTime: not null
+      componentId: 1
+      isError: false
+      spanType: Entry
+      peer: ''
+      tags:
+      - {key: url, value: not null}
+      - {key: http.method, value: GET}
+      - {key: http.status_code, value: '200'}
+      skipAnalysis: 'false'

--- a/test/plugin/scenarios/webflux-6.x-scenario/configuration.yml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/configuration.yml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+type: jvm
+entryService: http://localhost:8080/projectA/testcase
+healthCheck: http://localhost:8080/projectA/healthCheck
+runningMode: with_optional
+startScript: ./bin/startup.sh
+withPlugins: apm-spring-webflux-6.x-plugin-*.jar

--- a/test/plugin/scenarios/webflux-6.x-scenario/pom.xml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.skywalking</groupId>
+    <artifactId>webflux-6.x-scenario</artifactId>
+    <packaging>pom</packaging>
+    <version>9.2.0</version>
+    <modules>
+        <module>webflux-projectA-scenario</module>
+        <module>webflux-projectB-scenario</module>
+        <module>webflux-dist</module>
+    </modules>
+
+    <name>skywalking-webflux-6.x-scenario</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <compiler.version>17</compiler.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <test.framework.version>3.2.0</test.framework.version>
+        <docker.image.version>${test.framework.version}</docker.image.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${test.framework.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <finalName>webflux-6.x-scenario</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${compiler.version}</source>
+                    <target>${compiler.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/test/plugin/scenarios/webflux-6.x-scenario/support-version.list
+++ b/test/plugin/scenarios/webflux-6.x-scenario/support-version.list
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+3.0.0
+3.0.5
+3.1.0
+3.2.0

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-dist/bin/startup.sh
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-dist/bin/startup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+home="$(cd "$(dirname $0)"; pwd)"
+
+java -jar ${agent_opts} "-Dskywalking.agent.service_name=webflux-projectA-scenario" ${home}/../libs/webflux-projectA-scenario.jar &
+sleep 1
+
+java -jar ${agent_opts} "-Dskywalking.agent.service_name=webflux-projectB-scenario" ${home}/../libs/webflux-projectB-scenario.jar &

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-dist/pom.xml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-dist/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.skywalking</groupId>
+        <artifactId>webflux-6.x-scenario</artifactId>
+        <version>9.2.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webflux-dist</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <outputDirectory>../target/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-dist/src/main/assembly/assembly.xml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-dist/src/main/assembly/assembly.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<assembly
+    xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <fileSets>
+        <fileSet>
+            <directory>./bin</directory>
+            <fileMode>0775</fileMode>
+        </fileSet>
+    </fileSets>
+
+    <files>
+        <file>
+            <source>../webflux-projectA-scenario/target/webflux-projectA-scenario.jar</source>
+            <outputDirectory>./libs</outputDirectory>
+            <fileMode>0775</fileMode>
+        </file>
+        <file>
+            <source>../webflux-projectB-scenario/target/webflux-projectB-scenario.jar</source>
+            <outputDirectory>./libs</outputDirectory>
+            <fileMode>0775</fileMode>
+        </file>
+    </files>
+</assembly>

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/pom.xml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.apache.skywalking</groupId>
+        <artifactId>webflux-6.x-scenario</artifactId>
+        <version>9.2.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webflux-projectA-scenario</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+<!--            <version>6.0.7</version>-->
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-reactor-netty</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>webflux-projectA-scenario</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${test.framework.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/java/org/apache/skywalking/apm/testcase/sc/webflux/projectA/Application.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/java/org/apache/skywalking/apm/testcase/sc/webflux/projectA/Application.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.skywalking.apm.testcase.sc.webflux.projectA;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/java/org/apache/skywalking/apm/testcase/sc/webflux/projectA/controller/TestController.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/java/org/apache/skywalking/apm/testcase/sc/webflux/projectA/controller/TestController.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.skywalking.apm.testcase.sc.webflux.projectA.controller;
+
+import org.apache.skywalking.apm.testcase.sc.webflux.projectA.utils.HttpUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+
+@RestController
+public class TestController {
+
+    @Value("${projectB.host:localhost:18080}")
+    private String hostBAddress;
+
+    @Autowired
+    private HttpUtils httpUtils;
+
+    @RequestMapping("/testcase")
+    public String testcase() throws IOException {
+        visit("http://" + hostBAddress + "/testcase/annotation/success");
+        visit("http://" + hostBAddress + "/testcase/annotation/error");
+        visit("http://" + hostBAddress + "/testcase/annotation/foo");
+        visit("http://" + hostBAddress + "/testcase/annotation/loo");
+        visit("http://" + hostBAddress + "/testcase/route/success");
+        visit("http://" + hostBAddress + "/testcase/route/error");
+        visit("http://" + hostBAddress + "/notFound");
+        visit("http://" + hostBAddress + "/testcase/annotation/mono/hello");
+        visit("http://" + hostBAddress + "/testcase/annotation/mono/onnext");
+        testGet("http://" + hostBAddress + "/testcase/webclient/server");
+        return "test";
+    }
+
+    @RequestMapping("/healthCheck")
+    public String healthCheck() throws IOException {
+        httpUtils.visit("http://" + hostBAddress + "/testcase/annotation/healthCheck");
+        return "test";
+    }
+
+    private void visit(String path) {
+        try {
+            httpUtils.visit(path);
+        } catch (Exception i) {
+
+        }
+    }
+
+    /**
+     * test webflux webclient plugin
+     */
+    private void testGet(String remoteUri) {
+        Mono<String> response = WebClient
+                .create()
+                .get()
+                .uri(remoteUri)
+                .retrieve()
+                .bodyToMono(String.class);
+        response.subscribe();
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/java/org/apache/skywalking/apm/testcase/sc/webflux/projectA/utils/HttpUtils.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/java/org/apache/skywalking/apm/testcase/sc/webflux/projectA/utils/HttpUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.skywalking.apm.testcase.sc.webflux.projectA.utils;
+
+import java.io.IOException;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpUtils {
+
+    public String visit(String url) throws IOException {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        try {
+            HttpGet httpget = new HttpGet(url);
+            ResponseHandler<String> responseHandler = new ResponseHandler<String>() {
+                public String handleResponse(
+                    org.apache.http.HttpResponse response) throws ClientProtocolException, IOException {
+                    HttpEntity entity = response.getEntity();
+                    return entity != null ? EntityUtils.toString(entity) : null;
+                }
+
+            };
+            return httpclient.execute(httpget, responseHandler);
+        } finally {
+            httpclient.close();
+        }
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/resources/application.yml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectA-scenario/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+server:
+  servlet:
+    context-path: /projectA
+  port: 8080

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/pom.xml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>webflux-6.x-scenario</artifactId>
+        <groupId>org.apache.skywalking</groupId>
+        <version>9.2.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>webflux-projectB-scenario</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <version>${test.framework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.6</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>webflux-projectB-scenario</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${test.framework.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/org/apache/skywalking/apm/toolkit/webflux/v6/WebFluxSkyWalkingOperators.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/org/apache/skywalking/apm/toolkit/webflux/v6/WebFluxSkyWalkingOperators.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.toolkit.webflux.v6;
+
+import java.util.concurrent.Callable;
+import java.util.function.Consumer;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Signal;
+import reactor.core.publisher.SignalType;
+import reactor.util.context.ContextView;
+
+/**
+ * WebFlux operators that are capable to reuse tracing context from Reactor's Context.
+ */
+public final class WebFluxSkyWalkingOperators {
+
+    private WebFluxSkyWalkingOperators() {
+        throw new IllegalStateException("You can't instantiate a utility class");
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param signalType - Reactor's signal type
+     * @param runnable   - lambda to execute within the tracing context
+     * @return consumer of a signal
+     */
+    public static Consumer<Signal<?>> continueTracing(SignalType signalType, Runnable runnable) {
+        return signal -> {
+            if (signalType != signal.getType()) {
+                return;
+            }
+            continueTracing(runnable).accept(signal);
+        };
+    }
+
+    /**
+     * Wraps a consumer with a local span and continue tracing context.
+     *
+     * @param signalType - Reactor's signal type
+     * @param consumer   - lambda to execute within the tracing context
+     * @return consumer of a signal
+     */
+    public static Consumer<Signal> continueTracing(SignalType signalType, Consumer<Signal> consumer) {
+        return signal -> {
+            if (signalType != signal.getType()) {
+                return;
+            }
+            continueTracing(signal.getContextView(), () -> consumer.accept(signal));
+        };
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param runnable - lambda to execute within the tracing context
+     * @return consumer of a signal
+     */
+    public static Consumer<Signal> continueTracing(Runnable runnable) {
+        return signal -> {
+            ContextView context = signal.getContextView();
+            continueTracing(context, runnable);
+        };
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param context  - Reactor context that contains the tracing context
+     * @param runnable - lambda to execute within the tracing context
+     */
+    public static void continueTracing(ContextView context, Runnable runnable) {
+        runnable.run();
+    }
+
+    /**
+     * Wraps a callable with a local span and continue tracing context.
+     *
+     * @param context  - Reactor context that contains the tracing context
+     * @param callable - lambda to execute within the tracing context
+     * @param <T>      callable's return type
+     * @return value from the callable
+     */
+    public static <T> T continueTracing(ContextView context, Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            return sneakyThrow(e);
+        }
+    }
+
+    /**
+     * Wraps a callable with a local span and continue tracing context.
+     *
+     * @param serverWebExchange  - EnhancedInstance that contains the tracing context
+     * @param callable - lambda to execute within the tracing context
+     * @param <T>      callable's return type
+     * @return value from the callable
+     */
+    public static <T> T continueTracing(ServerWebExchange serverWebExchange, Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            return sneakyThrow(e);
+        }
+    }
+
+    /**
+     * Wraps a runnable with a local span and continue tracing context.
+     *
+     * @param serverWebExchange  - EnhancedInstance that contains the tracing context
+     * @param runnable - lambda to execute within the tracing context
+     */
+    public static void continueTracing(ServerWebExchange serverWebExchange, Runnable runnable) {
+        runnable.run();
+    }
+
+    private static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/Application.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/Application.java
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test.apache.skywalking.apm.testcase.sc.webflux.projectB;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/config/CustomFilter.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/config/CustomFilter.java
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test.apache.skywalking.apm.testcase.sc.webflux.projectB.config;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebExchangeDecorator;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+public class CustomFilter implements WebFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return chain.filter(new MyServerWebExchangeDecorator(exchange));
+    }
+
+    public static class MyServerWebExchangeDecorator extends ServerWebExchangeDecorator {
+        public MyServerWebExchangeDecorator(ServerWebExchange delegate) {
+            super(delegate);
+        }
+    }
+
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/controller/TestAnnotationController.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/controller/TestAnnotationController.java
@@ -1,0 +1,84 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test.apache.skywalking.apm.testcase.sc.webflux.projectB.controller;
+
+import org.apache.skywalking.apm.toolkit.webflux.v6.WebFluxSkyWalkingOperators;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.adapter.DefaultServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import static test.apache.skywalking.apm.testcase.sc.webflux.projectB.utils.HttpUtils.visit;
+
+@RestController
+public class TestAnnotationController {
+
+    @Value("${server.port:18080}")
+    private String serverPort;
+
+    @RequestMapping("/testcase/annotation/healthCheck")
+    public String healthCheck() {
+        return "healthCheck";
+    }
+
+    @RequestMapping("/testcase/annotation/success")
+    public String success() {
+        return "1";
+    }
+
+    @RequestMapping("/testcase/annotation/error")
+    public String error() {
+        if (1 == 1) {
+            throw new RuntimeException("test_error");
+        }
+        return "1";
+    }
+
+    @RequestMapping("/testcase/webclient/server")
+    public String webclientServer() {
+        return "success";
+    }
+
+    @GetMapping("/testcase/annotation/{test}")
+    public Mono<String> urlPattern(@PathVariable("test") String var) {
+        return Mono.just(var);
+    }
+
+    @GetMapping("/testcase/annotation/mono/hello")
+    public Mono<String> hello(@RequestBody(required = false) String body) {
+        return Mono.just("Hello World");
+    }
+
+    @RequestMapping("/testcase/success")
+    public String downstreamMock() {
+        return "1";
+    }
+
+    @GetMapping("/testcase/annotation/mono/onnext")
+    public Mono<String> monoOnNext(@RequestBody(required = false) String body) {
+        return Mono.deferContextual(
+            ctx -> WebFluxSkyWalkingOperators.continueTracing(ctx, () -> {
+                visit("http://localhost:" + serverPort + "/testcase/success");
+                return Mono.just("Hello World");
+            }));
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/route/RoutingConfiguration.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/route/RoutingConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test.apache.skywalking.apm.testcase.sc.webflux.projectB.route;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+
+@Configuration
+public class RoutingConfiguration {
+    @Bean
+    public RouterFunction<ServerResponse> routerFunction(TestHandler testHandler) {
+        return RouterFunctions.route(GET("/testcase/route/{test}"), testHandler::test);
+    }
+
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/route/TestHandler.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/route/TestHandler.java
@@ -1,0 +1,37 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test.apache.skywalking.apm.testcase.sc.webflux.projectB.route;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+public class TestHandler {
+
+    public Mono<ServerResponse> test(ServerRequest request) {
+        request.path();
+        if (request.path().contains("error")) {
+            throw new RuntimeException("test_error");
+        }
+        return ServerResponse.ok().contentType(MediaType.TEXT_PLAIN).body(BodyInserters.fromObject("route"));
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/utils/HttpUtils.java
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/utils/HttpUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package test.apache.skywalking.apm.testcase.sc.webflux.projectB.utils;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+
+public class HttpUtils {
+
+    public static String visit(String url) throws IOException {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        try {
+            HttpGet httpget = new HttpGet(url);
+            ResponseHandler<String> responseHandler = response -> {
+                HttpEntity entity = response.getEntity();
+                return entity != null ? EntityUtils.toString(entity) : null;
+            };
+            return httpclient.execute(httpget, responseHandler);
+        } finally {
+            httpclient.close();
+        }
+    }
+}

--- a/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/resources/application.yml
+++ b/test/plugin/scenarios/webflux-6.x-scenario/webflux-projectB-scenario/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+server.port: 18080

--- a/test/plugin/scenarios/webflux-scenario/pom.xml
+++ b/test/plugin/scenarios/webflux-scenario/pom.xml
@@ -35,9 +35,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler.version>1.8</compiler.version>
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <test.framework.version>2.1.1.RELEASE</test.framework.version>
+        <compiler.version>17</compiler.version>
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <test.framework.version>3.0.0</test.framework.version>
         <docker.image.version>${test.framework.version}</docker.image.version>
     </properties>
 

--- a/test/plugin/scenarios/webflux-scenario/webflux-projectA-scenario/pom.xml
+++ b/test/plugin/scenarios/webflux-scenario/webflux-projectA-scenario/pom.xml
@@ -42,12 +42,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>5.2.9.RELEASE</version>
+            <version>6.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-reactor-netty</artifactId>
-            <version>2.3.4.RELEASE</version>
+            <version>${test.framework.version}</version>
         </dependency>
     </dependencies>
 
@@ -57,7 +57,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>1.5.9.RELEASE</version>
+                <version>${test.framework.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/test/plugin/scenarios/webflux-scenario/webflux-projectA-scenario/src/main/resources/application.yml
+++ b/test/plugin/scenarios/webflux-scenario/webflux-projectA-scenario/src/main/resources/application.yml
@@ -18,4 +18,4 @@
 server:
   servlet:
     context-path: /projectA
-    port: 8080
+  port: 18081

--- a/test/plugin/scenarios/webflux-scenario/webflux-projectB-scenario/pom.xml
+++ b/test/plugin/scenarios/webflux-scenario/webflux-projectB-scenario/pom.xml
@@ -47,7 +47,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>1.5.9.RELEASE</version>
+                <version>${test.framework.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/test/plugin/scenarios/webflux-scenario/webflux-projectB-scenario/src/main/java/org/apache/skywalking/apm/toolkit/webflux/WebFluxSkyWalkingOperators.java
+++ b/test/plugin/scenarios/webflux-scenario/webflux-projectB-scenario/src/main/java/org/apache/skywalking/apm/toolkit/webflux/WebFluxSkyWalkingOperators.java
@@ -21,10 +21,10 @@ package org.apache.skywalking.apm.toolkit.webflux;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Signal;
 import reactor.core.publisher.SignalType;
-import reactor.util.context.Context;
 
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import reactor.util.context.ContextView;
 
 /**
  * WebFlux operators that are capable to reuse tracing context from Reactor's Context.
@@ -63,7 +63,7 @@ public final class WebFluxSkyWalkingOperators {
             if (signalType != signal.getType()) {
                 return;
             }
-            continueTracing(signal.getContext(), () -> consumer.accept(signal));
+            continueTracing(signal.getContextView(), () -> consumer.accept(signal));
         };
     }
 
@@ -75,7 +75,7 @@ public final class WebFluxSkyWalkingOperators {
      */
     public static Consumer<Signal> continueTracing(Runnable runnable) {
         return signal -> {
-            Context context = signal.getContext();
+            ContextView context = signal.getContextView();
             continueTracing(context, runnable);
         };
     }
@@ -86,7 +86,7 @@ public final class WebFluxSkyWalkingOperators {
      * @param context  - Reactor context that contains the tracing context
      * @param runnable - lambda to execute within the tracing context
      */
-    public static void continueTracing(Context context, Runnable runnable) {
+    public static void continueTracing(ContextView context, Runnable runnable) {
         runnable.run();
     }
 
@@ -98,7 +98,7 @@ public final class WebFluxSkyWalkingOperators {
      * @param <T>      callable's return type
      * @return value from the callable
      */
-    public static <T> T continueTracing(Context context, Callable<T> callable) {
+    public static <T> T continueTracing(ContextView context, Callable<T> callable) {
         try {
             return callable.call();
         } catch (Exception e) {

--- a/test/plugin/scenarios/webflux-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/controller/TestAnnotationController.java
+++ b/test/plugin/scenarios/webflux-scenario/webflux-projectB-scenario/src/main/java/test/apache/skywalking/apm/testcase/sc/webflux/projectB/controller/TestAnnotationController.java
@@ -74,8 +74,7 @@ public class TestAnnotationController {
 
     @GetMapping("/testcase/annotation/mono/onnext")
     public Mono<String> monoOnNext(@RequestBody(required = false) String body) {
-        return Mono.subscriberContext()
-                .flatMap(ctx -> WebFluxSkyWalkingOperators.continueTracing(ctx, () -> {
+        return Mono.deferContextual(ctx -> WebFluxSkyWalkingOperators.continueTracing(ctx, () -> {
                     visit("http://localhost:" + serverPort + "/testcase/success");
                     return Mono.just("Hello World");
                 }));


### PR DESCRIPTION
### Fix #11654 and add support for spring-webflux-6.x
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.


### Add an agent plugin to support Spring-Webflux-6.x
- [x] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)


- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #11654.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
