### PR TITLE
To prevent NPE use pool name for metrics if JDBC URL is not set.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Release Notes.
 
 * Add the virtual thread executor plugin
 * Fix Conflicts apm-jdk-threadpool-plugin conflicts with apm-jdk-forkjoinpool-plugin
+* Fix NPE in hikaricp-plugin if JDBC URL is not set
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/236?closed=1)
 

--- a/apm-sniffer/apm-sdk-plugin/hikaricp-3.x-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/hikaricp/PoolingSealInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/hikaricp-3.x-4.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/hikaricp/PoolingSealInterceptor.java
@@ -49,8 +49,13 @@ public class PoolingSealInterceptor implements InstanceMethodsAroundInterceptor 
     public Object afterMethod(EnhancedInstance objInst, Method method, Object[] allArguments, Class<?>[] argumentsTypes, Object ret) throws Throwable {
 
         HikariDataSource hikariDataSource = (HikariDataSource) objInst;
-        ConnectionInfo connectionInfo = URLParser.parser(hikariDataSource.getJdbcUrl());
-        String tagValue = connectionInfo.getDatabaseName() + "_" + connectionInfo.getDatabasePeer();
+        String tagValue;
+        if (hikariDataSource.getJdbcUrl() != null) {
+            ConnectionInfo connectionInfo = URLParser.parser(hikariDataSource.getJdbcUrl());
+            tagValue = connectionInfo.getDatabaseName() + "_" + connectionInfo.getDatabasePeer();
+        } else {
+            tagValue = hikariDataSource.getPoolName();
+        }
         final Map<String, Function<HikariPoolMXBean, Supplier<Double>>> poolMetricMap = getPoolMetrics();
         final Map<String, Function<HikariConfigMXBean, Supplier<Double>>> metricConfigMap = getConfigMetrics();
         poolMetricMap.forEach((key, value) -> MeterFactory.gauge(METER_NAME, value.apply(hikariDataSource.getHikariPoolMXBean()))


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix NPE 
```
java.lang.NullPointerException: Cannot invoke "String.toLowerCase()" because "url" is null
        at org.apache.skywalking.apm.plugin.jdbc.connectionurl.parser.URLParser.parser(URLParser.java:47)
        at org.apache.skywalking.apm.plugin.hikaricp.PoolingSealInterceptor.afterMethod(PoolingSealInterceptor.java:52)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:110)
        at com.zaxxer.hikari.HikariDataSource.seal(HikariDataSource.java)
        at com.zaxxer.hikari.HikariDataSource.$sw$original$getConnection$08spks0(HikariDataSource.java:112)
        at com.zaxxer.hikari.HikariDataSource.$sw$original$getConnection$08spks0$accessor$$sw$6kb3bn3(HikariDataSource.java)
        at com.zaxxer.hikari.HikariDataSource$$sw$auxiliary$93993q0.call(Unknown Source)
        at org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstMethodsInter.intercept(InstMethodsInter.java:95)
```
The pool can be configured with data source options but not JDBC URL so in this case we can use pool name for metrics.

- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.


<!-- ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👇 ====
### Add an agent plugin to support <framework name>
- [ ] Add a test case for the new plugin, refer to [the doc](https://github.com/apache/skywalking-java/blob/main/docs/en/setup/service-agent/java-agent/Plugin-test.md)
- [ ] Add a component id in [the component-libraries.yml](https://github.com/apache/skywalking/blob/master/oap-server/server-starter/src/main/resources/component-libraries.yml)
- [ ] Add a logo in [the UI repo](https://github.com/apache/skywalking-rocketbot-ui/tree/master/src/views/components/topology/assets)
     ==== 🔌 Remove this line WHEN AND ONLY WHEN you're adding a new plugin, follow the checklist 👆 ==== -->

<!-- ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 ====
### Improve the performance of <class or module or ...>
- [ ] Add a benchmark for the improvement, refer to [the existing ones](https://github.com/apache/skywalking-java/blob/main/apm-commons/apm-datacarrier/src/test/java/org/apache/skywalking/apm/commons/datacarrier/LinkedArrayBenchmark.java)
- [ ] The benchmark result.
```text
<Paste the benchmark results here>
```
- [ ] Links/URLs to the theory proof or discussion articles/blogs. <links/URLs here>
     ==== 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
