### PR TITLE
Support tagging cache keys for byte[] type in Jedis commands in jedis-2.x  and jedis-3.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Release Notes.
 * Bump up cli to the 0.15.0-dev.latest(77b4c49e89c9c000278f44e62729d534f2ec842e) in e2e.
 * Bump up apache parent pom to v35.
 * Update Maven to 3.6.3 in mvnw.
-
+* Support tagging cache keys for `byte[]` type in Jedis commands in jedis-2.x and jedis-3.x
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/242?closed=1)
 
 ------------------

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jedis/v3/JedisMethodInterceptor.java
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jedis/v3/JedisMethodInterceptor.java
@@ -30,6 +30,7 @@ import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Transaction;
 
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 public class JedisMethodInterceptor implements InstanceMethodsAroundInterceptor {
@@ -60,11 +61,15 @@ public class JedisMethodInterceptor implements InstanceMethodsAroundInterceptor 
             return Optional.empty();
         }
         Object argument = allArguments[0];
-        // include null
-        if (!(argument instanceof String)) {
-            return Optional.empty();
+        if (argument instanceof String) {
+            return Optional.of(StringUtil.cut((String) argument, JedisPluginConfig.Plugin.Jedis.REDIS_PARAMETER_MAX_LENGTH));
         }
-        return Optional.of(StringUtil.cut((String) argument, JedisPluginConfig.Plugin.Jedis.REDIS_PARAMETER_MAX_LENGTH));
+        if (argument instanceof byte[]) {
+            String key = new String((byte[]) argument, StandardCharsets.UTF_8);
+            return Optional.of(StringUtil.cut(key, JedisPluginConfig.Plugin.Jedis.REDIS_PARAMETER_MAX_LENGTH));
+        }
+        return Optional.empty();
+
     }
 
     @Override

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/src/test/java/org/apache/skywalking/apm/agent/JedisMethodInterceptorTest.java
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/src/test/java/org/apache/skywalking/apm/agent/JedisMethodInterceptorTest.java
@@ -1,0 +1,132 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one or more
+ *   contributor license agreements.  See the NOTICE file distributed with
+ *   this work for additional information regarding copyright ownership.
+ *   The ASF licenses this file to You under the Apache License, Version 2.0
+ *   (the "License"); you may not use this file except in compliance with
+ *   the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.skywalking.apm.agent;
+
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
+import org.apache.skywalking.apm.agent.core.context.util.TagValuePair;
+import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
+import org.apache.skywalking.apm.agent.test.helper.SegmentHelper;
+import org.apache.skywalking.apm.agent.test.helper.SpanHelper;
+import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStorage;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStoragePoint;
+import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
+import org.apache.skywalking.apm.plugin.jedis.v3.JedisMethodInterceptor;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import redis.clients.jedis.Jedis;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(TracingSegmentRunner.class)
+public class JedisMethodInterceptorTest {
+
+    private JedisMethodInterceptor interceptor;
+    @Rule
+    public AgentServiceRule serviceRule = new AgentServiceRule();
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    @SegmentStoragePoint
+    private SegmentStorage segmentStorage;
+
+    @Mock
+    private EnhancedInstance enhancedInstance;
+
+    @Before
+    public void setUp() {
+        interceptor = new JedisMethodInterceptor();
+    }
+
+    @Test
+    public void testSetStringKey() throws Throwable {
+        String methodName = "set";
+        String key = "testKey";
+        String value = "testValue";
+        when(enhancedInstance.getSkyWalkingDynamicField()).thenReturn("127.0.0.1:6379");
+        Object[] arguments = {key, value};
+        Class[] argumentTypes = {String.class, value.getClass()};
+
+        interceptor.beforeMethod(enhancedInstance, getJedisSetMethodWithStringKey(), arguments, argumentTypes, null);
+        interceptor.afterMethod(enhancedInstance, getJedisSetMethodWithStringKey(), arguments, argumentTypes, null);
+
+        MatcherAssert.assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+        AbstractTracingSpan span = spans.get(0);
+        assertThat(span.getOperationName(), startsWith("Jedis/set"));
+        assertThat(SpanHelper.getComponentId(span), is(30));
+        List<TagValuePair> tags = SpanHelper.getTags(span);
+        assertThat(tags.get(0).getValue(), is("Redis"));
+        assertThat(tags.get(1).getValue(), is(methodName));
+        assertThat(tags.get(2).getValue(), is(key));
+        assertThat(tags.get(3).getValue(), is("write"));
+        assertThat(span.isExit(), is(true));
+        assertThat(SpanHelper.getLayer(span), CoreMatchers.is(SpanLayer.CACHE));
+    }
+
+    private Method getJedisSetMethodWithStringKey() throws Exception {
+        return Jedis.class.getMethod("set", String.class, String.class);
+    }
+
+    @Test
+    public void testSetByteArrayKey() throws Throwable {
+        String methodName = "set";
+        byte[] key = "testKey".getBytes("utf-8");
+        byte[] value = "testValue".getBytes("utf-8");
+        when(enhancedInstance.getSkyWalkingDynamicField()).thenReturn("127.0.0.1:6379");
+        Object[] arguments = {key, value};
+        Class[] argumentTypes = {String.class, value.getClass()};
+
+        interceptor.beforeMethod(enhancedInstance, getJedisSetMethodWithByteArrayKey(), arguments, argumentTypes, null);
+        interceptor.afterMethod(enhancedInstance, getJedisSetMethodWithByteArrayKey(), arguments, argumentTypes, null);
+
+        MatcherAssert.assertThat(segmentStorage.getTraceSegments().size(), is(1));
+        TraceSegment traceSegment = segmentStorage.getTraceSegments().get(0);
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegment);
+        AbstractTracingSpan span = spans.get(0);
+        assertThat(span.getOperationName(), startsWith("Jedis/set"));
+        assertThat(SpanHelper.getComponentId(span), is(30));
+        List<TagValuePair> tags = SpanHelper.getTags(span);
+        assertThat(tags.get(0).getValue(), is("Redis"));
+        assertThat(tags.get(1).getValue(), is(methodName));
+        assertThat(tags.get(2).getValue(), is("testKey"));
+        assertThat(tags.get(3).getValue(), is("write"));
+        assertThat(span.isExit(), is(true));
+        assertThat(SpanHelper.getLayer(span), CoreMatchers.is(SpanLayer.CACHE));
+    }
+
+    private Method getJedisSetMethodWithByteArrayKey() throws Exception {
+        return Jedis.class.getMethod("set", byte[].class, byte[].class);
+    }
+
+}

