### PR TITLE
Fix bugs in Redisson plugin 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Release Notes.
 * Add support for `Derby`/`Sybase`/`SQLite`/`DB2`/`OceanBase` jdbc url format in `URLParser`.
 * Optimize spring-plugins:scheduled-annotation-plugin compatibility about Spring 6.1.x support.
 * Add a forceIgnoring mechanism in a CROSS_THREAD scenario.
+* Fix NPE in Redisson plugin since Redisson 3.20.0.
+* Support for showing batch command details and ignoring PING commands in Redisson plugin.
+* Fix peer value of Master-Slave mode in Redisson plugin.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/213?closed=1)
 

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
@@ -31,7 +31,7 @@
     <name>redisson-3.x-plugin</name>
     <url>http://maven.apache.org</url>
     <properties>
-        <redisson.version>3.6.0</redisson.version>
+        <redisson.version>3.20.0</redisson.version>
     </properties>
 
     <dependencies>

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptor.java
@@ -68,12 +68,12 @@ public class RedisConnectionMethodInterceptor implements InstanceMethodsAroundIn
             operationName = operationName + "BATCH_EXECUTE";
             command = "BATCH_EXECUTE";
             if (RedissonPluginConfig.Plugin.Redisson.SHOW_BATCH_COMMANDS) {
-                command += ":" + showBatchCommands(allArguments[0]);
+                command += ":" + showBatchCommands((CommandsData) allArguments[0]);
             }
         } else if (allArguments[0] instanceof CommandData) {
             CommandData commandData = (CommandData) allArguments[0];
             command = commandData.getCommand().getName();
-            if ("PING".equals(command) && RedissonPluginConfig.Plugin.Redisson.PING_IGNORED) {
+            if ("PING".equals(command) && !RedissonPluginConfig.Plugin.Redisson.SHOW_PING_COMMAND) {
                 return;
             } else {
                 operationName = operationName + command;
@@ -152,8 +152,7 @@ public class RedisConnectionMethodInterceptor implements InstanceMethodsAroundIn
         return Optional.empty();
     }
 
-    private String showBatchCommands(Object argument) {
-        CommandsData commandsData = (CommandsData) argument;
+    private String showBatchCommands(CommandsData commandsData) {
         return commandsData.getCommands()
                            .stream()
                            .map(data -> data.getCommand().getName())

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptor.java
@@ -19,6 +19,7 @@
 package org.apache.skywalking.apm.plugin.redisson.v3;
 
 import io.netty.channel.Channel;
+import java.util.stream.Collectors;
 import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
@@ -66,11 +67,18 @@ public class RedisConnectionMethodInterceptor implements InstanceMethodsAroundIn
         if (allArguments[0] instanceof CommandsData) {
             operationName = operationName + "BATCH_EXECUTE";
             command = "BATCH_EXECUTE";
+            if (RedissonPluginConfig.Plugin.Redisson.SHOW_BATCH_COMMANDS) {
+                command += ":" + showBatchCommands(allArguments[0]);
+            }
         } else if (allArguments[0] instanceof CommandData) {
             CommandData commandData = (CommandData) allArguments[0];
             command = commandData.getCommand().getName();
-            operationName = operationName + command;
-            arguments = commandData.getParams();
+            if ("PING".equals(command) && RedissonPluginConfig.Plugin.Redisson.PING_IGNORED) {
+                return;
+            } else {
+                operationName = operationName + command;
+                arguments = commandData.getParams();
+            }
         }
 
         AbstractSpan span = ContextManager.createExitSpan(operationName, peer);
@@ -142,5 +150,13 @@ public class RedisConnectionMethodInterceptor implements InstanceMethodsAroundIn
             return Optional.of("write");
         }
         return Optional.empty();
+    }
+
+    private String showBatchCommands(Object argument) {
+        CommandsData commandsData = (CommandsData) argument;
+        return commandsData.getCommands()
+                           .stream()
+                           .map(data -> data.getCommand().getName())
+                           .collect(Collectors.joining(";"));
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedissonPluginConfig.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedissonPluginConfig.java
@@ -41,9 +41,9 @@ public class RedissonPluginConfig {
              */
             public static int REDIS_PARAMETER_MAX_LENGTH = 128;
             /**
-             * If set to false, the PING command would be collected.
+             * If set to true, the PING command would be collected.
              */
-            public static boolean PING_IGNORED = true;
+            public static boolean SHOW_PING_COMMAND = false;
             /**
              * If set to true, the detail of the Redis batch commands would be collected.
              */

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedissonPluginConfig.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedissonPluginConfig.java
@@ -40,6 +40,14 @@ public class RedissonPluginConfig {
              * Set a negative number to save specified length of parameter string to the tag.
              */
             public static int REDIS_PARAMETER_MAX_LENGTH = 128;
+            /**
+             * If set to false, the PING command would be collected.
+             */
+            public static boolean PING_IGNORED = true;
+            /**
+             * If set to true, the detail of the Redis batch commands would be collected.
+             */
+            public static boolean SHOW_BATCH_COMMANDS = false;
 
             /**
              * Operation represent a cache span is "write" or "read" action , and "op"(operation) is tagged with key "cache.op" usually

--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -87,7 +87,7 @@ metrics based on the tracing data.
   * [aerospike](https://github.com/aerospike/aerospike-client-java) 3.x -> 6.x
   * Redis
     * [Jedis](https://github.com/xetorthio/jedis) 2.x-4.x
-    * [Redisson](https://github.com/redisson/redisson) Easy Java Redis client 3.5.2+
+    * [Redisson](https://github.com/redisson/redisson) Easy Java Redis client 3.5.0 -> 3.30.0 
     * [Lettuce](https://github.com/lettuce-io/lettuce-core) 5.x
   * [MongoDB Java Driver](https://github.com/mongodb/mongo-java-driver) 2.13-2.14, 3.4.0-3.12.7, 4.0.0-4.1.0
   * Memcached Client

--- a/test/plugin/scenarios/redisson-scenario/bin/startup.sh
+++ b/test/plugin/scenarios/redisson-scenario/bin/startup.sh
@@ -18,4 +18,4 @@
 
 home="$(cd "$(dirname $0)"; pwd)"
 
-java -Dredis.servers=${REDIS_SERVERS} -Dskywalking.plugin.redisson.trace_redis_parameters=true -jar ${agent_opts} ${home}/../libs/redisson-scenario.jar &
+java -Dredis.servers=${REDIS_SERVERS} -Dskywalking.plugin.redisson.trace_redis_parameters=true -Dskywalking.plugin.redisson.show_batch_commands=true -Dskywalking.plugin.redisson.ping_ignored=true -jar ${agent_opts} ${home}/../libs/redisson-scenario.jar &

--- a/test/plugin/scenarios/redisson-scenario/bin/startup.sh
+++ b/test/plugin/scenarios/redisson-scenario/bin/startup.sh
@@ -18,4 +18,4 @@
 
 home="$(cd "$(dirname $0)"; pwd)"
 
-java -Dredis.servers=${REDIS_SERVERS} -Dskywalking.plugin.redisson.trace_redis_parameters=true -Dskywalking.plugin.redisson.show_batch_commands=true -Dskywalking.plugin.redisson.ping_ignored=true -jar ${agent_opts} ${home}/../libs/redisson-scenario.jar &
+java -Dredis.servers=${REDIS_SERVERS} -Dskywalking.plugin.redisson.trace_redis_parameters=true -jar ${agent_opts} ${home}/../libs/redisson-scenario.jar &

--- a/test/plugin/scenarios/redisson-scenario/support-version.list
+++ b/test/plugin/scenarios/redisson-scenario/support-version.list
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# 3.5.0-3.12.4, 3.26.1-3.30.0 have been tested, and 3.12.5-3.26.0 are also supported but not included in the test
+3.30.0
+3.29.0
+3.28.0
+3.27.2
+3.26.1
+3.12.4
 3.11.5
 3.10.7
 3.9.1


### PR DESCRIPTION
### Fix bugs in Redisson plugin
* Fix NPE in Redisson plugin since Redisson 3.20.0.

Fix NPE  in Redisson tracing since 3.20.0, because [ServiceManager](https://www.javadoc.io/static/org.redisson/redisson/3.20.0/org/redisson/connection/ServiceManager.html).Config replaces Config in MasterSlaveConnectionManager.

```
ERROR 2024-05-20 09:42:35.670 redisson-netty-2-19 InstMethodsInter : class[class org.redisson.client.RedisConnection] after method[send] intercept failure 
java.lang.NullPointerException
	at org.apache.skywalking.apm.agent.core.context.ContextManager.stopSpan(ContextManager.java:194)
	at org.apache.skywalking.apm.plugin.redisson.v3.RedisConnectionMethodInterceptor.afterMethod(RedisConnectionMethodInterceptor.java:98)
	at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:97)
	at org.redisson.client.RedisConnection.send(RedisConnection.java)
	at org.redisson.client.RedisConnection.async(RedisConnection.java:252)
	at org.redisson.client.RedisConnection.async(RedisConnection.java:228)
	at org.redisson.client.handler.PingConnectionHandler.sendPing(PingConnectionHandler.java:65)
```


* Support for showing batch command details and ignoring PING commands in Redisson plugin.

Add params: skywalking.plugin.redisson.show_batch_commands=true(default false), to show batch_execute details
Add params: skywalking.plugin.redisson.ping_ignored=true(default true), to avoid ping tracing cost, the filtering configuration of PING since 3.13.6 that default ping per 30s
<img width="291" alt="2024-05-16 211518" src="https://github.com/apache/skywalking-java/assets/22817918/5ee590a1-1627-46c1-893c-9540a79edb68">


* Fix peer value of Master-Slave mode in Redisson plugin.

connect to redis in Master-Slave mode

```
Config config = new Config();
config.useMasterSlaveServers()
    .setMasterAddress("redis://127.0.0.1:7001")
    .addSlaveAddress("redis://127.0.0.1:7002");

RedissonClient redisson = Redisson.create(config);
```

peer before:
<img width="804" alt="redisson-0516-ms-scenario" src="https://github.com/apache/skywalking-java/assets/22817918/0dbfb260-5296-4e46-a316-f33f84f2f063">

peer now:
<img width="976" alt="General-Root  General-Service" src="https://github.com/apache/skywalking-java/assets/22817918/90705cc7-00f4-4fd2-9c41-94814d54f673">

* About the redisson-scenario, for redis single node , 3.5.0 - 3.30.0 has been tested, but 3.12.5 - 3.26.0 not included in the testcase because of the difference in expectedData

```
When startup params: -Dskywalking.plugin.redisson.trace_redis_parameters=true -Dskywalking.plugin.redisson.show_batch_commands=true -Dskywalking.plugin.redisson.ping_ignored=true
3.5.0 - 3.12.4： 
segmentItems:
- serviceName: redisson-scenario
  segmentSize: 2
  segments:
  - segmentId: 8113e722beb74d1b9afd97ba51a3881a.77.17162612625310000
    spans:
    - operationName: HEAD:/case/healthCheck
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716261262557
      endTime: 1716261262881
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/healthCheck'}
      - {key: http.method, value: HEAD}
      - {key: http.status_code, value: '200'}
  - segmentId: 8113e722beb74d1b9afd97ba51a3881a.78.17162612629290000
    spans:
    - operationName: Redisson/SET
      parentSpanId: 0
      spanId: 1
      spanLayer: Cache
      startTime: 1716261263432
      endTime: 1716261263511
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: SET}
      - {key: cache.key, value: key_a}
      - {key: cache.op, value: write}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 0
      spanId: 2
      spanLayer: Cache
      startTime: 1716261263553
      endTime: 1716261263554
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:SET;SET;PEXPIRE'}
    - operationName: Redisson/EVAL
      parentSpanId: 3
      spanId: 4
      spanLayer: Cache
      startTime: 1716261263638
      endTime: 1716261263638
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: EVAL}
      - {key: cache.key, value: 'if (redis.call(''exists'', KEYS[1]) == 0) then redis.call(''hincrby'',
          KEYS[1], ARGV[2], 1); redis.call(''pexpire'', KEYS[1], ARGV[1])'}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 3
      spanLayer: Cache
      startTime: 1716261263635
      endTime: 1716261263648
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_a}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '10000'}
      - {key: thread.id, value: '78'}
    - operationName: Redisson/EVAL
      parentSpanId: 5
      spanId: 6
      spanLayer: Cache
      startTime: 1716261263648
      endTime: 1716261263648
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: EVAL}
      - {key: cache.key, value: 'if (redis.call(''exists'', KEYS[1]) == 0) then redis.call(''hincrby'',
          KEYS[1], ARGV[2], 1); redis.call(''pexpire'', KEYS[1], ARGV[1])'}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 5
      spanLayer: Cache
      startTime: 1716261263648
      endTime: 1716261263656
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_b}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '20'}
      - {key: thread.id, value: '78'}
    - operationName: GET:/case/redisson-case
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716261262929
      endTime: 1716261263661
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/redisson-case'}
      - {key: http.method, value: GET}
      - {key: http.status_code, value: '200'}

3.12.5 - 3.16.8   
segmentItems:
- serviceName: redisson-scenario
  segmentSize: 2
  segments:
  - segmentId: 7fe18ab87b544234b4c277cd05e4ebe7.77.17162614778760000
    spans:
    - operationName: HEAD:/case/healthCheck
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716261477894
      endTime: 1716261478140
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/healthCheck'}
      - {key: http.method, value: HEAD}
      - {key: http.status_code, value: '200'}
  - segmentId: 7fe18ab87b544234b4c277cd05e4ebe7.78.17162614781750000
    spans:
    - operationName: Redisson/SET
      parentSpanId: 0
      spanId: 1
      spanLayer: Cache
      startTime: 1716261478235
      endTime: 1716261478242
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: SET}
      - {key: cache.key, value: key_a}
      - {key: cache.op, value: write}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 0
      spanId: 2
      spanLayer: Cache
      startTime: 1716261478290
      endTime: 1716261478290
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:SET;SET;PEXPIRE'}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 3
      spanId: 4
      spanLayer: Cache
      startTime: 1716261478357
      endTime: 1716261478357
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:EVAL'}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 3
      spanLayer: Cache
      startTime: 1716261478346
      endTime: 1716261478369
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_a}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '10000'}
      - {key: thread.id, value: '78'}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 5
      spanId: 6
      spanLayer: Cache
      startTime: 1716261478371
      endTime: 1716261478371
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:EVAL'}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 5
      spanLayer: Cache
      startTime: 1716261478371
      endTime: 1716261478374
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_b}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '20'}
      - {key: thread.id, value: '78'}
    - operationName: GET:/case/redisson-case
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716261478175
      endTime: 1716261478384
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/redisson-case'}
      - {key: http.method, value: GET}
      - {key: http.status_code, value: '200'}

3.17.0 - 3.26.0   
segmentItems:
- serviceName: redisson-scenario
  segmentSize: 2
  segments:
  - segmentId: 344f0a5bd7f6403484ea074501c26d70.93.17162619129550000
    spans:
    - operationName: HEAD:/case/healthCheck
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716261912970
      endTime: 1716261913186
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/healthCheck'}
      - {key: http.method, value: HEAD}
      - {key: http.status_code, value: '200'}
  - segmentId: 344f0a5bd7f6403484ea074501c26d70.94.17162619132080000
    spans:
    - operationName: Redisson/SET
      parentSpanId: 0
      spanId: 1
      spanLayer: Cache
      startTime: 1716261913394
      endTime: 1716261913396
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: SET}
      - {key: cache.key, value: key_a}
      - {key: cache.op, value: write}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 0
      spanId: 2
      spanLayer: Cache
      startTime: 1716261913424
      endTime: 1716261913424
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:SET;SET;EVAL'}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 3
      spanId: 4
      spanLayer: Cache
      startTime: 1716261913498
      endTime: 1716261913498
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:EVAL'}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 3
      spanLayer: Cache
      startTime: 1716261913497
      endTime: 1716261913502
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_a}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '10000'}
      - {key: thread.id, value: '94'}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 5
      spanId: 6
      spanLayer: Cache
      startTime: 1716261913507
      endTime: 1716261913507
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:EVAL'}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 5
      spanLayer: Cache
      startTime: 1716261913507
      endTime: 1716261913509
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_b}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '20'}
      - {key: thread.id, value: '94'}
    - operationName: GET:/case/redisson-case
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716261913208
      endTime: 1716261913514
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/redisson-case'}
      - {key: http.method, value: GET}
      - {key: http.status_code, value: '200'}

3.26.1 - 3.30.0  
segmentItems:
- serviceName: redisson-scenario
  segmentSize: 2
  segments:
  - segmentId: cffeac304ea5483fafb79376e257353c.93.17162625084100000
    spans:
    - operationName: HEAD:/case/healthCheck
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716262508451
      endTime: 1716262509297
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/healthCheck'}
      - {key: http.method, value: HEAD}
      - {key: http.status_code, value: '200'}
  - segmentId: cffeac304ea5483fafb79376e257353c.94.17162625094090000
    spans:
    - operationName: Redisson/SET
      parentSpanId: 0
      spanId: 1
      spanLayer: Cache
      startTime: 1716262509855
      endTime: 1716262509861
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: SET}
      - {key: cache.key, value: key_a}
      - {key: cache.op, value: write}
    - operationName: Redisson/BATCH_EXECUTE
      parentSpanId: 0
      spanId: 2
      spanLayer: Cache
      startTime: 1716262509992
      endTime: 1716262509993
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: 'BATCH_EXECUTE:SET;SET;EVAL'}
    - operationName: Redisson/EVAL
      parentSpanId: 3
      spanId: 4
      spanLayer: Cache
      startTime: 1716262510177
      endTime: 1716262510177
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: EVAL}
      - {key: cache.key, value: 'if ((redis.call(''exists'', KEYS[1]) == 0) or (redis.call(''hexists'',
          KEYS[1], ARGV[2]) == 1)) then redis.call(''hincrby'', KEYS[1], '}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 3
      spanLayer: Cache
      startTime: 1716262510176
      endTime: 1716262510184
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_a}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '10000'}
      - {key: thread.id, value: '94'}
    - operationName: Redisson/EVAL
      parentSpanId: 5
      spanId: 6
      spanLayer: Cache
      startTime: 1716262510198
      endTime: 1716262510198
      componentId: 56
      isError: false
      spanType: Exit
      peer: redis-server:6379
      skipAnalysis: false
      tags:
      - {key: cache.type, value: Redis}
      - {key: cache.instance, value: '172.18.0.2:6379'}
      - {key: cache.cmd, value: EVAL}
      - {key: cache.key, value: 'if ((redis.call(''exists'', KEYS[1]) == 0) or (redis.call(''hexists'',
          KEYS[1], ARGV[2]) == 1)) then redis.call(''hincrby'', KEYS[1], '}
    - operationName: Redisson/LOCK
      parentSpanId: 0
      spanId: 5
      spanLayer: Cache
      startTime: 1716262510197
      endTime: 1716262510201
      componentId: 56
      isError: false
      spanType: Local
      peer: ''
      skipAnalysis: false
      tags:
      - {key: lock.name, value: lock_b}
      - {key: cache.type, value: Redis}
      - {key: lease.time, value: '20'}
      - {key: thread.id, value: '94'}
    - operationName: GET:/case/redisson-case
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: 1716262509409
      endTime: 1716262510226
      componentId: 14
      isError: false
      spanType: Entry
      peer: ''
      skipAnalysis: false
      tags:
      - {key: url, value: 'http://localhost:8080/redisson-scenario/case/redisson-case'}
      - {key: http.method, value: GET}
      - {key: http.status_code, value: '200'}

```


- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
