### PR TITLE
Apply SQL_BODY_MAX_LENGTH to ClickHouse JDBC plugin span tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Release Notes.
 * Add Elasticsearch Java client (co.elastic.clients:elasticsearch-java) plugin for 7.16.x-9.x.
 * Only publish `apm-application-toolkit` modules to Maven Central. Agent and plugins are distributed via download package and Docker images.
 * Add unified release script (`tools/releasing/release.sh`) with two-step flow: `prepare-vote` and `vote-passed`.
+* Fix `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` was not honored by clickhouse-0.3.1 and clickhouse-0.3.2.x plugins.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/249?closed=1)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ Release Notes.
 * Add Elasticsearch Java client (co.elastic.clients:elasticsearch-java) plugin for 7.16.x-9.x.
 * Only publish `apm-application-toolkit` modules to Maven Central. Agent and plugins are distributed via download package and Docker images.
 * Add unified release script (`tools/releasing/release.sh`) with two-step flow: `prepare-vote` and `vote-passed`.
-* Fix `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` was not honored by clickhouse-0.3.1 and clickhouse-0.3.2.x plugins.
+* Fix an issue where `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` was not honored by clickhouse-0.3.1 and clickhouse-0.3.2.x plugins.
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/249?closed=1)
 

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHouseStatementTracingWrapper.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHouseStatementTracingWrapper.java
@@ -23,6 +23,7 @@ import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.plugin.jdbc.SqlBodyUtil;
 import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
 
 /**
@@ -37,7 +38,7 @@ public class ClickHouseStatementTracingWrapper {
         try {
             Tags.DB_TYPE.set(span, connectionInfo.getDBType());
             Tags.DB_INSTANCE.set(span, connectionInfo.getDatabaseName());
-            Tags.DB_STATEMENT.set(span, sql);
+            Tags.DB_STATEMENT.set(span, SqlBodyUtil.limitSqlBodySize(sql));
             span.setComponent(connectionInfo.getComponent());
             SpanLayer.asDB(span);
             return supplier.get();

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHouseStatementTracingWrapperTest.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHouseStatementTracingWrapperTest.java
@@ -82,7 +82,7 @@ public class ClickHouseStatementTracingWrapperTest {
     @Test
     public void longSqlIsTruncatedToConfiguredLimit() throws Exception {
         JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 16;
-        // 32 chars, twice the limit, so the helper must truncate to first 16 chars and append "..."
+        // Longer than the limit, so the helper must truncate to first 16 chars and append "..."
         String sql = "SELECT * FROM table_with_many_cols";
 
         ClickHouseStatementTracingWrapper.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHouseStatementTracingWrapperTest.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHouseStatementTracingWrapperTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.jdbc.clickhouse;
+
+import java.util.List;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
+import org.apache.skywalking.apm.agent.core.context.util.TagValuePair;
+import org.apache.skywalking.apm.agent.test.helper.SegmentHelper;
+import org.apache.skywalking.apm.agent.test.helper.SpanHelper;
+import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStorage;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStoragePoint;
+import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.plugin.jdbc.JDBCPluginConfig;
+import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Verify that {@link ClickHouseStatementTracingWrapper} truncates the SQL body
+ * recorded on the exit span according to {@link JDBCPluginConfig.Plugin.JDBC#SQL_BODY_MAX_LENGTH}.
+ */
+@RunWith(TracingSegmentRunner.class)
+public class ClickHouseStatementTracingWrapperTest {
+
+    @SegmentStoragePoint
+    private SegmentStorage segmentStorage;
+
+    @Rule
+    public AgentServiceRule serviceRule = new AgentServiceRule();
+
+    private ConnectionInfo connectionInfo;
+
+    private int originalLimit;
+
+    @Before
+    public void setUp() {
+        connectionInfo = new ConnectionInfo(
+                ComponentsDefine.CLICKHOUSE_JDBC_DRIVER, "ClickHouse", "127.0.0.1", 8123, "default");
+        originalLimit = JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH;
+    }
+
+    @After
+    public void tearDown() {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = originalLimit;
+    }
+
+    @Test
+    public void shortSqlIsRecordedAsIs() throws Exception {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 2048;
+        String sql = "SELECT 1";
+
+        ClickHouseStatementTracingWrapper.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);
+
+        assertThat(dbStatementTagValue(), is(sql));
+    }
+
+    @Test
+    public void longSqlIsTruncatedToConfiguredLimit() throws Exception {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 16;
+        // 32 chars, twice the limit, so the helper must truncate to first 16 chars and append "..."
+        String sql = "SELECT * FROM table_with_many_cols";
+
+        ClickHouseStatementTracingWrapper.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);
+
+        assertThat(dbStatementTagValue(), is(sql.substring(0, 16) + "..."));
+    }
+
+    @Test
+    public void negativeLimitDisablesTruncation() throws Exception {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = -1;
+        StringBuilder builder = new StringBuilder("SELECT ");
+        for (int i = 0; i < 1000; i++) {
+            builder.append("a, ");
+        }
+        builder.append("a FROM t");
+        String sql = builder.toString();
+
+        ClickHouseStatementTracingWrapper.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);
+
+        assertThat(dbStatementTagValue(), is(sql));
+    }
+
+    private String dbStatementTagValue() {
+        List<TraceSegment> traceSegments = segmentStorage.getTraceSegments();
+        assertThat(traceSegments.size(), is(1));
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegments.get(0));
+        assertThat(spans.size(), is(1));
+        List<TagValuePair> tags = SpanHelper.getTags(spans.get(0));
+        // tag order: db.type, db.instance, db.statement
+        return (String) tags.get(2).getValue();
+    }
+}

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/v32/ClickHousePrepareStatementTracing.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/main/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/v32/ClickHousePrepareStatementTracing.java
@@ -22,6 +22,7 @@ import org.apache.skywalking.apm.agent.core.context.ContextManager;
 import org.apache.skywalking.apm.agent.core.context.tag.Tags;
 import org.apache.skywalking.apm.agent.core.context.trace.AbstractSpan;
 import org.apache.skywalking.apm.agent.core.context.trace.SpanLayer;
