### PR TITLE
[plugin][pulsar] Handle the SendCallback method sign changed.

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -56,7 +56,7 @@ runs:
         ./mvnw -q --batch-mode clean package -Dmaven.test.skip || \
         ./mvnw -q --batch-mode clean package -Dmaven.test.skip
         echo "::endgroup::"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       name: Upload Agent
       with:
         name: skywalking-agent
@@ -89,7 +89,7 @@ runs:
         docker save -o test-containers/skywalking-agent-test-jvm-1.0.0.tgz skywalking/agent-test-jvm:1.0.0
         docker save -o test-containers/skywalking-agent-test-tomcat-1.0.0.tgz skywalking/agent-test-tomcat:1.0.0
         echo "::endgroup::"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       name: Upload Test Containers
       with:
         name: test-tools

--- a/.github/actions/run/action.yml
+++ b/.github/actions/run/action.yml
@@ -53,7 +53,7 @@ runs:
         echo "::group::Run Plugin Test ${{ inputs.test_case }}"
         bash test/plugin/run.sh ${{ inputs.test_case }}
         echo "::endgroup::"
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       name: Upload Agent
       if: always()
       with:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -54,11 +54,11 @@ jobs:
         java-version: 17
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - run: ./mvnw -q -Dmaven.test.skip=true clean install || ./mvnw -q -Dmaven.test.skip=true clean install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -47,7 +47,7 @@ jobs:
           java-version: 17
       - name: Build Agent
         run: make build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload Agent
         with:
           name: skywalking-agent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Release Notes.
 ------------------
 
 * Upgrade nats plugin to support 2.16.5
+* [pulsar] Handle the SendCallback class method signature change.
 
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/222?closed=1)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Release Notes.
 ------------------
 
 * Upgrade nats plugin to support 2.16.5
-* [pulsar] Handle the SendCallback class method signature change.
+* Support newer Pulsar versions to adopt SendCallback class method signature change.
 
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/222?closed=1)

--- a/apm-sniffer/apm-sdk-plugin/pulsar-common/src/main/java/org/apache/skywalking/apm/plugin/pulsar/common/SendCallbackInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-common/src/main/java/org/apache/skywalking/apm/plugin/pulsar/common/SendCallbackInterceptor.java
@@ -62,9 +62,9 @@ public class SendCallbackInterceptor implements InstanceMethodsAroundInterceptor
         Object ret) throws Throwable {
         SendCallbackEnhanceRequiredInfo requiredInfo = (SendCallbackEnhanceRequiredInfo) objInst.getSkyWalkingDynamicField();
         if (null != requiredInfo.getContextSnapshot()) {
-            Exception exceptions = (Exception) allArguments[0];
-            if (exceptions != null) {
-                ContextManager.activeSpan().log(exceptions);
+            Throwable t = (Throwable) allArguments[0];
+            if (t != null) {
+                ContextManager.activeSpan().log(t);
             }
             ContextManager.stopSpan();
         }


### PR DESCRIPTION
In https://github.com/apache/pulsar/pull/22940, Pulsar will change the `org.apache.pulsar.client.impl.SendCallback#sendComplete` method sign from

```java
public void sendComplete(Exception e)
```
to

```java
public void sendComplete(Throwable t, OpSendMsgStats stats)
```

This PR is to address it.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
