### PR TITLE
Fix release script: changelog archiving and master-branch links

### DIFF
--- a/tools/releasing/release.sh
+++ b/tools/releasing/release.sh
@@ -397,7 +397,7 @@ This is a call for vote to release Apache SkyWalking Java Agent version ${versio
 
 Release notes:
 
- * https://github.com/apache/skywalking-java/blob/master/changes/changes-${version}.md
+ * https://github.com/apache/skywalking-java/blob/main/changes/changes-${version}.md
 
 Release Candidate:
 
@@ -457,7 +457,7 @@ the previous version. The notable changes include:
 3. ...
 
 Please refer to the change log for the complete list of changes:
-https://github.com/apache/skywalking-java/blob/master/changes/changes-${version}.md
+https://github.com/apache/skywalking-java/blob/main/changes/changes-${version}.md
 
 Apache SkyWalking website:
 http://skywalking.apache.org/

--- a/tools/releasing/release.sh
+++ b/tools/releasing/release.sh
@@ -189,10 +189,14 @@ cmd_prepare() {
     info "Moving changelog to changes/changes-${version}.md..."
     local changes_file="changes/changes-${version}.md"
 
-    # Extract current version section from CHANGES.md
-    sed -n "/^${version}$/,/^------------------$/p" CHANGES.md | head -n -1 > "$changes_file"
-    grep "All issues and pull requests" CHANGES.md >> "$changes_file" || true
-    info "Created $changes_file"
+    # Archive CHANGES.md as the release changelog: everything up to and including
+    # the milestone link, dropping only the trailing "Find change logs of all
+    # versions" footer. Uses POSIX sed addressing so it works on BSD and GNU alike.
+    if ! grep -q "All issues and pull requests" CHANGES.md; then
+        error "CHANGES.md has no 'All issues and pull requests' milestone line; cannot archive changelog."
+    fi
+    sed -n '1,/All issues and pull requests/p' CHANGES.md > "$changes_file"
+    info "Created $changes_file ($(wc -l < "$changes_file" | tr -d ' ') lines)"
 
     # Reset CHANGES.md for next development version
     cat > CHANGES.md << EOF


### PR DESCRIPTION
Two fixes to `tools/releasing/release.sh`, both hit while preparing 9.7.0.

### 1. Changelog archiving was broken (release-blocking)

The "Move changelog" step of `cmd_prepare` aborted the release on macOS, after
`mvn release:prepare` had already created the commits and the tag:

```
[INFO] Moving changelog to changes/changes-9.7.0.md...
head: illegal line count -- -1
```

There were two independent bugs in that one block:

**a. `head -n -1` is GNU-only.** "All but the last line" is a GNU coreutils
extension; BSD `head` on macOS rejects a negative count. Combined with
`set -euo pipefail`, the release stopped mid-way.

**b. The sed range was wrong on every platform.**

```bash
sed -n "/^${version}$/,/^------------------$/p" CHANGES.md
```

In `CHANGES.md` the `------------------` underline sits *directly beneath* the
version number, so the range closes on the very next line and matches only 2
lines. Even on Linux with GNU `head`, the archived `changes-x.y.z.md` would
have been the version number plus the milestone link, with the entire
changelog body silently dropped.

Both are replaced with a single POSIX sed address that keeps everything up to
and including the milestone link and drops only the trailing "Find change logs
of all versions" footer:

```bash
sed -n '1,/All issues and pull requests/p' CHANGES.md > "$changes_file"
```

This reproduces the existing `changes/changes-9.6.0.md` layout exactly. Also
added: a guard that fails loudly if the milestone line is missing, and a line
count in the log line so a truncated archive is visible in the release output.

### 2. Email templates linked to a non-existent `master` branch

The vote and announce templates linked the changelog at
`https://github.com/apache/skywalking-java/blob/master/changes/changes-${version}.md`.
This repository's default branch is `main`, so both links 404 for anyone
following the release vote or announcement mail. Two occurrences, in
`cmd_email vote` and `cmd_email announce`.

### Testing

- `bash -n tools/releasing/release.sh` passes.
- Ran the fixed extraction against the current 9.7.0 `CHANGES.md`: produces a
  38-line file whose structure diffs clean against `changes/changes-9.6.0.md`
  (only the changelog bullets and milestone number differ).
- Swept the script for other GNU-only constructs (`sed -i`, `date -d`,
  `grep -P`, `readlink -f`, `sort -V`, …); none found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)