--- a/test/plugin/scenarios/jedis-2.x-3.x-cluster-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jedis-2.x-3.x-cluster-scenario/config/expectedData.yaml
@@ -69,10 +69,27 @@ segmentItems:
             - {key: cache.cmd, value: get}
             - {key: cache.key, value: a}
             - {key: cache.op, value: read}
-          - operationName: Jedis/del
+          - operationName: Jedis/get
             operationId: 0
             parentSpanId: 0
             spanId: 4
+            spanLayer: Cache
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 30
+            isError: false
+            spanType: Exit
+            peer: redis-server3:6379;redis-server2:6379;redis-server1:6379;
+            skipAnalysis: false
+            tags:
+              - { key: cache.type, value: Redis }
+              - { key: cache.cmd, value: get }
+              - { key: cache.key, value: a }
+              - { key: cache.op, value: read }
+          - operationName: Jedis/del
+            operationId: 0
+            parentSpanId: 0
+            spanId: 5
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -89,7 +106,7 @@ segmentItems:
           - operationName: Jedis/echo
             operationId: 0
             parentSpanId: 0
-            spanId: 5
+            spanId: 6
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -105,7 +122,7 @@ segmentItems:
           - operationName: Jedis/set
             operationId: 0
             parentSpanId: 0
-            spanId: 6
+            spanId: 7
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -122,7 +139,7 @@ segmentItems:
           - operationName: Jedis/get
             operationId: 0
             parentSpanId: 0
