### PR TITLE
Fixed issues in the MySQL component where the executeBatch method could result in empty SQL statements .

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Release Notes.
 * Fix the opentracing toolkit SPI config
 * Improve 4x performance of ContextManagerExtendService.createTraceContext()
 * Add a plugin that supports the Solon framework.
+* Fixed issues in the MySQL component where the executeBatch method could result in empty SQL statements and missing SQL parameters in certain scenarios.
 
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/213?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Release Notes.
 * Fix the opentracing toolkit SPI config
 * Improve 4x performance of ContextManagerExtendService.createTraceContext()
 * Add a plugin that supports the Solon framework.
-* Fixed issues in the MySQL component where the executeBatch method could result in empty SQL statements and missing SQL parameters in certain scenarios.
+* Fixed issues in the MySQL component where the executeBatch method could result in empty SQL statements .
 
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/213?closed=1)

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptor.java
@@ -25,8 +25,6 @@ import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
-import org.apache.skywalking.apm.plugin.jdbc.JDBCPluginConfig;
-import org.apache.skywalking.apm.plugin.jdbc.PreparedStatementParameterBuilder;
 import org.apache.skywalking.apm.plugin.jdbc.SqlBodyUtil;
 import org.apache.skywalking.apm.plugin.jdbc.define.StatementEnhanceInfos;
 import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
@@ -67,14 +65,6 @@ public class StatementExecuteMethodsInterceptor implements InstanceMethodsAround
             }
 
             Tags.DB_STATEMENT.set(span, sql);
-            if (JDBCPluginConfig.Plugin.JDBC.TRACE_SQL_PARAMETERS) {
-                final Object[] parameters = cacheObject.getParameters();
-                if (parameters != null && parameters.length > 0) {
-                    int maxIndex = cacheObject.getMaxIndex();
-                    String parameterString = getParameterString(parameters, maxIndex);
-                    Tags.SQL_PARAMETERS.set(span, parameterString);
-                }
-            }
             span.setComponent(connectInfo.getComponent());
 
             SpanLayer.asDB(span);