+import org.apache.skywalking.apm.plugin.jdbc.SqlBodyUtil;
 import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
 
 import java.sql.SQLException;
@@ -39,7 +40,7 @@ public class ClickHousePrepareStatementTracing {
         try {
             Tags.DB_TYPE.set(span, connectionInfo.getDBType());
             Tags.DB_INSTANCE.set(span, connectionInfo.getDatabaseName());
-            Tags.DB_STATEMENT.set(span, sql);
+            Tags.DB_STATEMENT.set(span, SqlBodyUtil.limitSqlBodySize(sql));
             span.setComponent(connectionInfo.getComponent());
             SpanLayer.asDB(span);
             return supplier.get();

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHousePrepareStatementTracingTest.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHousePrepareStatementTracingTest.java
@@ -83,7 +83,7 @@ public class ClickHousePrepareStatementTracingTest {
     @Test
     public void longSqlIsTruncatedToConfiguredLimit() throws Exception {
         JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 16;
-        // 32 chars, twice the limit, so the helper must truncate to first 16 chars and append "..."
+        // Longer than the configured limit, so the helper must truncate to the first 16 chars and append "..."
         String sql = "SELECT * FROM table_with_many_cols";
 
         ClickHousePrepareStatementTracing.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHousePrepareStatementTracingTest.java
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/src/test/java/org/apache/skywalking/apm/plugin/jdbc/clickhouse/ClickHousePrepareStatementTracingTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.skywalking.apm.plugin.jdbc.clickhouse;
+
+import java.util.List;
+import org.apache.skywalking.apm.agent.core.context.trace.AbstractTracingSpan;
+import org.apache.skywalking.apm.agent.core.context.trace.TraceSegment;
+import org.apache.skywalking.apm.agent.core.context.util.TagValuePair;
+import org.apache.skywalking.apm.agent.test.helper.SegmentHelper;
+import org.apache.skywalking.apm.agent.test.helper.SpanHelper;
+import org.apache.skywalking.apm.agent.test.tools.AgentServiceRule;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStorage;
+import org.apache.skywalking.apm.agent.test.tools.SegmentStoragePoint;
+import org.apache.skywalking.apm.agent.test.tools.TracingSegmentRunner;
+import org.apache.skywalking.apm.network.trace.component.ComponentsDefine;
+import org.apache.skywalking.apm.plugin.jdbc.JDBCPluginConfig;
+import org.apache.skywalking.apm.plugin.jdbc.clickhouse.v32.ClickHousePrepareStatementTracing;
+import org.apache.skywalking.apm.plugin.jdbc.trace.ConnectionInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Verify that {@link ClickHousePrepareStatementTracing} truncates the SQL body
+ * recorded on the exit span according to {@link JDBCPluginConfig.Plugin.JDBC#SQL_BODY_MAX_LENGTH}.
+ */
+@RunWith(TracingSegmentRunner.class)
+public class ClickHousePrepareStatementTracingTest {
+
+    @SegmentStoragePoint
+    private SegmentStorage segmentStorage;
+
+    @Rule
+    public AgentServiceRule serviceRule = new AgentServiceRule();
+
+    private ConnectionInfo connectionInfo;
+
+    private int originalLimit;
+
+    @Before
+    public void setUp() {
+        connectionInfo = new ConnectionInfo(
+                ComponentsDefine.CLICKHOUSE_JDBC_DRIVER, "ClickHouse", "127.0.0.1", 8123, "test");
+        originalLimit = JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH;
+    }
+
+    @After
+    public void tearDown() {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = originalLimit;
+    }
+
+    @Test
+    public void shortSqlIsRecordedAsIs() throws Exception {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 2048;
+        String sql = "SELECT 1";
+
+        ClickHousePrepareStatementTracing.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);
+
+        assertThat(dbStatementTagValue(), is(sql));
+    }
+
+    @Test
+    public void longSqlIsTruncatedToConfiguredLimit() throws Exception {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = 16;
+        // 32 chars, twice the limit, so the helper must truncate to first 16 chars and append "..."
+        String sql = "SELECT * FROM table_with_many_cols";
+
+        ClickHousePrepareStatementTracing.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);
+
+        assertThat(dbStatementTagValue(), is(sql.substring(0, 16) + "..."));
+    }
+
+    @Test
+    public void negativeLimitDisablesTruncation() throws Exception {
+        JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH = -1;
+        StringBuilder builder = new StringBuilder("SELECT ");
+        for (int i = 0; i < 1000; i++) {
+            builder.append("a, ");
+        }
+        builder.append("a FROM t");
+        String sql = builder.toString();
+
+        ClickHousePrepareStatementTracing.of(connectionInfo, "execute", sql, () -> Boolean.TRUE);
+
+        assertThat(dbStatementTagValue(), is(sql));
+    }
+
+    private String dbStatementTagValue() {
+        List<TraceSegment> traceSegments = segmentStorage.getTraceSegments();
+        assertThat(traceSegments.size(), is(1));
+        List<AbstractTracingSpan> spans = SegmentHelper.getSpans(traceSegments.get(0));
+        assertThat(spans.size(), is(1));
+        List<TagValuePair> tags = SpanHelper.getTags(spans.get(0));
+        // tag order: db.type, db.instance, db.statement
+        return (String) tags.get(2).getValue();
+    }
+}


### PR DESCRIPTION
## Problem

`ClickHouseStatementTracingWrapper` (in `clickhouse-0.3.1-plugin`) and `ClickHousePrepareStatementTracing` (in `clickhouse-0.3.2.x-plugin`) record the SQL string directly into the `DB_STATEMENT` span tag:

```java
Tags.DB_STATEMENT.set(span, sql);
```

Every other JDBC plugin in `apm-sdk-plugin/` routes the same tag through `SqlBodyUtil#limitSqlBodySize`, which truncates the value to `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` and appends `...`. As a result, an operator who lowers `SQL_BODY_MAX_LENGTH` to control trace payload size still sees the full unbounded SQL emitted by the ClickHouse plugins.

## Root Cause

The two ClickHouse interceptors miss the `SqlBodyUtil#limitSqlBodySize` call that the rest of the JDBC plugin family uses. The configuration option exists and works for every other JDBC dialect; only ClickHouse does not honour it.

## Fix

Wrap the SQL with `SqlBodyUtil#limitSqlBodySize` in both interceptors. `SqlBodyUtil` already handles the negative-limit sentinel that disables truncation, so behaviour is unchanged for users who left the default in place but rely on the disable-truncation override.

Add a CHANGES.md entry under "Bug Fixes".

## Tests Added

| Change point | Test |
|--------------|------|
| `ClickHouseStatementTracingWrapper.of` truncates when SQL exceeds the configured limit | `ClickHouseStatementTracingWrapperTest#longSqlIsTruncatedToConfiguredLimit` — sets the limit to 16, asserts the recorded tag is the first 16 characters plus `...` |
| Same wrapper passes short SQL through unchanged | `ClickHouseStatementTracingWrapperTest#shortSqlIsRecordedAsIs` — sets the limit to 2048, asserts the recorded tag equals the original SQL |
| Negative limit disables truncation | `ClickHouseStatementTracingWrapperTest#negativeLimitDisablesTruncation` — sets the limit to -1 with a 3KB SQL, asserts the full SQL is recorded |
| Same three semantics for `ClickHousePrepareStatementTracing.of` | `ClickHousePrepareStatementTracingTest#shortSqlIsRecordedAsIs`, `#longSqlIsTruncatedToConfiguredLimit`, `#negativeLimitDisablesTruncation` |

`mvn -pl apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin,apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin -am test` — all 31 tests in clickhouse-0.3.2.x-plugin and 6 tests in clickhouse-0.3.1-plugin pass locally.

Each test restores `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` in `@After` to keep test ordering safe.

## Impact

- Users who configured `plugin.jdbc.sql_body_max_length` will now see the same truncation behaviour for ClickHouse spans that they already get for MySQL / PostgreSQL / H2 / SQL Server / ...
- Default users (no explicit limit) keep the same payload size as before, since the default limit is large.
- No public API changes.