### PR TITLE
Fix problem in the jetty-client-9.x which leading original listener reading empty content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Release Notes.
 * Improve 4x performance of ContextManagerExtendService.createTraceContext()
 * Add a plugin that supports the Solon framework.
 * Fixed issues in the MySQL component where the executeBatch method could result in empty SQL statements .
+* Fix problem in the jetty-client-9.x which leading original listener reading empty content
 
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/213?closed=1)

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
@@ -31,7 +31,7 @@
     <url>http://maven.apache.org</url>
 
     <properties>
-        <jetty-client.version>9.1.0.v20131115</jetty-client.version>
+        <jetty-client.version>9.4.55.v20240627</jetty-client.version>
     </properties>
 
     <dependencies>

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jetty/v9/client/AsyncHttpRequestSendInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jetty/v9/client/AsyncHttpRequestSendInterceptorTest.java
@@ -33,6 +33,7 @@ import org.apache.skywalking.apm.agent.test.tools.SpanAssert;
 import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
 import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpConversation;
 import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.ResponseNotifier;
 import org.eclipse.jetty.client.api.Response;
@@ -147,7 +148,7 @@ public class AsyncHttpRequestSendInterceptorTest {
 
     private class MockHttpRequest extends HttpRequest implements EnhancedInstance {
         public MockHttpRequest(HttpClient httpClient, URI uri) {
-            super(httpClient, uri);
+            super(httpClient, new HttpConversation(), uri);
         }
 
         @Override
@@ -173,7 +174,7 @@ public class AsyncHttpRequestSendInterceptorTest {
 
     private class MockResponseNotifier extends ResponseNotifier implements EnhancedInstance {
         public MockResponseNotifier(HttpClient client) {
-            super(client);
+            super();
         }
 
         @Override

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jetty/v9/client/SyncHttpRequestSendInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jetty/v9/client/SyncHttpRequestSendInterceptorTest.java
@@ -34,6 +34,7 @@ import org.apache.skywalking.apm.agent.test.tools.SegmentStoragePoint;
 import org.apache.skywalking.apm.agent.test.tools.SpanAssert;
 import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpConversation;
 import org.eclipse.jetty.client.HttpRequest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -124,7 +125,7 @@ public class SyncHttpRequestSendInterceptorTest {
 
     private class MockHttpRequest extends HttpRequest implements EnhancedInstance {
         public MockHttpRequest(HttpClient httpClient, URI uri) {
-            super(httpClient, uri);
+            super(httpClient, new HttpConversation(), uri);
         }
 
         @Override


### PR DESCRIPTION






### Fix problem in the jetty-client-9.x which leading original listener reading empty content

- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
  
  

when using jetty-client 9.x send async request, reponse body is always empty

because the onContent callback could not be executed

```java
        request.send(new BufferingResponseListener() {
            @Override
            public void onComplete(Result result) {
                try { 
                    //this is always empty when use agent
                    byte[] responseBytes = getContent();
                    if (responseBytes == null || responseBytes.length == 0) {
                        System.out.println("responseBytes is empty");
                    }
                    System.out.println(new String(responseBytes, "UTF-8"));
                } catch (UnsupportedEncodingException e) {
                    throw new RuntimeException(e);
                }
            }
        });
```



- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).