### PR TITLE
(build)version management for maven-pulgin and artifactId

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 * Support gRPC 1.59.x and 1.70.x server interceptor trace
 * Fix the `CreateAopProxyInterceptor` in the Spring core-patch changes the AOP proxy type when a class is
   enhanced by both SkyWalking and Spring AOP.
+* Build: Centralized plugin version management in the root POM and Remove Redundant Declarations by PR #766
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/236?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Release Notes.
 * Support gRPC 1.59.x and 1.70.x server interceptor trace
 * Fix the `CreateAopProxyInterceptor` in the Spring core-patch changes the AOP proxy type when a class is
   enhanced by both SkyWalking and Spring AOP.
-* Build: Centralized plugin version management in the root POM and Remove Redundant Declarations by PR #766
+* Build: Centralized plugin version management in the root POM and remove redundant declarations.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/236?closed=1)
 

--- a/apm-protocol/apm-network/pom.xml
+++ b/apm-protocol/apm-network/pom.xml
@@ -35,12 +35,10 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -75,7 +73,6 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty-tcnative-boringssl-static.version}</version>
         </dependency>
         <dependency> <!-- necessary for Java 9+ -->
             <groupId>org.apache.tomcat</groupId>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -36,7 +36,6 @@
         <generateGitPropertiesFilename>${project.build.outputDirectory}/skywalking-agent-version.properties</generateGitPropertiesFilename>
         <guava.version>32.0.1-jre</guava.version>
         <wiremock.version>2.6.0</wiremock.version>
-        <netty-tcnative-boringssl-static.version>2.0.7.Final</netty-tcnative-boringssl-static.version>
         <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <shade.com.google.source>com.google</shade.com.google.source>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -81,7 +81,6 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <version>${bytebuddy.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -139,11 +138,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>tools.profiler</groupId>

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -165,7 +165,6 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>${bytebuddy.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-7.x-8.x-plugin/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apm-sniffer/apm-sdk-plugin/websphere-liberty-23.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/websphere-liberty-23.x-plugin/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apm-sniffer/apm-test-tools/pom.xml
+++ b/apm-sniffer/apm-test-tools/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/apm-sniffer/optional-plugins/netty-http-4.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/netty-http-4.1.x-plugin/pom.xml
@@ -30,14 +30,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.51.Final</netty.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.0.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.0.x-plugin/pom.xml
@@ -61,7 +61,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
@@ -61,7 +61,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-3.x-plugin/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-4.x-plugin/pom.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/pom.xml
@@ -63,7 +63,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
@@ -137,7 +137,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy</id>

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <com.google.protobuf.protoc.version>3.25.5</com.google.protobuf.protoc.version>
         <protoc-gen-grpc-java.plugin.version>1.68.1</protoc-gen-grpc-java.plugin.version>
+        <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <objenesis.version>3.1</objenesis.version>
         <async-profiler.version>3.0</async-profiler.version>
@@ -273,6 +274,16 @@
 			    <type>pom</type>
 			    <scope>import</scope>
 			</dependency>
+			<dependency>
+	            <groupId>io.netty</groupId>
+	            <artifactId>netty-tcnative-boringssl-static</artifactId>
+	            <version>${netty-tcnative-boringssl-static.version}</version>
+	        </dependency>
+			<dependency>
+	            <groupId>io.netty</groupId>
+	            <artifactId>netty-tcnative-classes</artifactId>
+	            <version>${netty-tcnative-boringssl-static.version}</version>
+	        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <com.google.protobuf.protoc.version>3.25.5</com.google.protobuf.protoc.version>
         <protoc-gen-grpc-java.plugin.version>1.68.1</protoc-gen-grpc-java.plugin.version>
-        <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <objenesis.version>3.1</objenesis.version>
         <async-profiler.version>3.0</async-profiler.version>
@@ -112,18 +111,19 @@
         <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
-        <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-resource-plugin.version>3.1.0</maven-resource-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
         <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <jmh.version>1.33</jmh.version>
         <gmaven-plugin.version>1.5</gmaven-plugin.version>
         <checkstyle.fails.on.error>true</checkstyle.fails.on.error>
-
+		<maven-docker-plugin.version>0.46.0</maven-docker-plugin.version>
     </properties>
 
     <profiles>
@@ -320,6 +320,32 @@
                         <containerNamePattern>%a-%t-%i</containerNamePattern>
                     </configuration>
                 </plugin>
+                <plugin>
+	                <artifactId>maven-enforcer-plugin</artifactId>
+	                <version>${maven-enforcer-plugin.version}</version>
+                </plugin>
+                <plugin>
+	                <artifactId>maven-compiler-plugin</artifactId>
+	                <version>${maven-compiler-plugin.version}</version>
+	            </plugin>
+	            <plugin>
+	                <artifactId>maven-resources-plugin</artifactId>
+	                <version>${maven-resource-plugin.version}</version>
+	            </plugin>
+	            <plugin>
+	                <artifactId>maven-source-plugin</artifactId>
+	                <version>${maven-source-plugin.version}</version>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-surefire-plugin</artifactId>
+	                <version>${maven-surefire-plugin.version}</version>
+	            </plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-dependency-plugin</artifactId>
+	                <version>${maven-dependency-plugin.version}</version>
+	            </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -338,7 +364,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>${maven-enforcer-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -362,7 +387,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${compiler.version}</source>
                     <target>${compiler.version}</target>
@@ -371,7 +395,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven-resource-plugin.version}</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
@@ -386,7 +409,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -461,7 +483,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M8</version>
                 <configuration>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,13 @@
                 <artifactId>async-profiler</artifactId>
                 <version>${async-profiler.version}</version>
             </dependency>
+            <dependency>
+			    <groupId>io.netty</groupId>
+			    <artifactId>netty-bom</artifactId>
+			    <version>${netty.version}</version>
+			    <type>pom</type>
+			    <scope>import</scope>
+			</dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Build: Update Maven Plugin Versions and Remove Redundant Declarations  

• Removed redundant version declarations across modules  for `netty` and `junit`
• Remove duplicate artifactId declarations `jmh-generator-annprocess` in `apm-sniffer/apm-agent-core/pom.xml`
• Centralized plugin (`maven-shade-plugin` and `maven-surefire-plugin` ) version management in the root POM 
• Centralized `netty` version management in the root POM by add `netty-bom`
• (fix)Declare property `maven-docker-plugin.version`