### PR TITLE
Fix CreateAopProxyInterceptor in the Spring core-patch indeed changes the implementation of the Spring AOP proxy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 * Add empty judgment for constructorInterceptPoint
 * Bump up gRPC to 1.68.1
 * Bump up netty to 4.1.115.Final
+* Fix the `CreateAopProxyInterceptor` in the Spring core-patch to prevent it from changing the implementation of the Spring AOP proxy  
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/222?closed=1)
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/src/test/java/org/apache/skywalking/apm/plugin/spring/patch/CreateAopProxyInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/src/test/java/org/apache/skywalking/apm/plugin/spring/patch/CreateAopProxyInterceptorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.aop.SpringProxy;
 import org.springframework.aop.framework.AdvisedSupport;
 
 import static org.hamcrest.core.Is.is;
@@ -48,18 +49,69 @@ public class CreateAopProxyInterceptorTest {
     }
 
     @Test
-    public void testInterceptNormalObject() throws Throwable {
-        doReturn(Object.class).when(advisedSupport).getTargetClass();
+    public void testInterceptClassImplementsNoInterfaces() throws Throwable {
+        // doReturn(Object.class).when(advisedSupport).getTargetClass();
+        // doReturn(Object.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(true, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, true)));
+    }
+
+    @Test
+    public void testInterceptClassImplementsUserSuppliedInterface() throws Throwable {
+        doReturn(MockClassImplementsUserSuppliedInterface.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsUserSuppliedInterface.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
         assertThat(false, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
     }
 
     @Test
-    public void testInterceptEnhanceInstanceObject() throws Throwable {
-        doReturn(MockClass.class).when(advisedSupport).getTargetClass();
+    public void testInterceptClassImplementsSpringProxy() throws Throwable {
+        // doReturn(MockClassImplementsSpringProxy.class).when(advisedSupport).getTargetClass();
+        // doReturn(MockClassImplementsSpringProxy.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(true, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, true)));
+    }
+
+    @Test
+    public void testInterceptClassImplementsEnhancedInstance() throws Throwable {
+        doReturn(MockClassImplementsEnhancedInstance.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsEnhancedInstance.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
         assertThat(true, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
     }
 
-    private class MockClass implements EnhancedInstance {
+    @Test
+    public void testClassImplementsEnhancedInstanceAndUserSuppliedInterface() throws Throwable {
+        doReturn(MockClassImplementsSpringProxyAndUserSuppliedInterface.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsSpringProxyAndUserSuppliedInterface.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(false, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
+    }
+
+    @Test
+    public void testInterceptClassImplementsSpringProxyAndEnhancedInstance() throws Throwable {
+        doReturn(MockClassImplementsSpringProxyAndEnhancedInstance.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsSpringProxyAndEnhancedInstance.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(true, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
+    }
+
+    @Test
+    public void testInterceptClassImplementsSpringProxyAndUserSuppliedInterface() throws Throwable {
+        doReturn(MockClassImplementsSpringProxyAndUserSuppliedInterface.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsSpringProxyAndUserSuppliedInterface.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(false, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
+    }
+
+    @Test
+    public void testInterceptClassImplementsEnhancedInstanceAndUserSuppliedInterface() throws Throwable {
+        doReturn(MockClassImplementsEnhancedInstanceAndUserSuppliedInterface.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsEnhancedInstanceAndUserSuppliedInterface.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(false, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
+    }
+
+    @Test
+    public void testInterceptClassImplementsSpringProxyAndEnhancedInstanceAndUserSuppliedInterface() throws Throwable {
+        doReturn(MockClassImplementsSpringProxyAndEnhancedInstanceAndUserSuppliedInterface.class).when(advisedSupport).getTargetClass();
+        doReturn(MockClassImplementsSpringProxyAndEnhancedInstanceAndUserSuppliedInterface.class.getInterfaces()).when(advisedSupport).getProxiedInterfaces();
+        assertThat(false, is(interceptor.afterMethod(enhancedInstance, null, new Object[] {advisedSupport}, new Class[] {Object.class}, false)));
+    }
+
+    private class MockClassImplementsEnhancedInstance implements EnhancedInstance {
 
         @Override
         public Object getSkyWalkingDynamicField() {
@@ -70,6 +122,83 @@ public class CreateAopProxyInterceptorTest {
         public void setSkyWalkingDynamicField(Object value) {
 
         }
+    }
+
+    private class MockClassImplementsUserSuppliedInterface implements UserSuppliedInterface {
+
+        @Override
+        public void methodOfUserSuppliedInterface() {
+
+        }
+
+    }
+
+    private class MockClassImplementsSpringProxy implements SpringProxy {
+
+    }
+
+    private class MockClassImplementsSpringProxyAndEnhancedInstance  implements EnhancedInstance, SpringProxy {
+
+        @Override
+        public Object getSkyWalkingDynamicField() {
+            return null;
+        }
+
+        @Override
+        public void setSkyWalkingDynamicField(Object value) {
+
+        }
+
+    }
+
+    private class MockClassImplementsEnhancedInstanceAndUserSuppliedInterface  implements EnhancedInstance, UserSuppliedInterface {
+
+        @Override
+        public Object getSkyWalkingDynamicField() {
+            return null;
+        }
+
+        @Override
+        public void setSkyWalkingDynamicField(Object value) {
+
+        }
+
+        @Override
+        public void methodOfUserSuppliedInterface() {
+        }
+
+    }
+
+    private class MockClassImplementsSpringProxyAndUserSuppliedInterface  implements SpringProxy, UserSuppliedInterface {
+
+        @Override
+        public void methodOfUserSuppliedInterface() {
+        }
+
+    }
+
+    private class MockClassImplementsSpringProxyAndEnhancedInstanceAndUserSuppliedInterface  implements EnhancedInstance, SpringProxy, UserSuppliedInterface {
+
+        @Override
+        public Object getSkyWalkingDynamicField() {
+            return null;
+        }
+
+        @Override
+        public void setSkyWalkingDynamicField(Object value) {
+
+        }
+
+        @Override
+        public void methodOfUserSuppliedInterface() {
+        }
+
+    }
+
+    interface UserSuppliedInterface {
+
+         void methodOfUserSuppliedInterface();
+
     }
 
 }


### PR DESCRIPTION
 Fix https://github.com/apache/skywalking/issues/12858 The `CreateAopProxyInterceptor` in the Spring core-patch indeed changes the implementation of the Spring AOP proxy
- [X] Add a unit test to verify that the fix works.
- [X] Explain briefly why the bug exists and how to fix it.
The current version of `CreateAopProxyInterceptor` does not account for scenarios where the proxy target class implements `UserSuppliedInterface` and should work correctly with only `JdkDynamicAopProxy`. This can lead to inconsistencies in behavior when the SkyWalking agent is used.

This PR fixes the issue by adding restrictions on when the behavior changes, ensuring that the proxy mechanism reverts to using `JdkDynamicAopProxy` when appropriate. Specifically, it ensures that the application's behavior remains consistent both with and without the SkyWalking agent enhancement.
