### PR TITLE
remove idleCount in druid plugin

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/druid-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/druid/v1/PoolingAddDruidDataSourceInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/druid-1.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/druid/v1/PoolingAddDruidDataSourceInterceptor.java
@@ -58,10 +58,9 @@ public class PoolingAddDruidDataSourceInterceptor implements StaticMethodsAround
     }
 
     private Map<String, Function<DruidDataSourceMBean, Supplier<Double>>> getMetrics() {
-        Map<String, Function<DruidDataSourceMBean, Supplier<Double>>> metricMap = new HashMap();
+        Map<String, Function<DruidDataSourceMBean, Supplier<Double>>> metricMap = new HashMap<>();
         metricMap.put("activeCount", (DruidDataSourceMBean druidDataSource) -> () -> (double) druidDataSource.getActiveCount());
         metricMap.put("poolingCount", (DruidDataSourceMBean druidDataSource) -> () -> (double) druidDataSource.getPoolingCount());
-        metricMap.put("idleCount", (DruidDataSourceMBean druidDataSource) -> () -> (double) (druidDataSource.getPoolingCount() - druidDataSource.getActiveCount()));
         metricMap.put("lockQueueLength", (DruidDataSourceMBean druidDataSource) -> () -> (double) druidDataSource.getLockQueueLength());
         metricMap.put("maxWaitThreadCount", (DruidDataSourceMBean druidDataSource) -> () -> (double) druidDataSource.getMaxWaitThreadCount());
         metricMap.put("commitCount", (DruidDataSourceMBean druidDataSource) -> () -> (double) druidDataSource.getCommitCount());

--- a/test/plugin/scenarios/druid-1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/druid-1.x-scenario/config/expectedData.yaml
@@ -224,12 +224,6 @@ meterItems:
       name: datasource
       tags:
       - {name: name, value: test_mysql-server:3306}
-      - {name: status, value: idleCount}
-    singleValue: ge 0
-  - meterId:
-      name: datasource
-      tags:
-      - {name: name, value: test_mysql-server:3306}
       - {name: status, value: lockQueueLength}
     singleValue: ge 0
   - meterId:

--- a/test/plugin/scenarios/druid-1.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/druid-1.x-scenario/config/expectedData.yaml
@@ -206,7 +206,7 @@ segmentItems:
       - {key: http.status_code, value: '200'}
 meterItems:
 - serviceName: druid-1.x-scenario
-  meterSize: 14
+  meterSize: 13
   meters:
   - meterId:
       name: datasource


### PR DESCRIPTION
In fact, in the druid, `PoolingCount` and `idleCount` represent the same meaning.

associate [issue](https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11072) in opentelemetry-java-instrumentation