### PR TITLE
Support for tracing the callbacks of async methods in elastiicsearch-6.x/7.x-plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Release Notes.
 * Fix NPE in Redisson plugin since Redisson 3.20.0.
 * Support for showing batch command details and ignoring PING commands in Redisson plugin.
 * Fix peer value of Master-Slave mode in Redisson plugin.
+* Support for tracing the callbacks of asynchronous methods in elasticsearch-6.x-plugin/elasticsearch-7.x-plugin.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/213?closed=1)
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/define/IndicesClientInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/define/IndicesClientInstrumentation.java
@@ -68,7 +68,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -85,7 +85,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -102,7 +102,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
                 new InstanceMethodsInterceptPoint() {
@@ -119,7 +119,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                     @Override
                     public boolean isOverrideArgs() {
-                        return false;
+                        return true;
                     }
                 }
         };

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/define/RestHighLevelClientInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/define/RestHighLevelClientInstrumentation.java
@@ -86,7 +86,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -102,7 +102,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -118,7 +118,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -134,7 +134,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -182,7 +182,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -198,7 +198,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -214,7 +214,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -230,7 +230,7 @@ public class RestHighLevelClientInstrumentation extends ClassEnhancePluginDefine
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             }
         };

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/Constants.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/Constants.java
@@ -79,4 +79,7 @@ public class Constants {
     public static final AbstractTag<String> ES_TOOK_MILLIS = Tags.ofKey("es.took_millis");
     public static final AbstractTag<String> ES_TOTAL_HITS = Tags.ofKey("es.total_hits");
     public static final AbstractTag<String> ES_INGEST_TOOK_MILLIS = Tags.ofKey("es.ingest_took_millis");
+
+    public static final String ON_RESPONSE_SUFFIX = "/onResponse";
+    public static final String ON_FAILURE_SUFFIX = "/onFailure";
 }

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientAnalyzeMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientAnalyzeMethodsInterceptor.java
@@ -30,6 +30,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeRequest;
 
 import java.lang.reflect.Method;
@@ -58,6 +60,10 @@ public class IndicesClientAnalyzeMethodsInterceptor implements InstanceMethodsAr
                 Tags.DB_STATEMENT.set(span, analyzeRequest.text()[0]);
             }
             SpanLayer.asDB(span);
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.ANALYZE_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientCreateMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientCreateMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 
 import static org.apache.skywalking.apm.plugin.elasticsearch.v6.ElasticsearchPluginConfig.Plugin.Elasticsearch.TRACE_DSL;
@@ -52,6 +54,10 @@ public class IndicesClientCreateMethodsInterceptor implements InstanceMethodsAro
                 Tags.DB_STATEMENT.set(span, createIndexRequest.mappings().utf8ToString());
             }
             SpanLayer.asDB(span);
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.CREATE_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientDeleteMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientDeleteMethodsInterceptor.java
@@ -29,6 +29,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 
 import static org.apache.skywalking.apm.plugin.elasticsearch.v6.interceptor.Constants.DB_TYPE;
@@ -48,6 +50,10 @@ public class IndicesClientDeleteMethodsInterceptor implements InstanceMethodsAro
             Tags.DB_TYPE.set(span, DB_TYPE);
             Tags.DB_INSTANCE.set(span, Arrays.asList(deleteIndexRequest.indices()).toString());
             SpanLayer.asDB(span);
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.DELETE_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientRefreshMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/IndicesClientRefreshMethodsInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 
 import java.lang.reflect.Method;
@@ -48,6 +50,10 @@ public class IndicesClientRefreshMethodsInterceptor implements InstanceMethodsAr
             Tags.DB_TYPE.set(span, DB_TYPE);
             Tags.DB_INSTANCE.set(span, buildIndicesString(request.indices()));
             SpanLayer.asDB(span);
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.REFRESH_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientClearScrollMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientClearScrollMethodsInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.ClearScrollRequest;
 
 import java.lang.reflect.Method;
@@ -52,6 +54,10 @@ public class RestHighLevelClientClearScrollMethodsInterceptor implements Instanc
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.CLEAR_SCROLL_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientDeleteByQueryMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientDeleteByQueryMethodsInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 
 import java.lang.reflect.Method;
@@ -58,6 +60,10 @@ public class RestHighLevelClientDeleteByQueryMethodsInterceptor implements Insta
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.DELETE_BY_QUERY_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientGetMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientGetMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
 
 import static org.apache.skywalking.apm.plugin.elasticsearch.v6.ElasticsearchPluginConfig.Plugin.Elasticsearch.TRACE_DSL;
@@ -51,6 +53,10 @@ public class RestHighLevelClientGetMethodsInterceptor implements InstanceMethods
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.GET_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientIndexMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientIndexMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 
 import static org.apache.skywalking.apm.plugin.elasticsearch.v6.ElasticsearchPluginConfig.Plugin.Elasticsearch.TRACE_DSL;