-            spanId: 7
+            spanId: 8
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -139,7 +156,7 @@ segmentItems:
           - operationName: Jedis/del
             operationId: 0
             parentSpanId: 0
-            spanId: 8
+            spanId: 9
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0

--- a/test/plugin/scenarios/jedis-2.x-3.x-cluster-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
+++ b/test/plugin/scenarios/jedis-2.x-3.x-cluster-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
@@ -38,6 +38,7 @@ public class CaseController {
         try (RedisClusterCommandExecutor command = new RedisClusterCommandExecutor(redisCluster)) {
             command.set("a", "a");
             command.get("a");
+            command.get("a".getBytes());
             command.del("a");
         }
 

--- a/test/plugin/scenarios/jedis-2.x-3.x-cluster-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisClusterCommandExecutor.java
+++ b/test/plugin/scenarios/jedis-2.x-3.x-cluster-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisClusterCommandExecutor.java
@@ -48,6 +48,10 @@ public class RedisClusterCommandExecutor implements AutoCloseable {
         jedisCluster.get(key);
     }
 
+    public void get(byte[] key) {
+        jedisCluster.get(key);
+    }
+
     public void del(String key) {
         jedisCluster.del(key);
     }

--- a/test/plugin/scenarios/jedis-2.x-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jedis-2.x-scenario/config/expectedData.yaml
@@ -69,10 +69,27 @@ segmentItems:
             - {key: cache.cmd, value: get}
             - {key: cache.key, value: a}
             - {key: cache.op, value: read}
-          - operationName: Jedis/del
+          - operationName: Jedis/get
             operationId: 0
             parentSpanId: 0
             spanId: 4
+            spanLayer: Cache
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 30
+            isError: false
+            spanType: Exit
+            peer: redis-server:6379
+            skipAnalysis: false
+            tags:
+            - { key: cache.type, value: Redis }
+            - { key: cache.cmd, value: get }
+            - { key: cache.key, value: a }
+            - { key: cache.op, value: read }
+          - operationName: Jedis/del
+            operationId: 0
+            parentSpanId: 0
+            spanId: 5
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -89,21 +106,6 @@ segmentItems:
           - operationName: Jedis/syncAndReturnAll
             operationId: 0
             parentSpanId: 0
-            spanId: 5
-            spanLayer: Cache
-            startTime: gt 0
-            endTime: gt 0
-            componentId: 30
-            isError: false
-            spanType: Exit
-            peer: redis-server:6379
-            skipAnalysis: false
-            tags:
-              - {key: cache.type, value: Redis}
-              - {key: cache.cmd, value: BATCH_EXECUTE}
-          - operationName: Jedis/discard
-            operationId: 0
-            parentSpanId: 0
             spanId: 6
             spanLayer: Cache
             startTime: gt 0
@@ -116,7 +118,7 @@ segmentItems:
             tags:
               - {key: cache.type, value: Redis}
               - {key: cache.cmd, value: BATCH_EXECUTE}
-          - operationName: Jedis/exec
+          - operationName: Jedis/discard
             operationId: 0
             parentSpanId: 0
             spanId: 7
@@ -131,10 +133,25 @@ segmentItems:
             tags:
               - {key: cache.type, value: Redis}
               - {key: cache.cmd, value: BATCH_EXECUTE}
-          - operationName: Jedis/discard
+          - operationName: Jedis/exec
             operationId: 0
             parentSpanId: 0
             spanId: 8
+            spanLayer: Cache
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 30
+            isError: false
+            spanType: Exit
+            peer: redis-server:6379
+            skipAnalysis: false
+            tags:
+              - {key: cache.type, value: Redis}
+              - {key: cache.cmd, value: BATCH_EXECUTE}
+          - operationName: Jedis/discard
+            operationId: 0
+            parentSpanId: 0
+            spanId: 9
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0

--- a/test/plugin/scenarios/jedis-2.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
+++ b/test/plugin/scenarios/jedis-2.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
@@ -41,6 +41,7 @@ public class CaseController {
         try (RedisCommandExecutor command = new RedisCommandExecutor(redisHost, redisPort)) {
             command.set("a", "a");
             command.get("a");
+            command.get("a".getBytes());
             command.del("a");
         }
 

--- a/test/plugin/scenarios/jedis-2.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisCommandExecutor.java
+++ b/test/plugin/scenarios/jedis-2.x-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisCommandExecutor.java
@@ -36,6 +36,10 @@ public class RedisCommandExecutor implements AutoCloseable {
         jedis.get(key);
     }
 
+    public void get(byte[] key) {
+        jedis.get(key);
+    }
+
     public void del(String key) {
         jedis.del(key);
     }

--- a/test/plugin/scenarios/jedis-3.1.x-plus-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jedis-3.1.x-plus-scenario/config/expectedData.yaml
@@ -70,10 +70,27 @@ segmentItems:
               - {key: cache.cmd, value: get}
               - {key: cache.key, value: a}
               - {key: cache.op, value: read}
-          - operationName: Jedis/del
+          - operationName: Jedis/get
             operationId: 0
             parentSpanId: 0
             spanId: 4
+            spanLayer: Cache
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 30
+            isError: false
+            spanType: Exit
+            peer: redis-server:6379
+            skipAnalysis: false
+            tags:
+              - { key: cache.type, value: Redis }
+              - { key: cache.cmd, value: get }
+              - { key: cache.key, value: a }
+              - { key: cache.op, value: read }
+          - operationName: Jedis/del
+            operationId: 0
+            parentSpanId: 0
+            spanId: 5
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -90,7 +107,7 @@ segmentItems:
           - operationName: Jedis/syncAndReturnAll
             operationId: 0
             parentSpanId: 0
-            spanId: 5
+            spanId: 6
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -105,7 +122,7 @@ segmentItems:
           - operationName: Jedis/discard
             operationId: 0
             parentSpanId: 0
-            spanId: 6
+            spanId: 7
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -120,7 +137,7 @@ segmentItems:
           - operationName: Jedis/exec
             operationId: 0
             parentSpanId: 0
-            spanId: 7
+            spanId: 8
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -135,7 +152,7 @@ segmentItems:
           - operationName: Jedis/discard
             operationId: 0
             parentSpanId: 0
-            spanId: 8
+            spanId: 9
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -150,7 +167,7 @@ segmentItems:
           - operationName: Jedis/xadd
             operationId: 0
             parentSpanId: 0
-            spanId: 9
+            spanId: 10
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -167,7 +184,7 @@ segmentItems:
           - operationName: Jedis/xread
             operationId: 0
             parentSpanId: 0
-            spanId: 10
+            spanId: 11
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -183,7 +200,7 @@ segmentItems:
           - operationName: Jedis/xdel
             operationId: 0
             parentSpanId: 0
-            spanId: 11
+            spanId: 12
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0

--- a/test/plugin/scenarios/jedis-3.1.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
+++ b/test/plugin/scenarios/jedis-3.1.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
@@ -41,6 +41,7 @@ public class CaseController {
         try (RedisCommandExecutor command = new RedisCommandExecutor(redisHost, redisPort)) {
             command.set("a", "a");
             command.get("a");
+            command.get("a".getBytes());
             command.del("a");
         }
 

--- a/test/plugin/scenarios/jedis-3.1.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisCommandExecutor.java
+++ b/test/plugin/scenarios/jedis-3.1.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisCommandExecutor.java
@@ -36,6 +36,10 @@ public class RedisCommandExecutor implements AutoCloseable {
         jedis.get(key);
     }
 
+    public void get(byte[] key) {
+        jedis.get(key);
+    }
+
     public void del(String key) {
         jedis.del(key);
     }

--- a/test/plugin/scenarios/jedis-3.3.x-plus-scenario/config/expectedData.yaml
+++ b/test/plugin/scenarios/jedis-3.3.x-plus-scenario/config/expectedData.yaml
@@ -69,10 +69,27 @@ segmentItems:
               - {key: cache.cmd, value: get}
               - {key: cache.key, value: a}
               - {key: cache.op, value: read}
-          - operationName: Jedis/del
+          - operationName: Jedis/get
             operationId: 0
             parentSpanId: 0
             spanId: 4
+            spanLayer: Cache
+            startTime: gt 0
+            endTime: gt 0
+            componentId: 30
+            isError: false
+            spanType: Exit
+            peer: redis-server:6379
+            skipAnalysis: false
+            tags:
+              - { key: cache.type, value: Redis }
+              - { key: cache.cmd, value: get }
+              - { key: cache.key, value: a }
+              - { key: cache.op, value: read }
+          - operationName: Jedis/del
+            operationId: 0
+            parentSpanId: 0
+            spanId: 5
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -89,7 +106,7 @@ segmentItems:
           - operationName: Jedis/syncAndReturnAll
             operationId: 0
             parentSpanId: 0
-            spanId: 5
+            spanId: 6
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -104,7 +121,7 @@ segmentItems:
           - operationName: Jedis/discard
             operationId: 0
             parentSpanId: 0
-            spanId: 6
+            spanId: 7
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -119,7 +136,7 @@ segmentItems:
           - operationName: Jedis/exec
             operationId: 0
             parentSpanId: 0
-            spanId: 7
+            spanId: 8
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -134,7 +151,7 @@ segmentItems:
           - operationName: Jedis/discard
             operationId: 0
             parentSpanId: 0
-            spanId: 8
+            spanId: 9
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -149,7 +166,7 @@ segmentItems:
           - operationName: Jedis/xadd
             operationId: 0
             parentSpanId: 0
-            spanId: 9
+            spanId: 10
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -166,7 +183,7 @@ segmentItems:
           - operationName: Jedis/xread
             operationId: 0
             parentSpanId: 0
-            spanId: 10
+            spanId: 11
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0
@@ -182,7 +199,7 @@ segmentItems:
           - operationName: Jedis/xdel
             operationId: 0
             parentSpanId: 0
-            spanId: 11
+            spanId: 12
             spanLayer: Cache
             startTime: gt 0
             endTime: gt 0

--- a/test/plugin/scenarios/jedis-3.3.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
+++ b/test/plugin/scenarios/jedis-3.3.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/CaseController.java
@@ -41,6 +41,7 @@ public class CaseController {
         try (RedisCommandExecutor command = new RedisCommandExecutor(redisHost, redisPort)) {
             command.set("a", "a");
             command.get("a");
+            command.get("a".getBytes());
             command.del("a");
         }
 

--- a/test/plugin/scenarios/jedis-3.3.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisCommandExecutor.java
+++ b/test/plugin/scenarios/jedis-3.3.x-plus-scenario/src/main/java/org/apache/skywalking/apm/testcase/jedis/controller/RedisCommandExecutor.java
@@ -39,6 +39,10 @@ public class RedisCommandExecutor implements AutoCloseable {
         jedis.get(key);
     }
 
+    public void get(byte[] key) {
+        jedis.get(key);
+    }
+
     public void del(String key) {
         jedis.del(key);
     }


### PR DESCRIPTION
fix  https://github.com/apache/skywalking/issues/13478

Currently, the jedis-2.x-3.x-plugin only supports collecting the `cache.key` tag for keys of `String` type. However, in some application codes, methods corresponding to the `byte[]` key type are invoked due to various reasons . This limitation prevents the cache.keytag from being collected for these byte[]-type keys, potentially leading to incomplete monitoring or tracing data.

It is necessary to extend the plugin's capability to also collect the cache.keytag for keys of byte[]type, ensuring comprehensive coverage and consistent monitoring for both key types.

### Support tagging cache keys for `byte[]` type in Jedis commands in jedis-2.x  and jedis-3.x
- [X] Tests(including UT, IT, E2E) are added to verify the new feature.
- [X] Closes 13478.
- [X] Update the [`CHANGES` log](https://github.com/apache/skywalking-java/blob/main/CHANGES.md).
