### PR TITLE
fix redission has not parameter problem

### DIFF
--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/redisson/v3/RedisConnectionMethodInterceptor.java
@@ -140,6 +140,9 @@ public class RedisConnectionMethodInterceptor implements InstanceMethodsAroundIn
             return Optional.empty();
         }
         Object argument = allArguments[0];
+        if (argument instanceof byte[]) {
+            return Optional.of(new String((byte[]) argument));
+        }
         // include null
         if (!(argument instanceof String)) {
             return Optional.empty();


### PR DESCRIPTION
when i use redission plugin,i found even agent.config plugin.redisson.trace_redis_parameters set to true but skywalking ui do not have parameter. so fix this problem.