@@ -51,6 +53,10 @@ public class RestHighLevelClientIndexMethodsInterceptor implements InstanceMetho
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.INDEX_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientSearchMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientSearchMethodsInterceptor.java
@@ -29,6 +29,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 
 import static org.apache.skywalking.apm.plugin.elasticsearch.v6.ElasticsearchPluginConfig.Plugin.Elasticsearch.TRACE_DSL;
@@ -52,6 +54,10 @@ public class RestHighLevelClientSearchMethodsInterceptor implements InstanceMeth
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.SEARCH_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientSearchScrollMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientSearchScrollMethodsInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchScrollRequest;
 
 import java.lang.reflect.Method;
@@ -51,6 +53,10 @@ public class RestHighLevelClientSearchScrollMethodsInterceptor implements Instan
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.SEARCH_SCROLL_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientSearchTemplateMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientSearchTemplateMethodsInterceptor.java
@@ -27,6 +27,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.script.mustache.SearchTemplateRequest;
 
 import java.lang.reflect.Method;
@@ -55,6 +57,10 @@ public class RestHighLevelClientSearchTemplateMethodsInterceptor implements Inst
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.SEARCH_TEMPLATE_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientUpdateMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/interceptor/RestHighLevelClientUpdateMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceM
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.update.UpdateRequest;
 
 import static org.apache.skywalking.apm.plugin.elasticsearch.v6.ElasticsearchPluginConfig.Plugin.Elasticsearch.TRACE_DSL;
@@ -51,6 +53,10 @@ public class RestHighLevelClientUpdateMethodsInterceptor implements InstanceMeth
         }
 
         SpanLayer.asDB(span);
