### PR TITLE
Pin docker/login-action to an ASF-approved commit SHA

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -91,7 +91,7 @@ jobs:
           docker info
           echo "DOCKER_API_VERSION=$(docker version --format '{{.Server.APIVersion}}')" >> "$GITHUB_ENV"
       - name: Log in to the Container registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}


### PR DESCRIPTION
## Why

The ASF org-wide GitHub Actions allow-list requires third-party actions to be pinned to a reviewed commit SHA rather than a floating version tag. `.github/workflows/publish-docker.yaml` referenced `docker/login-action@v1.10.0`, which the allow-list rejects. It was the only unpinned third-party action across the repo's workflows.

## What

Pin `docker/login-action` to `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` (v4.2.0):

- present in `apache/infrastructure-actions`' [`approved_patterns.yml`](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml),
- already used by `apache/skywalking`.

`docker/login-action`'s inputs (`registry` / `username` / `password`) are unchanged from v1 to v4, so the login step behaves identically.

Policy references: <https://infra.apache.org/github-actions-policy.html> · <https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+Security>