### PR TITLE
build: fix Checkstyle encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
                 <configuration>
                     <configLocation>${maven.multiModuleProjectDirectory}/apm-checkstyle/checkStyle.xml</configLocation>
                     <headerLocation>${maven.multiModuleProjectDirectory}/apm-checkstyle/CHECKSTYLE_HEAD</headerLocation>
-                    <encoding>UTF-8</encoding>
+                    <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
                     <consoleOutput>true</consoleOutput>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <failOnViolation>${checkstyle.fails.on.error}</failOnViolation>


### PR DESCRIPTION
- checkstyle's parameter encoding is deprecated since commit (https://github.com/apache/maven-checkstyle-plugin/commit/627fa4f684866a579f2c105fcc1dbf3ed776daa8).
- use inputEncoding instead of encoding