### PR TITLE
Upgrade bytebuddy to 1.17.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Release Notes.
 * Add support for `dameng(DM)` JDBC url format in `URLParser`.
 * Fix RabbitMQ Consumer could not receive handleCancelOk callback.
 * Support for tracking in lettuce versions 6.5.x and above.
-* Upgrade byte-buddy version to 1.15.5.
+* Upgrade byte-buddy version to 1.17.6.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/236?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 * Add support for `dameng(DM)` JDBC url format in `URLParser`.
 * Fix RabbitMQ Consumer could not receive handleCancelOk callback.
 * Support for tracking in lettuce versions 6.5.x and above.
+* Upgrade byte-buddy version to 1.15.5.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/236?closed=1)
 

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -106,6 +106,7 @@
                                     <artifact>net.bytebuddy:byte-buddy</artifact>
                                     <excludes>
                                         <exclude>META-INF/versions/9/module-info.class</exclude>
+                                        <exclude>META-INF/versions/24/**</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -215,7 +215,7 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is the standard Apache 2.0 license.
 
-    raphw (byte-buddy) 1.15.5: http://bytebuddy.net/ , Apache 2.0
+    raphw (byte-buddy) 1.17.6: http://bytebuddy.net/ , Apache 2.0
     Google: grpc-java 1.68.1: https://github.com/grpc/grpc-java, Apache 2.0
     Google: gson 2.8.9: https://github.com/google/gson , Apache 2.0
     Google: proto-google-common-protos 2.0.1: https://github.com/googleapis/googleapis , Apache 2.0

--- a/dist-material/LICENSE
+++ b/dist-material/LICENSE
@@ -215,7 +215,7 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is the standard Apache 2.0 license.
 
-    raphw (byte-buddy) 1.14.9: http://bytebuddy.net/ , Apache 2.0
+    raphw (byte-buddy) 1.15.5: http://bytebuddy.net/ , Apache 2.0
     Google: grpc-java 1.68.1: https://github.com/grpc/grpc-java, Apache 2.0
     Google: gson 2.8.9: https://github.com/google/gson , Apache 2.0
     Google: proto-google-common-protos 2.0.1: https://github.com/googleapis/googleapis , Apache 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <lombok.version>1.18.30</lombok.version>
 
         <!-- core lib dependency -->
-        <bytebuddy.version>1.15.5</bytebuddy.version>
+        <bytebuddy.version>1.17.6</bytebuddy.version>
         <grpc.version>1.68.1</grpc.version>
         <netty.version>4.1.115.Final</netty.version>
         <gson.version>2.8.9</gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <lombok.version>1.18.30</lombok.version>
 
         <!-- core lib dependency -->
-        <bytebuddy.version>1.14.9</bytebuddy.version>
+        <bytebuddy.version>1.15.5</bytebuddy.version>
         <grpc.version>1.68.1</grpc.version>
         <netty.version>4.1.115.Final</netty.version>
         <gson.version>2.8.9</gson.version>


### PR DESCRIPTION
This is my problem recurrence：

skywalking：9.3.0

guava: 33.2.1

then:

An error occurred during startup

```
2025-06-26 19:43:35.174 WARN main AbstractClassEnhancePluginDefine : enhance class org.springframework.web.reactive.DispatcherHandler by plugin org.apache.skywalking.apm.plugin.spring.cloud.gateway.v20x.define.DispatcherHandlerInstrumentation is not activated. Witness class org.springframework.cloud.gateway.config.GatewayAutoConfiguration$1 does not exist. 
2025-06-26 19:43:35.177 WARN main AbstractClassEnhancePluginDefine : enhance class org.springframework.web.reactive.DispatcherHandler by plugin org.apache.skywalking.apm.plugin.spring.cloud.gateway.v21x.define.DispatcherHandlerInstrumentation is not activated. Witness class org.springframework.cloud.gateway.filter.LoadBalancerClientFilter does not exist. 
2025-06-26 19:43:35.179 WARN main AbstractClassEnhancePluginDefine : enhance class org.springframework.web.reactive.DispatcherHandler by plugin org.apache.skywalking.apm.plugin.spring.cloud.gateway.v4x.define.DispatcherHandlerInstrumentation is not activated. Witness class org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties does not exist. 
2025-06-26 19:43:36.310 ERROR main SkyWalkingAgent : Enhance class com.google.common.collect.Iterators error. 
java.lang.IllegalStateException: Unexpected type reference on method: 16
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.pool.TypePool$Default$TypeExtractor$MethodExtractor.visitTypeAnnotation(TypePool.java:8791)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.jar.asm.ClassReader.readMethod(ClassReader.java:1453)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.jar.asm.ClassReader.accept(ClassReader.java:745)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.jar.asm.ClassReader.accept(ClassReader.java:425)
****
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:108)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65)
```

Then I packaged it based on 9.5.0 (without upgrading byte-buddy) and found the same problem

```
INFO 2025-06-27 10:32:00.768 main Version : SkyWalking agent version: 9.5.0-SNAPSHOT-b1f18f3 
ERROR 2025-06-27 10:32:07.748 main SkyWalkingAgent : Enhance class com.google.common.collect.Iterators error. 
java.lang.IllegalStateException: Unexpected type reference on method: 16
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.pool.TypePool$Default$TypeExtractor$MethodExtractor.visitTypeAnnotation(TypePool.java:8791)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.jar.asm.ClassReader.readMethod(ClassReader.java:1453)
	at org.apache.skywalking.apm.dependencies.net.bytebuddy.jar.asm.ClassReader.accept(ClassReader.java:74****
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:108)
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65)
```



When I updated to 1.15.5, the problem was solved

```
INFO 2025-06-27 11:04:54.683 main SkyWalkingAgent : Skywalking agent transformer has installed. 
INFO 2025-06-27 11:04:55.195 main Version : SkyWalking agent version: 9.5.0-SNAPSHOT-b1f18f3 
INFO 2025-06-27 11:05:06.663 background-preinit AgentClassLoader : ****/infra/skywalking-agent/plugins/websphere-liberty-23.x-plugin-9.5.0-SNAPSHOT.jar loaded. 
```

