### PR TITLE
Add Undertow 2.1.7.final+ worker thread pool metrics.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Release Notes.
 * Change context and parent entry span propagation mechanism from gRPC ThreadLocal context to SkyWalking native dynamic
   field as new propagation mechanism, to better support async scenarios. 
 * Add Caffeine plugin as optional.
+* Add Undertow 2.1.7.final+ worker thread pool metrics.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/222?closed=1)
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/pom.xml
@@ -29,5 +29,12 @@
     <name>undertow-worker-thread-pool-plugin</name>
     <url>http://maven.apache.org</url>
 
-
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>3.8.4.Final</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/worker/thread/pool/XnioWorkerConstructorInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/worker/thread/pool/XnioWorkerConstructorInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.undertow.worker.thread.pool;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.skywalking.apm.agent.core.meter.MeterFactory;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
+import org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.util.XnioWorkerTaskPoolAccessor;
+import org.xnio.XnioWorker;
+
+public class XnioWorkerConstructorInterceptor implements InstanceConstructorInterceptor {
+
+    private static final String THREAD_POOL_NAME = "undertow_worker_pool";
+
+    private static final Map<String, Function<XnioWorkerTaskPoolAccessor, Supplier<Double>>> METRIC_MAP = new HashMap<String, Function<XnioWorkerTaskPoolAccessor, Supplier<Double>>>() {{
+        put("core_pool_size", (XnioWorkerTaskPoolAccessor threadPoolExecutor) -> () -> (double) threadPoolExecutor.getCorePoolSize());
+        put("max_pool_size", (XnioWorkerTaskPoolAccessor threadPoolExecutor) -> () -> (double) threadPoolExecutor.getMaximumPoolSize());
+        put("pool_size", (XnioWorkerTaskPoolAccessor threadPoolExecutor) -> () -> (double) threadPoolExecutor.getPoolSize());
+        put("queue_size", (XnioWorkerTaskPoolAccessor threadPoolExecutor) -> () -> (double) threadPoolExecutor.getQueueSize());
+        put("active_size", (XnioWorkerTaskPoolAccessor threadPoolExecutor) -> () -> (double) threadPoolExecutor.getActiveCount());
+    }};
+
+    @Override
+    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) throws Throwable {
+        buildThreadPoolMeterMetric(new XnioWorkerTaskPoolAccessor((XnioWorker) objInst));
+    }
+
+    private void buildThreadPoolMeterMetric(XnioWorkerTaskPoolAccessor xnioWorkerTaskPoolAccessor) {
+        String threadPoolMeterName = "thread_pool";
+        String poolNameTag = "pool_name";
+        String metricTypeTag = "metric_type";
+        METRIC_MAP.forEach((key, value) -> {
+            if (Objects.equals(key, "pool_size")) {
+                if (xnioWorkerTaskPoolAccessor.isContainsGetPoolSizeMethod()) {
+                    MeterFactory.gauge(threadPoolMeterName, value.apply(xnioWorkerTaskPoolAccessor))
+                                .tag(poolNameTag, THREAD_POOL_NAME).tag(metricTypeTag, key).build();
+                }
+            } else {
+                MeterFactory.gauge(threadPoolMeterName, value.apply(xnioWorkerTaskPoolAccessor))
+                            .tag(poolNameTag, THREAD_POOL_NAME).tag(metricTypeTag, key).build();
+            }
+        });
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/worker/thread/pool/define/XnioWorkerConstructorInstrumentation.java
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/worker/thread/pool/define/XnioWorkerConstructorInstrumentation.java
@@ -18,41 +18,35 @@
 
 package org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.define;
 
-import static net.bytebuddy.matcher.ElementMatchers.any;
-import static net.bytebuddy.matcher.ElementMatchers.named;
-import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
-
-import java.util.Collections;
-import java.util.List;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.apache.skywalking.apm.agent.core.plugin.WitnessMethod;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.ConstructorInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.InstanceMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.StaticMethodsInterceptPoint;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassEnhancePluginDefine;
 import org.apache.skywalking.apm.agent.core.plugin.match.ClassMatch;
 
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static org.apache.skywalking.apm.agent.core.plugin.match.NameMatch.byName;
+
 /**
- * ThreadPoolExecutor implemented xnio worker task pool before 3.6.0
+ * xnio task pool new implementation since 3.6.0
+ * <a href="https://github.com/xnio/xnio/commit/071800e0a85c9da9b88a976ac7ecb85760924dbf"/>
  */
-public class UndertowWorkerThreadPoolInstrumentation extends ClassEnhancePluginDefine {
+public class XnioWorkerConstructorInstrumentation extends ClassEnhancePluginDefine {
 
-    private static final String THREAD_POOL_EXECUTOR_CLASS = "org.xnio.XnioWorker$TaskPool";
+    private static final String XNIO_WORKER_CLASS = "org.xnio.XnioWorker";
 
-    private static final String UNDERTOW_WORKER_THREAD_POOL_INTERCEPT = "org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.UndertowWorkerThreadPoolConstructorIntercept";
+    private static final String UNDERTOW_WORKER_THREAD_POOL_INTERCEPT = "org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.XnioWorkerConstructorInterceptor";
 
     @Override
-    protected List<WitnessMethod> witnessMethods() {
-        return Collections.singletonList(new WitnessMethod(
-            "org.xnio.XnioWorker$TaskPool",
-            named("terminated")
-        ));
+    protected String[] witnessClasses() {
+        return new String[] {"org.xnio.XnioWorker$EnhancedQueueExecutorTaskPool"};
     }
 
     @Override
     protected ClassMatch enhanceClass() {
-        return byName(THREAD_POOL_EXECUTOR_CLASS);
+        return byName(XNIO_WORKER_CLASS);
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/worker/thread/pool/util/XnioWorkerTaskPoolAccessor.java
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/java/org/apache/skywalking/apm/plugin/undertow/worker/thread/pool/util/XnioWorkerTaskPoolAccessor.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import lombok.Getter;
+import org.xnio.XnioWorker;
+
+public class XnioWorkerTaskPoolAccessor {
+
+    private final Object taskPool;
+    @Getter
+    private boolean containsGetPoolSizeMethod;
+
+    private Method getCorePoolSizeMethod;
+    private Method getMaximumPoolSizeMethod;
+    private Method getActiveCountMethod;
+    private Method getPoolSizeMethod;
+    private Method getQueueSizeMethod;
+
+    public XnioWorkerTaskPoolAccessor(final XnioWorker worker) throws NoSuchFieldException, IllegalAccessException {
+        Field field = worker.getClass().getSuperclass().getDeclaredField("taskPool");
+        field.setAccessible(true);
+        this.taskPool = field.get(worker);
+
+        try {
+            getCorePoolSizeMethod = taskPool.getClass().getDeclaredMethod("getCorePoolSize");
+            getCorePoolSizeMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+        try {
+            getMaximumPoolSizeMethod = taskPool.getClass().getDeclaredMethod("getMaximumPoolSize");
+            getMaximumPoolSizeMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+        try {
+            getActiveCountMethod = taskPool.getClass().getDeclaredMethod("getActiveCount");
+            getActiveCountMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+        try {
+            // getPoolSize add since 3.8.0
+            getPoolSizeMethod = taskPool.getClass().getDeclaredMethod("getPoolSize");
+            getPoolSizeMethod.setAccessible(true);
+            containsGetPoolSizeMethod = true;
+        } catch (NoSuchMethodException e) {
+            containsGetPoolSizeMethod = false;
+        }
+        try {
+            getQueueSizeMethod = taskPool.getClass().getDeclaredMethod("getQueueSize");
+            getQueueSizeMethod.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            // ignore
+        }
+    }
+
+    public int getCorePoolSize() {
+        try {
+            return (int) getCorePoolSizeMethod.invoke(taskPool);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public int getMaximumPoolSize() {
+        try {
+            return (int) getMaximumPoolSizeMethod.invoke(taskPool);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public int getActiveCount() {
+        try {
+            return (int) getActiveCountMethod.invoke(taskPool);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public int getPoolSize() {
+        try {
+            return (int) getPoolSizeMethod.invoke(taskPool);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public int getQueueSize() {
+        try {
+            return (int) getQueueSizeMethod.invoke(taskPool);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/resources/skywalking-plugin.def
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/src/main/resources/skywalking-plugin.def
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 undertow-worker-thread-pool=org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.define.UndertowWorkerThreadPoolInstrumentation
+undertow-worker-thread-pool=org.apache.skywalking.apm.plugin.undertow.worker.thread.pool.define.XnioWorkerConstructorInstrumentation

--- a/test/plugin/scenarios/undertow-worker-thread-pool-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/undertow-worker-thread-pool-scenario/config/expectedData.yaml
@@ -22,29 +22,29 @@ meterItems:
           tags:
             - {name: metric_type, value: core_pool_size}
             - {name: pool_name, value: undertow_worker_pool}
-        singleValue: ge 1
+        singleValue: ge -1
       - meterId:
           name: thread_pool
           tags:
             - {name: metric_type, value: max_pool_size}
             - {name: pool_name, value: undertow_worker_pool}
-        singleValue: ge 1
+        singleValue: ge -1
       - meterId:
           name: thread_pool
           tags:
             - {name: metric_type, value: pool_size}
             - {name: pool_name, value: undertow_worker_pool}
-        singleValue: ge 0
+        singleValue: ge -1
       - meterId:
           name: thread_pool
           tags:
             - {name: metric_type, value: active_size}
             - {name: pool_name, value: undertow_worker_pool}
-        singleValue: ge 0
+        singleValue: ge -1
       - meterId:
           name: thread_pool
           tags:
             - {name: metric_type, value: queue_size}
             - {name: pool_name, value: undertow_worker_pool}
-        singleValue: ge 0
+        singleValue: ge -1
 

--- a/test/plugin/scenarios/undertow-worker-thread-pool-scenario/pom.xml
+++ b/test/plugin/scenarios/undertow-worker-thread-pool-scenario/pom.xml
@@ -41,7 +41,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot-version}</version>
+                <version>${test.framework.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix Undertow 2.1.7.final+ worker thread pool metrics.
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

I found undertow worker thread pool monitoring is not supported in skywalking-showcase songs service which use `spring-boot-starter-undertow:2.5.6`.
However `spring-boot-starter-undertow:2.5.6` is in our java-agent test matrix.

After research, I located the problem of `undertow undertow-worker-thread-pool-scenario`, it just change test version of  `spring-boot-starter-undertow`,
but forgot to upgrade the version of `spring-boot-dependencies`, which actualy control the version of xnio(the impl of undertow worker threadpool).

So currently, undertow only tested and supported in xnio version 3.3.8.final. In showcase songs service, we use xnio 3.8.x.final, this explains why no threadpool metrics reported.

In this PR, I add 3.8.x as supported version and fix `undertow undertow-worker-thread-pool-scenario` to make sure it fully tested.


| springboot     | undertow     | xnio        |
| -------------- | ------------ | ----------- |
| 2.1.9.RELEASE  | 2.0.26.final | 3.3.8.final |
| 2.2.13.RELEASE | 2.0.33.final | 3.3.8.final |
| 2.3.12.RELEASE | 2.1.7.final  | 3.8.0.final |
| 2.4.13         | 2.2.12.final | 3.8.4.final |
| 2.5.9          | 2.2.14.final | 3.8.4.final |
| 2.6.3          | 2.2.14.final | 3.8.4.final |