@@ -102,12 +92,5 @@ public class StatementExecuteMethodsInterceptor implements InstanceMethodsAround
 
     private String buildOperationName(ConnectionInfo connectionInfo, String methodName, String statementName) {
         return connectionInfo.getDBType() + "/JDBC/" + statementName + "/" + methodName;
-    }
-
-    private String getParameterString(Object[] parameters, int maxIndex) {
-        return new PreparedStatementParameterBuilder()
-                .setParameters(parameters)
-                .setMaxIndex(maxIndex)
-                .build();
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/main/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptor.java
@@ -25,9 +25,12 @@ import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceMethodsAroundInterceptor;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.MethodInterceptResult;
+import org.apache.skywalking.apm.plugin.jdbc.JDBCPluginConfig;
+import org.apache.skywalking.apm.plugin.jdbc.PreparedStatementParameterBuilder;
 import org.apache.skywalking.apm.plugin.jdbc.SqlBodyUtil;
 import org.apache.skywalking.apm.plugin.jdbc.define.StatementEnhanceInfos;
 import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
+import org.apache.skywalking.apm.util.StringUtil;
 
 import java.lang.reflect.Method;
 
@@ -52,15 +55,26 @@ public class StatementExecuteMethodsInterceptor implements InstanceMethodsAround
             Tags.DB_INSTANCE.set(span, connectInfo.getDatabaseName());
 
             /**
-             * The first argument of all intercept method in `com.mysql.jdbc.StatementImpl` class is SQL, except the
-             * `executeBatch` method that the jdbc plugin need to trace, because of this method argument size is zero.
+             * Except for the `executeBatch` method, the first parameter of all enhanced methods in `com.mysql.jdbc.StatementImpl` is the SQL statement.
+             * Therefore, executeBatch will attempt to obtain the SQL from `cacheObject`.
              */
             String sql = "";
             if (allArguments.length > 0) {
                 sql = (String) allArguments[0];
                 sql = SqlBodyUtil.limitSqlBodySize(sql);
+            } else if (StringUtil.isNotBlank(cacheObject.getSql())) {
+                sql = SqlBodyUtil.limitSqlBodySize(cacheObject.getSql());
             }
+
             Tags.DB_STATEMENT.set(span, sql);
+            if (JDBCPluginConfig.Plugin.JDBC.TRACE_SQL_PARAMETERS) {
+                final Object[] parameters = cacheObject.getParameters();
+                if (parameters != null && parameters.length > 0) {
+                    int maxIndex = cacheObject.getMaxIndex();
+                    String parameterString = getParameterString(parameters, maxIndex);
+                    Tags.SQL_PARAMETERS.set(span, parameterString);
+                }
+            }
             span.setComponent(connectInfo.getComponent());
 
             SpanLayer.asDB(span);
@@ -88,5 +102,12 @@ public class StatementExecuteMethodsInterceptor implements InstanceMethodsAround
 
     private String buildOperationName(ConnectionInfo connectionInfo, String methodName, String statementName) {
         return connectionInfo.getDBType() + "/JDBC/" + statementName + "/" + methodName;
+    }
+
+    private String getParameterString(Object[] parameters, int maxIndex) {
+        return new PreparedStatementParameterBuilder()
+                .setParameters(parameters)
+                .setMaxIndex(maxIndex)
+                .build();
     }
 }

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/test/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/test/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptorTest.java
@@ -73,32 +73,13 @@ public class StatementExecuteMethodsInterceptorTest {
         serviceMethodInterceptor = new StatementExecuteMethodsInterceptor();
 
         enhanceRequireCacheObject = new StatementEnhanceInfos(connectionInfo, SQL, "CallableStatement");
-        enhanceRequireCacheObject.setParameter(1, "value1");
+
         when(objectInstance.getSkyWalkingDynamicField()).thenReturn(enhanceRequireCacheObject);
         when(method.getName()).thenReturn("executeQuery");
         when(connectionInfo.getComponent()).thenReturn(ComponentsDefine.H2_JDBC_DRIVER);
         when(connectionInfo.getDBType()).thenReturn("H2");
         when(connectionInfo.getDatabaseName()).thenReturn("test");
         when(connectionInfo.getDatabasePeer()).thenReturn("localhost:3307");
-    }
-
-    @Test
-    public void testCreateDatabaseSpanWithSqlParam() throws Throwable {
-        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 2048;
-        JDBCPluginConfig.Plugin.JDBC.TRACE_SQL_PARAMETERS = true;
-        serviceMethodInterceptor.beforeMethod(objectInstance, method, new Object[] {"SELECT * FROM test WHERE id = ?"}, null, null);
-        serviceMethodInterceptor.afterMethod(objectInstance, method, new Object[] {"SELECT * FROM test WHERE id = ?"}, null, null);
-
-        assertThat(segmentStorage.getTraceSegments().size(), is(1));
-        TraceSegment segment = segmentStorage.getTraceSegments().get(0);
-        assertThat(SegmentHelper.getSpans(segment).size(), is(1));
-        AbstractTracingSpan span = SegmentHelper.getSpans(segment).get(0);
-        SpanAssert.assertLayer(span, SpanLayer.DB);
-        assertThat(span.getOperationName(), is("H2/JDBC/CallableStatement/executeQuery"));
-        SpanAssert.assertTag(span, 0, "H2");
-        SpanAssert.assertTag(span, 1, "test");
-        SpanAssert.assertTag(span, 2, "SELECT * FROM test WHERE id = ?");
-        SpanAssert.assertTag(span, 3, "[value1]");
     }
 
     @Test

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/src/test/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/src/test/java/org/apache/skywalking/apm/plugin/jdbc/mysql/StatementExecuteMethodsInterceptorTest.java
@@ -72,13 +72,51 @@ public class StatementExecuteMethodsInterceptorTest {
         JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 2048;
         serviceMethodInterceptor = new StatementExecuteMethodsInterceptor();
 
-        enhanceRequireCacheObject = new StatementEnhanceInfos(connectionInfo, "SELECT * FROM test", "CallableStatement");
+        enhanceRequireCacheObject = new StatementEnhanceInfos(connectionInfo, SQL, "CallableStatement");
+        enhanceRequireCacheObject.setParameter(1, "value1");
         when(objectInstance.getSkyWalkingDynamicField()).thenReturn(enhanceRequireCacheObject);
         when(method.getName()).thenReturn("executeQuery");
         when(connectionInfo.getComponent()).thenReturn(ComponentsDefine.H2_JDBC_DRIVER);
         when(connectionInfo.getDBType()).thenReturn("H2");
         when(connectionInfo.getDatabaseName()).thenReturn("test");
         when(connectionInfo.getDatabasePeer()).thenReturn("localhost:3307");
+    }
+
+    @Test
+    public void testCreateDatabaseSpanWithSqlParam() throws Throwable {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 2048;
+        JDBCPluginConfig.Plugin.JDBC.TRACE_SQL_PARAMETERS = true;
+        serviceMethodInterceptor.beforeMethod(objectInstance, method, new Object[] {"SELECT * FROM test WHERE id = ?"}, null, null);
+        serviceMethodInterceptor.afterMethod(objectInstance, method, new Object[] {"SELECT * FROM test WHERE id = ?"}, null, null);
+
+        assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment segment = segmentStorage.getTraceSegments().get(0);
+        assertThat(SegmentHelper.getSpans(segment).size(), is(1));
+        AbstractTracingSpan span = SegmentHelper.getSpans(segment).get(0);
+        SpanAssert.assertLayer(span, SpanLayer.DB);
+        assertThat(span.getOperationName(), is("H2/JDBC/CallableStatement/executeQuery"));
+        SpanAssert.assertTag(span, 0, "H2");
+        SpanAssert.assertTag(span, 1, "test");
+        SpanAssert.assertTag(span, 2, "SELECT * FROM test WHERE id = ?");
+        SpanAssert.assertTag(span, 3, "[value1]");
+    }
+
+    @Test
+    public void testCreateDatabaseSpanWithNoMethodParamButWithCache() throws Throwable {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 2048;
+
+        serviceMethodInterceptor.beforeMethod(objectInstance, method, new Object[0], null, null);
+        serviceMethodInterceptor.afterMethod(objectInstance, method, new Object[0], null, null);
+
+        assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment segment = segmentStorage.getTraceSegments().get(0);
+        assertThat(SegmentHelper.getSpans(segment).size(), is(1));
+        AbstractTracingSpan span = SegmentHelper.getSpans(segment).get(0);
+        SpanAssert.assertLayer(span, SpanLayer.DB);
+        assertThat(span.getOperationName(), is("H2/JDBC/CallableStatement/executeQuery"));
+        SpanAssert.assertTag(span, 0, "H2");
+        SpanAssert.assertTag(span, 1, "test");
+        SpanAssert.assertTag(span, 2, SQL);
     }
 
     @Test


### PR DESCRIPTION
Fixed an issue in the MySQL component where the executeBatch method could obtain SQL in certain scenarios, but the final SQL statement was empty.
The issue arises because the existing code defaults to using the first parameter of the enhanced method as the source of the SQL statement. However, the executeBatch method does not have any parameters. Given the[ previous problem](https://github.com/apache/skywalking-java/commit/c9dbd6d9c3777661479c6d8d413603431d2eb9d6) where SQL could not be obtained from the cacheObject, this approach merely attempts to retrieve the SQL to the best extent possible, though perfect collection cannot be guaranteed.
 