+        if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+            allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.UPDATE_OPERATOR_NAME,
+                                                             (ActionListener) allArguments[2]);
+        }
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/support/ActionListenerAdapter.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/support/ActionListenerAdapter.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.elasticsearch.v6.support;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.plugin.elasticsearch.v6.interceptor.Constants;
+import org.elasticsearch.action.ActionListener;
+
+import static org.apache.skywalking.apm.plugin.elasticsearch.v6.interceptor.Constants.DB_TYPE;
+
+public class ActionListenerAdapter<T> implements ActionListener<T>, EnhancedInstance {
+
+    private final RestClientCache<T> restClientCache;
+
+    public ActionListenerAdapter(RestClientCache<T> restClientCache) {
+        this.restClientCache = restClientCache;
+    }
+
+    @Override
+    public void onResponse(final T o) {
+        try {
+            if (restClientCache.getContextSnapshot() != null) {
+                continueContext(Constants.ON_RESPONSE_SUFFIX);
+            }
+            if (restClientCache.getActionListener() != null) {
+                restClientCache.getActionListener().onResponse(o);
+            }
+        } catch (Throwable t) {
+            ContextManager.activeSpan().log(t);
+            throw t;
+        } finally {
+            restClientCache.setContextSnapshot(null);
+            ContextManager.stopSpan();
+        }
+    }
+
+    @Override
+    public void onFailure(final Exception e) {
+        try {
+            if (restClientCache.getContextSnapshot() != null) {
+                continueContext(Constants.ON_FAILURE_SUFFIX);
+            }
+            if (restClientCache.getActionListener() != null) {
+                restClientCache.getActionListener().onFailure(e);
+            }
+        } catch (Throwable t) {
+            ContextManager.activeSpan().log(t);
+            throw t;
+        } finally {
+            ContextManager.stopSpan();
+        }
+    }
+
+    @Override
+    public Object getSkyWalkingDynamicField() {
+        return restClientCache;
+    }
+
+    @Override
+    public void setSkyWalkingDynamicField(final Object enhanceInfo) {
+
+    }
+
+    private void continueContext(String action) {
+        AbstractSpan activeSpan = ContextManager.createLocalSpan(restClientCache.getOperationName() + action);
+        activeSpan.setComponent(ComponentsDefine.REST_HIGH_LEVEL_CLIENT);
+        Tags.DB_TYPE.set(activeSpan, DB_TYPE);
+        SpanLayer.asDB(activeSpan);
+        ContextManager.continued(restClientCache.getContextSnapshot());
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/support/AdapterUtil.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/support/AdapterUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.elasticsearch.v6.support;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.elasticsearch.action.ActionListener;
+
+public class AdapterUtil {
+
+    public static  <T> ActionListener<T> wrapActionListener(RestClientEnhanceInfo restClientEnhanceInfo,
+                                                     String operation,
+                                                     ActionListener<T> listener) {
+        ContextSnapshot capture = ContextManager.capture();
+        capture.getExtensionContext().setSendingTimestamp(System.currentTimeMillis());
+        RestClientCache<T> cache = new RestClientCache<T>();
+        cache.setEnhanceInfo(restClientEnhanceInfo);
+        cache.setContextSnapshot(capture);
+        cache.setOperationName(operation);
+        cache.setActionListener(listener);
+        return new ActionListenerAdapter<T>(cache);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/support/RestClientCache.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v6/support/RestClientCache.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.elasticsearch.v6.support;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.elasticsearch.action.ActionListener;
+
+public class RestClientCache<T> {
+    private RestClientEnhanceInfo enhanceInfo;
+    private ActionListener<T> actionListener;
+    private ContextSnapshot contextSnapshot;
+    private String operationName;
+
+    public ContextSnapshot getContextSnapshot() {
+        return contextSnapshot;
+    }
+
+    public void setContextSnapshot(final ContextSnapshot contextSnapshot) {
+        this.contextSnapshot = contextSnapshot;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(final String operationName) {
+        this.operationName = operationName;
+    }
+
+    public ActionListener<T> getActionListener() {
+        return actionListener;
+    }
+
+    public void setActionListener(final ActionListener<T> actionListener) {
+        this.actionListener = actionListener;
+    }
+
+    public RestClientEnhanceInfo getEnhanceInfo() {
+        return enhanceInfo;
+    }
+
+    public void setEnhanceInfo(final RestClientEnhanceInfo enhanceInfo) {
+        this.enhanceInfo = enhanceInfo;
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/Constants.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/Constants.java
@@ -48,4 +48,8 @@ public class Constants {
     public static final AbstractTag<String> ES_TOOK_MILLIS = Tags.ofKey("es.took_millis");
     public static final AbstractTag<String> ES_TOTAL_HITS = Tags.ofKey("es.total_hits");
     public static final AbstractTag<String> ES_INGEST_TOOK_MILLIS = Tags.ofKey("es.ingest_took_millis");
+
+    public static final String ON_RESPONSE_SUFFIX = "/onResponse";
+    public static final String ON_FAILURE_SUFFIX = "/onFailure";
+
 }

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/define/IndicesClientInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/define/IndicesClientInstrumentation.java
@@ -62,7 +62,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -79,7 +79,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -96,7 +96,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             },
             new InstanceMethodsInterceptPoint() {
@@ -113,7 +113,7 @@ public class IndicesClientInstrumentation extends ClassEnhancePluginDefine {
 
                 @Override
                 public boolean isOverrideArgs() {
-                    return false;
+                    return true;
                 }
             }
         };

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientAnalyzeMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientAnalyzeMethodsInterceptor.java
@@ -31,6 +31,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
 import org.apache.skywalking.apm.plugin.elasticsearch.v7.Constants;
+import org.apache.skywalking.apm.plugin.elasticsearch.v7.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.indices.AnalyzeRequest;
 
 import java.lang.reflect.Method;
@@ -59,6 +61,10 @@ public class IndicesClientAnalyzeMethodsInterceptor implements InstanceMethodsAr
                 Tags.DB_STATEMENT.set(span, analyzeRequest.text()[0]);
             }
             SpanLayer.asDB(span);
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.ANALYZE_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientCreateMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientCreateMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
 import org.apache.skywalking.apm.plugin.elasticsearch.v7.Constants;
+import org.apache.skywalking.apm.plugin.elasticsearch.v7.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 
 import java.lang.reflect.Method;
@@ -49,6 +51,11 @@ public class IndicesClientCreateMethodsInterceptor implements InstanceMethodsAro
             Tags.DB_TYPE.set(span, DB_TYPE);
             Tags.DB_INSTANCE.set(span, createIndexRequest.index());
             SpanLayer.asDB(span);
+
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.CREATE_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientDeleteMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientDeleteMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
 import org.apache.skywalking.apm.plugin.elasticsearch.v7.Constants;
+import org.apache.skywalking.apm.plugin.elasticsearch.v7.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 
 import java.lang.reflect.Method;
@@ -50,6 +52,11 @@ public class IndicesClientDeleteMethodsInterceptor implements InstanceMethodsAro
             Tags.DB_TYPE.set(span, DB_TYPE);
             Tags.DB_INSTANCE.set(span, Arrays.asList(deleteIndexRequest.indices()).toString());
             SpanLayer.asDB(span);
+
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.DELETE_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientRefreshMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/interceptor/IndicesClientRefreshMethodsInterceptor.java
@@ -28,6 +28,8 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInt
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
 import org.apache.skywalking.apm.plugin.elasticsearch.v7.Constants;
+import org.apache.skywalking.apm.plugin.elasticsearch.v7.support.AdapterUtil;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 
 import java.lang.reflect.Method;
@@ -49,6 +51,11 @@ public class IndicesClientRefreshMethodsInterceptor implements InstanceMethodsAr
             Tags.DB_TYPE.set(span, DB_TYPE);
             Tags.DB_INSTANCE.set(span, buildIndicesString(request.indices()));
             SpanLayer.asDB(span);
+
+            if (allArguments.length > 2 && allArguments[2] != null && allArguments[2] instanceof ActionListener) {
+                allArguments[2] = AdapterUtil.wrapActionListener(restClientEnhanceInfo, Constants.REFRESH_OPERATOR_NAME,
+                                                                 (ActionListener) allArguments[2]);
+            }
         }
     }
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/support/ActionListenerAdapter.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/support/ActionListenerAdapter.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.elasticsearch.v7.support;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.tag.Tags;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.plugin.elasticsearch.v7.Constants;
+import org.elasticsearch.action.ActionListener;
+
+import static org.apache.skywalking.apm.plugin.elasticsearch.v7.Constants.DB_TYPE;
+
+public class ActionListenerAdapter<T> implements ActionListener<T>, EnhancedInstance {
+
+    private final RestClientCache<T> restClientCache;
+
+    public ActionListenerAdapter(RestClientCache<T> restClientCache) {
+        this.restClientCache = restClientCache;
+    }
+
+    @Override
+    public void onResponse(final T o) {
+        try {
+            if (restClientCache.getContextSnapshot() != null) {
+                continueContext(Constants.ON_RESPONSE_SUFFIX);
+            }
+            if (restClientCache.getActionListener() != null) {
+                restClientCache.getActionListener().onResponse(o);
+            }
+        } catch (Throwable t) {
+            ContextManager.activeSpan().log(t);
+            throw t;
+        } finally {
+            restClientCache.setContextSnapshot(null);
+            ContextManager.stopSpan();
+        }
+    }
+
+    @Override
+    public void onFailure(final Exception e) {
+        try {
+            if (restClientCache.getContextSnapshot() != null) {
+                continueContext(Constants.ON_FAILURE_SUFFIX);
+            }
+            if (restClientCache.getActionListener() != null) {
+                restClientCache.getActionListener().onFailure(e);
+            }
+        } catch (Throwable t) {
+            ContextManager.activeSpan().log(t);
+            throw t;
+        } finally {
+            ContextManager.stopSpan();
+        }
+    }
+
+    @Override
+    public Object getSkyWalkingDynamicField() {
+        return restClientCache;
+    }
+
+    @Override
+    public void setSkyWalkingDynamicField(final Object enhanceInfo) {
+
+    }
+
+    private void continueContext(String action) {
+        AbstractSpan activeSpan = ContextManager.createLocalSpan(restClientCache.getOperationName() + action);
+        activeSpan.setComponent(ComponentsDefine.REST_HIGH_LEVEL_CLIENT);
+        Tags.DB_TYPE.set(activeSpan, DB_TYPE);
+        SpanLayer.asDB(activeSpan);
+        ContextManager.continued(restClientCache.getContextSnapshot());
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/support/AdapterUtil.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/support/AdapterUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.elasticsearch.v7.support;
+
+import org.apache.skywalking.apm.agent.core.context.ContextManager;
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.elasticsearch.action.ActionListener;
+
+public class AdapterUtil {
+
+    public static  <T> ActionListener<T> wrapActionListener(RestClientEnhanceInfo restClientEnhanceInfo,
+                                                     String operation,
+                                                     ActionListener<T> listener) {
+        ContextSnapshot capture = ContextManager.capture();
+        capture.getExtensionContext().setSendingTimestamp(System.currentTimeMillis());
+        RestClientCache<T> cache = new RestClientCache<T>();
+        cache.setEnhanceInfo(restClientEnhanceInfo);
+        cache.setContextSnapshot(capture);
+        cache.setOperationName(operation);
+        cache.setActionListener(listener);
+        return new ActionListenerAdapter<T>(cache);
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/support/RestClientCache.java
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/elasticsearch/v7/support/RestClientCache.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.elasticsearch.v7.support;
+
+import org.apache.skywalking.apm.agent.core.context.ContextSnapshot;
+import org.apache.skywalking.apm.plugin.elasticsearch.common.RestClientEnhanceInfo;
+import org.elasticsearch.action.ActionListener;
+
+public class RestClientCache<T> {
+    private RestClientEnhanceInfo enhanceInfo;
+    private ActionListener<T> actionListener;
+    private ContextSnapshot contextSnapshot;
+    private String operationName;
+
+    public ContextSnapshot getContextSnapshot() {
+        return contextSnapshot;
+    }
+
+    public void setContextSnapshot(final ContextSnapshot contextSnapshot) {
+        this.contextSnapshot = contextSnapshot;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(final String operationName) {
+        this.operationName = operationName;
+    }
+
+    public ActionListener<T> getActionListener() {
+        return actionListener;
+    }
+
+    public void setActionListener(final ActionListener<T> actionListener) {
+        this.actionListener = actionListener;
+    }
+
+    public RestClientEnhanceInfo getEnhanceInfo() {
+        return enhanceInfo;
+    }
+
+    public void setEnhanceInfo(final RestClientEnhanceInfo enhanceInfo) {
+        this.enhanceInfo = enhanceInfo;
+    }
+}

--- a/docs/en/setup/service-agent/java-agent/Supported-list.md
+++ b/docs/en/setup/service-agent/java-agent/Supported-list.md
@@ -98,7 +98,7 @@ metrics based on the tracing data.
     * [transport-client](https://github.com/elastic/elasticsearch/tree/v6.2.3/client/transport) 6.2.3-6.8.4
     * [transport-client](https://github.com/elastic/elasticsearch/tree/7.0/client/transport) 7.0.0-7.5.2
     * [rest-high-level-client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/6.7/index.html) 6.7.1-6.8.4
-    * [rest-high-level-client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.0/java-rest-high.html) 7.0.0-7.5.2
+    * [rest-high-level-client](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.0/java-rest-high.html) 7.x
   * [Solr](https://github.com/apache/solr/)
     * [SolrJ](https://github.com/apache/solr/tree/main/solr/solrj) 7.x
   * [Cassandra](https://github.com/apache/cassandra) 3.x

--- a/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
@@ -128,7 +128,7 @@ segmentItems:
               - {key: transmission.latency, value: not null}
             refs:
               - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
-                 refType: CrossThread, parentSpanId: 12, parentTraceSegmentId: not null,
+                 refType: CrossThread, parentSpanId: 13, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -149,7 +149,7 @@ segmentItems:
               - {key: transmission.latency, value: not null}
             refs:
               - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
-                 refType: CrossThread, parentSpanId: 14, parentTraceSegmentId: not null,
+                 refType: CrossThread, parentSpanId: 15, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -170,7 +170,7 @@ segmentItems:
               - {key: transmission.latency, value: not null}
             refs:
               - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
-                 refType: CrossThread, parentSpanId: 16, parentTraceSegmentId: not null,
+                 refType: CrossThread, parentSpanId: 17, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -191,7 +191,7 @@ segmentItems:
               - {key: transmission.latency, value: not null}
             refs:
               - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
-                 refType: CrossThread, parentSpanId: 18, parentTraceSegmentId: not null,
+                 refType: CrossThread, parentSpanId: 19, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -212,7 +212,7 @@ segmentItems:
               - {key: transmission.latency, value: not null}
             refs:
               - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
-                 refType: CrossThread, parentSpanId: 20, parentTraceSegmentId: not null,
+                 refType: CrossThread, parentSpanId: 21, parentTraceSegmentId: not null,
                  parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
                  traceId: not null}
       - segmentId: not null
@@ -357,7 +357,7 @@ segmentItems:
             tags:
               - {key: db.type, value: Elasticsearch}
               - {key: db.instance, value: not null}
-          - operationName: Elasticsearch/GetRequest
+          - operationName: Elasticsearch/RefreshRequest
             parentSpanId: 0
             spanId: 11
             spanLayer: Database
@@ -371,7 +371,6 @@ segmentItems:
             tags:
               - {key: db.type, value: Elasticsearch}
               - {key: db.instance, value: not null}
-              - {key: db.statement, value: not null}
           - operationName: Elasticsearch/GetRequest
             parentSpanId: 0
             spanId: 12
@@ -387,7 +386,7 @@ segmentItems:
               - {key: db.type, value: Elasticsearch}
               - {key: db.instance, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/SearchRequest
+          - operationName: Elasticsearch/GetRequest
             parentSpanId: 0
             spanId: 13
             spanLayer: Database
@@ -417,7 +416,7 @@ segmentItems:
               - {key: db.type, value: Elasticsearch}
               - {key: db.instance, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/UpdateRequest
+          - operationName: Elasticsearch/SearchRequest
             parentSpanId: 0
             spanId: 15
             spanLayer: Database
@@ -447,7 +446,7 @@ segmentItems:
               - {key: db.type, value: Elasticsearch}
               - {key: db.instance, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/AnalyzeRequest
+          - operationName: Elasticsearch/UpdateRequest
             parentSpanId: 0
             spanId: 17
             spanLayer: Database
@@ -460,7 +459,7 @@ segmentItems:
             skipAnalysis: false
             tags:
               - {key: db.type, value: Elasticsearch}
-              - {key: analyzer, value: not null}
+              - {key: db.instance, value: not null}
               - {key: db.statement, value: not null}
           - operationName: Elasticsearch/AnalyzeRequest
             parentSpanId: 0
@@ -477,7 +476,7 @@ segmentItems:
               - {key: db.type, value: Elasticsearch}
               - {key: analyzer, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/DeleteRequest
+          - operationName: Elasticsearch/AnalyzeRequest
             parentSpanId: 0
             spanId: 19
             spanLayer: Database
@@ -490,7 +489,8 @@ segmentItems:
             skipAnalysis: false
             tags:
               - {key: db.type, value: Elasticsearch}
-              - {key: db.instance, value: not null}
+              - {key: analyzer, value: not null}
+              - {key: db.statement, value: not null}
           - operationName: Elasticsearch/DeleteRequest
             parentSpanId: 0
             spanId: 20
@@ -505,9 +505,23 @@ segmentItems:
             tags:
               - {key: db.type, value: Elasticsearch}
               - {key: db.instance, value: not null}
-          - operationName: Elasticsearch/IndexRequest
+          - operationName: Elasticsearch/DeleteRequest
             parentSpanId: 0
             spanId: 21
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/IndexRequest
+            parentSpanId: 0
+            spanId: 22
             spanLayer: Database
             startTime: not null
             endTime: not null
@@ -525,7 +539,7 @@ segmentItems:
               - {key: db.statement, value: not null}
           - operationName: Elasticsearch/actionGet
             parentSpanId: 0
-            spanId: 22
+            spanId: 23
             spanLayer: Unknown
             startTime: not null
             endTime: not null
@@ -538,24 +552,6 @@ segmentItems:
               - {key: db.type, value: Elasticsearch}
               - {key: db.statement, value: not null}
           - operationName: Elasticsearch/GetRequest
-            parentSpanId: 0
-            spanId: 23
-            spanLayer: Database
-            startTime: not null
-            endTime: not null
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            skipAnalysis: false
-            tags:
-              - {key: db.type, value: Elasticsearch}
-              - {key: db.instance, value: not null}
-              - {key: node.address, value: not null}
-              - {key: es.indices, value: not null}
-              - {key: es.types, value: not null}
-              - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/SearchRequest
             parentSpanId: 0
             spanId: 24
             spanLayer: Database
@@ -573,25 +569,9 @@ segmentItems:
               - {key: es.indices, value: not null}
               - {key: es.types, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/actionGet
+          - operationName: Elasticsearch/SearchRequest
             parentSpanId: 0
             spanId: 25
-            spanLayer: Unknown
-            startTime: not null
-            endTime: not null
-            componentId: 48
-            isError: false
-            spanType: Local
-            peer: ''
-            skipAnalysis: false
-            tags:
-              - {key: db.type, value: Elasticsearch}
-              - {key: es.took_millis, value: not null}
-              - {key: es.total_hits, value: not null}
-              - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/UpdateRequest
-            parentSpanId: 0
-            spanId: 26
             spanLayer: Database
             startTime: not null
             endTime: not null
@@ -607,7 +587,23 @@ segmentItems:
               - {key: es.indices, value: not null}
               - {key: es.types, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/DeleteRequest
+          - operationName: Elasticsearch/actionGet
+            parentSpanId: 0
+            spanId: 26
+            spanLayer: Unknown
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: es.took_millis, value: not null}
+              - {key: es.total_hits, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/UpdateRequest
             parentSpanId: 0
             spanId: 27
             spanLayer: Database
@@ -625,9 +621,27 @@ segmentItems:
               - {key: es.indices, value: not null}
               - {key: es.types, value: not null}
               - {key: db.statement, value: not null}
-          - operationName: Elasticsearch/DeleteIndexRequest
+          - operationName: Elasticsearch/DeleteRequest
             parentSpanId: 0
             spanId: 28
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+              - {key: es.types, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/DeleteIndexRequest
+            parentSpanId: 0
+            spanId: 29
             spanLayer: Database
             startTime: not null
             endTime: not null

--- a/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/elasticsearch-7.x-scenario/config/expectedData.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 segmentItems:
   - serviceName: elasticsearch-7.x-scenario
-    segmentSize: ge 1
+    segmentSize: ge 10
     segments:
       - segmentId: not null
         spans:
@@ -23,303 +23,636 @@ segmentItems:
             parentSpanId: 0
             spanId: 1
             spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
+            startTime: not null
+            endTime: not null
             componentId: 77
             isError: false
             spanType: Exit
             peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/GetSettings
-            parentSpanId: 0
-            spanId: 2
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/PutSettings
-            parentSpanId: 0
-            spanId: 3
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/CreateRequest
-            parentSpanId: 0
-            spanId: 4
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/IndexRequest
-            parentSpanId: 0
-            spanId: 5
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/RefreshRequest
-            parentSpanId: 0
-            spanId: 6
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/GetRequest
-            parentSpanId: 0
-            spanId: 7
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/SearchRequest
-            parentSpanId: 0
-            spanId: 8
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/UpdateRequest
-            parentSpanId: 0
-            spanId: 9
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/AnalyzeRequest
-            parentSpanId: 0
-            spanId: 10
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: analyzer, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/DeleteRequest
-            parentSpanId: 0
-            spanId: 11
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 77
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/IndexRequest
-            parentSpanId: 0
-            spanId: 12
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: node.address, value: not null }
-              - { key: es.indices, value: not null }
-              - { key: es.types, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/actionGet
-            parentSpanId: 0
-            spanId: 13
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Local
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/GetRequest
-            parentSpanId: 0
-            spanId: 14
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: node.address, value: not null }
-              - { key: es.indices, value: not null }
-              - { key: es.types, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/SearchRequest
-            parentSpanId: 0
-            spanId: 15
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: node.address, value: not null }
-              - { key: es.indices, value: not null }
-              - { key: es.types, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/actionGet
-            parentSpanId: 0
-            spanId: 16
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Local
+            skipAnalysis: false
             tags:
               - {key: db.type, value: Elasticsearch}
-              - {key: es.took_millis, value: not null }
-              - {key: es.total_hits, value: not null }
-              - {key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/UpdateRequest
-            parentSpanId: 0
-            spanId: 17
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: node.address, value: not null }
-              - { key: es.indices, value: not null }
-              - { key: es.types, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/DeleteRequest
-            parentSpanId: 0
-            spanId: 18
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: node.address, value: not null }
-              - { key: es.indices, value: not null }
-              - { key: es.types, value: not null }
-              - { key: db.statement, value: not null }
-            skipAnalysis: 'false'
-          - operationName: Elasticsearch/DeleteIndexRequest
-            parentSpanId: 0
-            spanId: 19
-            spanLayer: Database
-            startTime: nq 0
-            endTime: nq 0
-            componentId: 48
-            isError: false
-            spanType: Exit
-            peer: not null
-            tags:
-              - { key: db.type, value: Elasticsearch }
-              - { key: db.instance, value: not null }
-              - { key: node.address, value: not null }
-              - { key: es.indices, value: not null }
-            skipAnalysis: 'false'
-          - operationName: GET:/elasticsearch-case/case/elasticsearch
+          - operationName: HEAD:/elasticsearch-case/case/healthCheck
             parentSpanId: -1
             spanId: 0
             spanLayer: Http
-            startTime: nq 0
-            endTime: nq 0
+            startTime: not null
+            endTime: not null
             componentId: 1
             isError: false
             spanType: Entry
             peer: ''
+            skipAnalysis: false
             tags:
-              - { key: url, value: 'http://localhost:8080/elasticsearch-case/case/elasticsearch' }
-              - { key: http.method, value: GET }
+              - {key: url, value: 'http://localhost:8080/elasticsearch-case/case/healthCheck'}
+              - {key: http.method, value: HEAD}
               - {key: http.status_code, value: '200'}
-            skipAnalysis: 'false'
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/CreateRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 5, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/IndexRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 8, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/RefreshRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 9, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/GetRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 12, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/SearchRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 14, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/UpdateRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 16, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/AnalyzeRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 18, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/DeleteRequest/onResponse
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: transmission.latency, value: not null}
+            refs:
+              - {parentEndpoint: 'GET:/elasticsearch-case/case/elasticsearch', networkAddress: '',
+                 refType: CrossThread, parentSpanId: 20, parentTraceSegmentId: not null,
+                 parentServiceInstance: not null, parentService: elasticsearch-7.x-scenario,
+                 traceId: not null}
+      - segmentId: not null
+        spans:
+          - operationName: Elasticsearch/Health
+            parentSpanId: 0
+            spanId: 1
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+          - operationName: Elasticsearch/GetSettings
+            parentSpanId: 0
+            spanId: 2
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+          - operationName: Elasticsearch/PutSettings
+            parentSpanId: 0
+            spanId: 3
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/CreateRequest
+            parentSpanId: 0
+            spanId: 4
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/CreateRequest
+            parentSpanId: 0
+            spanId: 5
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/IndexRequest
+            parentSpanId: 0
+            spanId: 6
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/RefreshRequest
+            parentSpanId: 0
+            spanId: 7
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/IndexRequest
+            parentSpanId: 0
+            spanId: 8
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/RefreshRequest
+            parentSpanId: 0
+            spanId: 9
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/RefreshRequest
+            parentSpanId: 0
+            spanId: 10
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/GetRequest
+            parentSpanId: 0
+            spanId: 11
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/GetRequest
+            parentSpanId: 0
+            spanId: 12
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/SearchRequest
+            parentSpanId: 0
+            spanId: 13
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/SearchRequest
+            parentSpanId: 0
+            spanId: 14
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/UpdateRequest
+            parentSpanId: 0
+            spanId: 15
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/UpdateRequest
+            parentSpanId: 0
+            spanId: 16
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/AnalyzeRequest
+            parentSpanId: 0
+            spanId: 17
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: analyzer, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/AnalyzeRequest
+            parentSpanId: 0
+            spanId: 18
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: analyzer, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/DeleteRequest
+            parentSpanId: 0
+            spanId: 19
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/DeleteRequest
+            parentSpanId: 0
+            spanId: 20
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 77
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+          - operationName: Elasticsearch/IndexRequest
+            parentSpanId: 0
+            spanId: 21
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+              - {key: es.types, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/actionGet
+            parentSpanId: 0
+            spanId: 22
+            spanLayer: Unknown
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/GetRequest
+            parentSpanId: 0
+            spanId: 23
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+              - {key: es.types, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/SearchRequest
+            parentSpanId: 0
+            spanId: 24
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+              - {key: es.types, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/actionGet
+            parentSpanId: 0
+            spanId: 25
+            spanLayer: Unknown
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Local
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: es.took_millis, value: not null}
+              - {key: es.total_hits, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/UpdateRequest
+            parentSpanId: 0
+            spanId: 26
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+              - {key: es.types, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/DeleteRequest
+            parentSpanId: 0
+            spanId: 27
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+              - {key: es.types, value: not null}
+              - {key: db.statement, value: not null}
+          - operationName: Elasticsearch/DeleteIndexRequest
+            parentSpanId: 0
+            spanId: 28
+            spanLayer: Database
+            startTime: not null
+            endTime: not null
+            componentId: 48
+            isError: false
+            spanType: Exit
+            peer: not null
+            skipAnalysis: false
+            tags:
+              - {key: db.type, value: Elasticsearch}
+              - {key: db.instance, value: not null}
+              - {key: node.address, value: not null}
+              - {key: es.indices, value: not null}
+          - operationName: GET:/elasticsearch-case/case/elasticsearch
+            parentSpanId: -1
+            spanId: 0
+            spanLayer: Http
+            startTime: not null
+            endTime: not null
+            componentId: 1
+            isError: false
+            spanType: Entry
+            peer: ''
+            skipAnalysis: false
+            tags:
+              - {key: url, value: 'http://localhost:8080/elasticsearch-case/case/elasticsearch'}
+              - {key: http.method, value: GET}
+              - {key: http.status_code, value: '200'}

--- a/test/plugin/scenarios/elasticsearch-7.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/elasticsearch/RestHighLevelClientCase.java
+++ b/test/plugin/scenarios/elasticsearch-7.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/elasticsearch/RestHighLevelClientCase.java
@@ -109,6 +109,7 @@ public class RestHighLevelClientCase {
 
             // refresh
             client.indices().refresh(new RefreshRequest(indexName), RequestOptions.DEFAULT);
+            client.indices().refresh(new RefreshRequest(indexName2), RequestOptions.DEFAULT);
 
             // get
             get(indexName);

--- a/test/plugin/scenarios/elasticsearch-7.x-scenario/support-version.list
+++ b/test/plugin/scenarios/elasticsearch-7.x-scenario/support-version.list
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# 7.0.0 - 7.17.12 have been tested, and 7.0.0 - 7.2.1 not included in the test
 7.3.2
 7.4.2
 7.5.2
@@ -27,4 +28,4 @@
 7.13.4
 7.14.2
 7.16.3
-7.17.12
+7.17.21


### PR DESCRIPTION
### Support for tracing the callbacks of async methods in elastiicsearch-6.x/7.x-plugin
- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

callbacks(onResponse/onFailure) for 
- createAsync
- deleteAsync
- analyzeAsync
- refreshAsync
- getAsync
- searchAsync
- indexAsync
- updateAsync
- scrollAsync
- searchTemplateAsync
- clearScrollAsync
- deleteByQueryAsync

<img width="1434" alt="image" src="https://github.com/apache/skywalking-java/assets/22817918/c29f3bbf-a690-486b-b455-62b59f20ff3d">

Trace details:
<img width="1128" alt="ElasticsearchDeleteRequestonResponse" src="https://github.com/apache/skywalking-java/assets/22817918/36350f07-f755-4436-95b3-40fd310b027f">
<img width="1112" alt="ElasticsearchGetReguest" src="https://github.com/apache/skywalking-java/assets/22817918/04677e4b-4e12-41f9-8080-eee45c39ad89">
<img width="1121" alt="ElasticsearchactionGet" src="https://github.com/apache/skywalking-java/assets/22817918/3fa3309e-95a2-4ac4-b2f0-deb47a249768">

record `transmission.latency` when callback:

<img width="1365" alt="image" src="https://github.com/apache/skywalking-java/assets/22817918/d37b161c-b44c-4bd2-a008-c2dba1396178">

7.0.0 - 7.2.1 not included in the test because analyze method appears since 7.3.0
