### PR TITLE
Fix to Ensure All Rules Satisfy not isInterface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Release Notes.
 * Support for showing batch command details and ignoring PING commands in Redisson plugin.
 * Fix peer value of Master-Slave mode in Redisson plugin.
 * Support for tracing the callbacks of asynchronous methods in elasticsearch-6.x-plugin/elasticsearch-7.x-plugin.
+* Fixed the invalid issue in the isInterface method in PluginFinder.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/213?closed=1)
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
@@ -95,13 +95,13 @@ public class PluginFinder {
                 return nameMatchDefine.containsKey(target.getActualName());
             }
         };
-        judge = judge.and(not(isInterface()));
         for (AbstractClassEnhancePluginDefine define : signatureMatchDefine) {
             ClassMatch match = define.enhanceClass();
             if (match instanceof IndirectMatch) {
                 judge = judge.or(((IndirectMatch) match).buildJunction());
             }
         }
+        judge = judge.and(not(isInterface()));
         return new ProtectiveShieldMatcher(judge);
     }
 

--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginFinder.java
@@ -101,7 +101,8 @@ public class PluginFinder {
                 judge = judge.or(((IndirectMatch) match).buildJunction());
             }
         }
-        judge = judge.and(not(isInterface()));
+        // Filter out all matchers returns to exclude pure interface types.
+        judge = not(isInterface()).and(judge);
         return new ProtectiveShieldMatcher(judge);
     }
 


### PR DESCRIPTION

### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it. 
    According to the code principles of `net.bytebuddy.matcher.ElementMatcher.Junction`:
    In the current code, the running effect can only ensure that the first `NamedMatch` satisfies `not isInterface`:
   ` (((NamedMatch) and (not(isInterface))) or IndirectMatch) or...IndirectMatch.`
    
    After moving `not isInterface` to the end, the running effect can ensure that all rules satisfy `not isInterface`:
   ` (((NamedMatch) or (IndirectMatch)) or...IndirectMatch) and not(isInterface).`

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
