### PR TITLE
Fix parent class enhancement issue during retransform

### DIFF
--- a/apm-sniffer/bytebuddy-patch/src/main/java/net/bytebuddy/agent/builder/SWDescriptionStrategy.java
+++ b/apm-sniffer/bytebuddy-patch/src/main/java/net/bytebuddy/agent/builder/SWDescriptionStrategy.java
@@ -145,6 +145,8 @@ public class SWDescriptionStrategy implements AgentBuilder.DescriptionStrategy {
 
         private TypeDescription delegate;
 
+        private Generic superClass;
+
         public SWTypeDescriptionWrapper(TypeDescription delegate, String nameTrait, ClassLoader classLoader, String typeName) {
             this.delegate = delegate;
             this.nameTrait = nameTrait;
@@ -325,7 +327,14 @@ public class SWDescriptionStrategy implements AgentBuilder.DescriptionStrategy {
 
         @Override
         public Generic getSuperClass() {
-            return delegate.getSuperClass();
+            if (this.superClass == null) {
+                Generic delegateSuperClass = delegate.getSuperClass();
+                if (delegateSuperClass == null) {
+                    return delegateSuperClass;
+                }
+                this.superClass = new SWTypeDescriptionWrapper(delegateSuperClass.asErasure(), this.nameTrait, this.classLoader, delegateSuperClass.getTypeName()).asGenericType();
+            }
+            return this.superClass;
         }
 
         @Override

--- a/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar.java
+++ b/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar.java
@@ -1,0 +1,7 @@
+package org.apache.skywalking.apm.agent.bytebuddy.biz;
+
+public class ChildBar extends ParentBar {
+    public String sayHelloChild() {
+        return "Joe";
+    }
+}

--- a/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/biz/ParentBar.java
+++ b/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/biz/ParentBar.java
@@ -1,0 +1,7 @@
+package org.apache.skywalking.apm.agent.bytebuddy.biz;
+
+public class ParentBar {
+    public String sayHelloParent() {
+        return "Joe";
+    }
+}

--- a/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/cases/AbstractInterceptTest.java
+++ b/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/cases/AbstractInterceptTest.java
@@ -38,6 +38,7 @@ import org.apache.skywalking.apm.agent.bytebuddy.SWAsmVisitorWrapper;
 import org.apache.skywalking.apm.agent.bytebuddy.SWAuxiliaryTypeNamingStrategy;
 import org.apache.skywalking.apm.agent.bytebuddy.SWClassFileLocator;
 import org.apache.skywalking.apm.agent.bytebuddy.biz.BizFoo;
+import org.apache.skywalking.apm.agent.bytebuddy.biz.ChildBar;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -63,6 +64,8 @@ public class AbstractInterceptTest {
     public static final String BIZ_FOO_CLASS_NAME = "org.apache.skywalking.apm.agent.bytebuddy.biz.BizFoo";
     public static final String PROJECT_SERVICE_CLASS_NAME = "org.apache.skywalking.apm.agent.bytebuddy.biz.ProjectService";
     public static final String DOC_SERVICE_CLASS_NAME = "org.apache.skywalking.apm.agent.bytebuddy.biz.DocService";
+    public static final String PARENT_BAR_CLASS_NAME = "org.apache.skywalking.apm.agent.bytebuddy.biz.ParentBar";
+    public static final String CHILD_BAR_CLASS_NAME = "org.apache.skywalking.apm.agent.bytebuddy.biz.ChildBar";
     public static final String SAY_HELLO_METHOD = "sayHello";
     public static final int BASE_INT_VALUE = 100;
     public static final String CONSTRUCTOR_INTERCEPTOR_CLASS = "constructorInterceptorClass";
@@ -84,6 +87,20 @@ public class AbstractInterceptTest {
             Log.printToConsole();
         }
     };
+
+    protected static void callBar(int round) {
+        Log.info("-------------");
+        Log.info("callChildBar: " + round);
+        // load target class
+        String strResultChild = new ChildBar().sayHelloChild();
+        Log.info("result: " + strResultChild);
+
+        String strResultParent = new ChildBar().sayHelloParent();
+        Log.info("result: " + strResultParent);
+
+        Assert.assertEquals("String value is unexpected", "John", strResultChild);
+        Assert.assertEquals("String value is unexpected", "John", strResultParent);
+    }
 
     protected static void callBizFoo(int round) {
         Log.info("-------------");
@@ -115,7 +132,7 @@ public class AbstractInterceptTest {
 
     protected static void checkInterface(Class testClass, Class interfaceCls) {
         Assert.assertTrue("Check interface failure, the test class: " + testClass + " does not implement the expected interface: " + interfaceCls,
-                EnhancedInstance.class.isAssignableFrom(BizFoo.class));
+                EnhancedInstance.class.isAssignableFrom(testClass));
     }
 
     protected static void checkErrors() {
@@ -139,8 +156,7 @@ public class AbstractInterceptTest {
                             return builder
                                     .method(ElementMatchers.nameContainsIgnoreCase(methodName))
                                     .intercept(MethodDelegation.withDefaultConfiguration()
-                                            .to(new InstMethodsInter(interceptorClassName, classLoader), fieldName))
-                                    ;
+                                            .to(new InstMethodsInter(interceptorClassName, classLoader), fieldName));
                         }
                 )
                 .with(getListener(interceptorClassName))
@@ -223,7 +239,7 @@ public class AbstractInterceptTest {
         ClassFileTransformer classFileTransformer = new ClassFileTransformer() {
             @Override
             public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
-                if (className.endsWith("BizFoo") || className.endsWith("ProjectService") || className.endsWith("DocService")) {
+                if (className.endsWith("BizFoo") || className.endsWith("ProjectService") || className.endsWith("DocService") || className.endsWith("ChildBar") || className.endsWith("ParentBar")) {
                     Log.error(msg + className);
                     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
                     ClassReader cr = new ClassReader(classfileBuffer);

--- a/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/cases/ReTransform4Test.java
+++ b/apm-sniffer/bytebuddy-patch/src/test/java/org/apache/skywalking/apm/agent/bytebuddy/cases/ReTransform4Test.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.agent.bytebuddy.cases;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.apache.skywalking.apm.agent.bytebuddy.biz.ChildBar;
+import org.apache.skywalking.apm.agent.bytebuddy.biz.ParentBar;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.junit.Test;
+
+import java.lang.instrument.Instrumentation;
+
+public class ReTransform4Test extends AbstractReTransformTest {
+
+    @Test
+    public void testEnhancedInstanceForMultiShotRetransform() throws Exception {
+        Instrumentation instrumentation = ByteBuddyAgent.install();
+
+        // install transformer
+        installMethodInterceptor(PARENT_BAR_CLASS_NAME, "sayHelloParent", 1);
+        installMethodInterceptor(CHILD_BAR_CLASS_NAME, "sayHelloChild", 1);
+        // implement EnhancedInstance
+        installInterface(PARENT_BAR_CLASS_NAME);
+        installInterface(CHILD_BAR_CLASS_NAME);
+
+        callBar(1);
+
+        // check interceptors
+        checkInterface(ParentBar.class, EnhancedInstance.class);
+        checkInterface(ChildBar.class, EnhancedInstance.class);
+        checkErrors();
+
+        installTraceClassTransformer("Trace class: ");
+
+        // do retransform
+        reTransform(instrumentation, ChildBar.class);
+
+        // check interceptors
+        checkInterface(ParentBar.class, EnhancedInstance.class);
+        checkInterface(ChildBar.class, EnhancedInstance.class);
+        checkErrors();
+    }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <lombok.version>1.18.30</lombok.version>
 
         <!-- core lib dependency -->
-        <bytebuddy.version>1.14.9</bytebuddy.version>
+        <bytebuddy.version>1.17.5</bytebuddy.version>
         <grpc.version>1.68.1</grpc.version>
         <netty.version>4.1.115.Final</netty.version>
         <gson.version>2.8.9</gson.version>


### PR DESCRIPTION

### Fix retransform bug if parent class has also been enhanced
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Closes #<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).

This PR adds a unit test to reproduce a retransform issue:

When a child class extends a parent class and the both classes need to be enhanced by SkyWalking Agent, retransform will fail since `getter/setter` are not generated in the child class.

```
ReTransform class org.apache.skywalking.apm.agent.bytebuddy.biz.ChildBar failure: java.lang.UnsupportedOperationException: class redefinition failed: attempted to delete a method
// class version 52.0 (52)
-------------
// access flags 0x21

public class org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar extends org/apache/skywalking/apm/agent/bytebuddy/biz/ParentBar  implements org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/EnhancedInstance  {


  // access flags 0x1049
  public static volatile synthetic Lorg/apache/skywalking/apm/agent/bytebuddy/InstMethodsInter; $sw$_delegate$sayHelloChild1

  // access flags 0x101A
  private final static synthetic Ljava/lang/reflect/Method; cachedValue$$sw$r4cldq0$5k2gah0

  // access flags 0x42
  private volatile Ljava/lang/Object; _$EnhancedClassField_ws

  // access flags 0x1
  public <init>()V
    ALOAD 0
    INVOKESPECIAL org/apache/skywalking/apm/agent/bytebuddy/biz/ParentBar.<init> ()V
    RETURN
    MAXSTACK = 1
    MAXLOCALS = 1

  // access flags 0x1
  public sayHelloChild()Ljava/lang/String;
    GETSTATIC org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar.$sw$_delegate$sayHelloChild1 : Lorg/apache/skywalking/apm/agent/bytebuddy/InstMethodsInter;
    ALOAD 0
    ICONST_0
    ANEWARRAY java/lang/Object
    NEW org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar$$sw$auxiliary$7rsdj21
    DUP
    ALOAD 0
    INVOKESPECIAL org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar$$sw$auxiliary$7rsdj21.<init> (Lorg/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar;)V
    GETSTATIC org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar.cachedValue$$sw$r4cldq0$5k2gah0 : Ljava/lang/reflect/Method;
    INVOKEVIRTUAL org/apache/skywalking/apm/agent/bytebuddy/InstMethodsInter.intercept (Ljava/lang/Object;[Ljava/lang/Object;Ljava/util/concurrent/Callable;Ljava/lang/reflect/Method;)Ljava/lang/Object;
    CHECKCAST java/lang/String
    ARETURN
    MAXSTACK = 6
    MAXLOCALS = 1

  // access flags 0x1002
  private synthetic $sw$original$sayHelloChild$7s6edk3()Ljava/lang/String;
    LDC "Joe"
    ARETURN
    MAXSTACK = 1
    MAXLOCALS = 1

  // access flags 0x8
  static <clinit>()V
    GOTO L0
   L1
    NOP
    INVOKESTATIC java/lang/ClassLoader.getSystemClassLoader ()Ljava/lang/ClassLoader;
    LDC "net.bytebuddy.dynamic.Nexus"
    INVOKEVIRTUAL java/lang/ClassLoader.loadClass (Ljava/lang/String;)Ljava/lang/Class;
    LDC "initialize"
    ICONST_2
    ANEWARRAY java/lang/Class
    DUP
    ICONST_0
    LDC Ljava/lang/Class;.class
    AASTORE
    DUP
    ICONST_1
    GETSTATIC java/lang/Integer.TYPE : Ljava/lang/Class;
    AASTORE
    INVOKEVIRTUAL java/lang/Class.getMethod (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
    ACONST_NULL
    ICONST_2
    ANEWARRAY java/lang/Object
    DUP
    ICONST_0
    LDC Lorg/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar;.class
    AASTORE
    DUP
    ICONST_1
    LDC -905907445
    INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
    AASTORE
    INVOKEVIRTUAL java/lang/reflect/Method.invoke (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
    POP
    LDC Lorg/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar;.class
    LDC "sayHelloChild"
    ICONST_0
    ANEWARRAY java/lang/Class
    INVOKEVIRTUAL java/lang/Class.getMethod (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
    PUTSTATIC org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar.cachedValue$$sw$r4cldq0$5k2gah0 : Ljava/lang/reflect/Method;
    RETURN
   L0
    NOP
    INVOKESTATIC java/lang/ClassLoader.getSystemClassLoader ()Ljava/lang/ClassLoader;
    LDC "net.bytebuddy.dynamic.Nexus"
    INVOKEVIRTUAL java/lang/ClassLoader.loadClass (Ljava/lang/String;)Ljava/lang/Class;
    LDC "initialize"
    ICONST_2
    ANEWARRAY java/lang/Class
    DUP
    ICONST_0
    LDC Ljava/lang/Class;.class
    AASTORE
    DUP
    ICONST_1
    GETSTATIC java/lang/Integer.TYPE : Ljava/lang/Class;
    AASTORE
    INVOKEVIRTUAL java/lang/Class.getMethod (Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
    ACONST_NULL
    ICONST_2
    ANEWARRAY java/lang/Object
    DUP
    ICONST_0
    LDC Lorg/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar;.class
    AASTORE
    DUP
    ICONST_1
    LDC -805445578
    INVOKESTATIC java/lang/Integer.valueOf (I)Ljava/lang/Integer;
    AASTORE
    INVOKEVIRTUAL java/lang/reflect/Method.invoke (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
    POP
    GOTO L1
    MAXSTACK = 6
    MAXLOCALS = 0

  // access flags 0x1010
  final synthetic $sw$original$sayHelloChild$7s6edk3$accessor$$sw$r4cldq0()Ljava/lang/String;
    ALOAD 0
    INVOKESPECIAL org/apache/skywalking/apm/agent/bytebuddy/biz/ChildBar.$sw$original$sayHelloChild$7s6edk3 ()Ljava/lang/String;
    ARETURN
    MAXSTACK = 1
    MAXLOCALS = 1
}

Test failure: class org.apache.skywalking.apm.agent.bytebuddy.cases.ReTransform4Test.testEnhancedInstanceForMultiShotRetransform(), error: java.lang.UnsupportedOperationException: class redefinition failed: attempted to delete a method


java.lang.UnsupportedOperationException: class redefinition failed: attempted to delete a method

	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses0(Native Method)
	at java.instrument/sun.instrument.InstrumentationImpl.retransformClasses(InstrumentationImpl.java:169)
	at org.apache.skywalking.apm.agent.bytebuddy.cases.AbstractReTransformTest.reTransform(AbstractReTransformTest.java:43)
	at org.apache.skywalking.apm.agent.bytebuddy.cases.ReTransform4Test.testEnhancedInstanceForMultiShotRetransform(ReTransform4Test.java:52)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:231)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
```