### PR TITLE
Release 9.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Release Notes.
 ------------------
 
 
-All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/xxx?closed=1)
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/263?closed=1)
 
 ------------------
 Find change logs of all versions [here](changes).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,40 +2,11 @@ Changes by Version
 ==================
 Release Notes.
 
-9.7.0
+9.8.0
 ------------------
 
-* Fix `plugin.http.include_http_headers` not working on Spring Boot 3.x / Jakarta EE (apache/skywalking#13938).
-* Support `plugin.http.include_http_headers` in the Tomcat plugin, collecting the configured request headers as the `http.headers` tag on Tomcat entry spans (e.g. RESTEasy on Tomcat), consistent with the Spring MVC plugin. Honors the shared `plugin.http.http_headers_length_threshold`.
-* Unify the Tomcat plugins into a single `tomcat` plugin (Tomcat 7 - 10) and the Jetty server plugins into a single `jetty-server` plugin (Jetty 9 - 11), each supporting both `javax.servlet` and `jakarta.servlet`. Breaking change: plugin names `tomcat-7.x/8.x` and `tomcat-10.x` are replaced by `tomcat`, and `jetty-server-9.x` and `jetty-server-11.x` by `jetty-server`; update `plugin.exclude_plugins` if you reference the old names.
-* Add a Jetty 12 server plugin (`jetty-server-12.x`). Jetty 12 removed the `HttpChannel` handle target and moved request handling to the async `Server#handle(Request, Response, Callback)` core API, so it needs a separate plugin from the merged `jetty-server`.
-* Add a Struts 7 plugin (`struts2-7.x`) for Jakarta Struts, whose `DefaultActionInvocation` moved to `org.apache.struts2`.
-* Added support for Lettuce reactive Redis commands.
-* Add tracing support for `invokeAll` and `invokeAny` in the JDK thread pool plugin (`jdk-threadpool-plugin`).
-* Add Spring AI 1.x plugin and GenAI layer.
-* Fix httpclient-5.x plugin injecting sw8 propagation headers into ClickHouse HTTP requests (port 8123), causing HTTP 400. Add `PROPAGATION_EXCLUDE_PORTS` config to skip tracing (including header injection) for specified ports in the classic client interceptor.
-* Add Spring RabbitMQ 2.x - 4.x plugin.
-* Extend MySQL plugin to support MySQL Connector/J 8.4.0 and 9.x (9.0 -> 9.6).
-* Extend MariaDB plugin to support MariaDB Connector/J 2.7.x.
-* Extend MongoDB 4.x plugin to support MongoDB Java Driver 4.2 -> 4.10. Fix db.bind_vars extraction for driver 4.9+ where InsertOperation/DeleteOperation/UpdateOperation classes were removed.
-* Fix MongoDB 4.x plugin for driver 4.11+ where Cluster.getDescription() was removed, use getCurrentDescription() instead.
-* Extend Feign plugin to support OpenFeign 10.x, 11.x, 12.1.
-* Add Feign 12.2+ PathVar support (BuildTemplateByResolvingArgs moved to RequestTemplateFactoryResolver).
-* Extend Undertow plugin to support Undertow 2.1.x, 2.2.x, 2.3.x.
-* Extend GraphQL plugin to support graphql-java 18 -> 24 (20+ requires JDK 17).
-* Extend Spring Kafka plugin to support Spring Kafka 2.4 -> 2.9 and 3.0 -> 3.3.
-* Enhance test/plugin/run.sh to support extra Maven properties per version in support-version.list (format: version,key=value).
-* Add MariaDB 3.x plugin (all classes renamed in 3.x).
-* Extend Jedis 4.x plugin to support Jedis 5.x (fix witness method for 5.x compatibility).
-* Add Elasticsearch Java client (co.elastic.clients:elasticsearch-java) plugin for 7.16.x-9.x.
-* Only publish `apm-application-toolkit` modules to Maven Central. Agent and plugins are distributed via download package and Docker images.
-* Add unified release script (`tools/releasing/release.sh`) with two-step flow: `prepare-vote` and `vote-passed`.
-* Fix an issue where `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` was not honored by clickhouse-0.3.1 and clickhouse-0.3.2.x plugins.
-- Add tracing support for vector-store retrieval operations.
-* Fix agent lifecycle events: the Start event now carries the service instance name, and the Shutdown event is delivered on graceful JVM exit. `ServiceManager` prepares/starts higher-priority `BootService`s first and shuts them down last (matching `BootService#priority()`), and the shutdown event refreshes its gRPC deadline before sending.
-* Fix the `SenderSendInterceptor` in the nutz-plugins/http-1.x-plugin to avoid NPE caused by the Response status.
 
-All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/249?closed=1)
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/xxx?closed=1)
 
 ------------------
 Find change logs of all versions [here](changes).

--- a/apm-application-toolkit/apm-toolkit-kafka/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-kafka/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-kafka/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-kafka/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-logback-1.x/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-meter/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-meter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-meter/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-meter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-micrometer-1.10/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-micrometer-1.10/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-micrometer-1.10/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-micrometer-1.10/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-micrometer-registry/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-micrometer-registry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-micrometer-registry/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-micrometer-registry/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-opentracing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-trace/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-trace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-trace/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-trace/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-webflux/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-webflux/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/apm-toolkit-webflux/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-webflux/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-application-toolkit</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-application-toolkit/pom.xml
+++ b/apm-application-toolkit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apm-application-toolkit</artifactId>

--- a/apm-application-toolkit/pom.xml
+++ b/apm-application-toolkit/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>apm-application-toolkit</artifactId>

--- a/apm-commons/apm-datacarrier/pom.xml
+++ b/apm-commons/apm-datacarrier/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-datacarrier/pom.xml
+++ b/apm-commons/apm-datacarrier/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-util/pom.xml
+++ b/apm-commons/apm-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>java-agent-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/apm-util/pom.xml
+++ b/apm-commons/apm-util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>java-agent-commons</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/pom.xml
+++ b/apm-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-commons/pom.xml
+++ b/apm-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/apm-network/pom.xml
+++ b/apm-protocol/apm-network/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-protocol</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/apm-network/pom.xml
+++ b/apm-protocol/apm-network/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-protocol</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/pom.xml
+++ b/apm-protocol/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-protocol/pom.xml
+++ b/apm-protocol/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-core</artifactId>

--- a/apm-sniffer/apm-agent-core/pom.xml
+++ b/apm-sniffer/apm-agent-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-agent-core</artifactId>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-agent</artifactId>

--- a/apm-sniffer/apm-agent/pom.xml
+++ b/apm-sniffer/apm-agent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/activemq-artemis-jakarta-client-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-artemis-jakarta-client-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/activemq-artemis-jakarta-client-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/activemq-artemis-jakarta-client-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/aerospike-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/aerospike-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/aerospike-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/aerospike-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.84.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.84.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-armeria-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.84.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.84.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-armeria-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.85.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.85.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-armeria-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.85.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-0.85.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-armeria-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-1.0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-1.0.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-armeria-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-1.0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/apm-armeria-1.0.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-armeria-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/apm-armeria-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-sdk-plugin/asynchttpclient-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/asynchttpclient-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/asynchttpclient-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/asynchttpclient-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/avro-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/avro-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/avro-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/avro-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/baidu-brpc-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/baidu-brpc-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/apm-sdk-plugin/baidu-brpc-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/baidu-brpc-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/apm-sdk-plugin/baidu-brpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/baidu-brpc-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/apm-sdk-plugin/baidu-brpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/baidu-brpc-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/apm-sdk-plugin/c3p0-0.9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/c3p0-0.9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/c3p0-0.9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/c3p0-0.9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/canal-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cassandra-java-driver-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.1-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/clickhouse-0.3.2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cxf-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cxf-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/cxf-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/cxf-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dbcp-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dbcp-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dbcp-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dbcp-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/druid-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/druid-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/druid-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/druid-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-2.7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-3.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-3.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-3.x-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-3.x-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-conflict-patch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/dubbo-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elastic-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticjob-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticjob-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticjob-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticjob-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-java-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-java-plugin/pom.xml
@@ -17,15 +17,13 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-elasticsearch-java-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/elasticsearch-java-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/elasticsearch-java-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-elasticsearch-java-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/feign-default-http-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/finagle-6.25.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-12.x-15.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-12.x-15.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-12.x-15.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-12.x-15.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-16plus-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-16plus-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-16plus-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-16plus-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-8.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-8.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/graphql-9.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>graphql-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-sdk-plugin/graphql-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/graphql-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-work-threadpool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-work-threadpool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-grizzly-2.x-4.x-work-threadpool-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-work-threadpool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grizzly-2.3.x-4.x-work-threadpool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grizzly-2.x-4.x-work-threadpool-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-grpc-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/grpc-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/guava-eventbus-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/guava-eventbus-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/guava-eventbus-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/guava-eventbus-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/h2-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hbase-1.x-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hbase-1.x-2.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-hbase-1.x-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/hbase-1.x-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hbase-1.x-2.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-hbase-1.x-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/hikaricp-3.x-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hikaricp-3.x-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hikaricp-3.x-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hikaricp-3.x-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-httpClient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpClient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpClient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpasyncclient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpasyncclient-4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-httpasyncclient-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-httpclient-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-3.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpclient-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-httpclient-5.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpclient-5.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-commons/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpclient-commons</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/httpclient-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/httpclient-commons/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-httpclient-commons</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/hutool-plugins/hutool-http-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hutool-plugins/hutool-http-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>hutool-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hutool-plugins/hutool-http-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hutool-plugins/hutool-http-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>hutool-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hutool-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hutool-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hutool-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hutool-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/hystrix-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/influxdb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/influxdb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>apm-sdk-plugin</artifactId>
     <groupId>org.apache.skywalking</groupId>
-    <version>9.7.0</version>
+    <version>9.8.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/influxdb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/influxdb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>apm-sdk-plugin</artifactId>
     <groupId>org.apache.skywalking</groupId>
-    <version>9.7.0-SNAPSHOT</version>
+    <version>9.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jdbc-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>jedis-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-2.x-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>jedis-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jedis-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/jedis-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>jedis-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <properties>

--- a/apm-sniffer/apm-sdk-plugin/jedis-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jedis-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/apm-sniffer/apm-sdk-plugin/jersey-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jersey-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jersey-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jersey-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jersey-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jersey-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jersey-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jersey-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-11.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-11.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-11.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-11.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-client-9.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-12.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-12.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-12.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-12.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/jetty-server-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>jetty-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>jetty-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jetty-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/jetty-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-thread-pool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jetty-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jetty-thread-pool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jsonrpc4j-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jsonrpc4j-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/jsonrpc4j-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/jsonrpc4j-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/kafka-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-kafka-commons</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/kafka-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-kafka-commons</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kafka-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/kylin-jdbc-2.6.x-3.x-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kylin-jdbc-2.6.x-3.x-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/kylin-jdbc-2.6.x-3.x-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/kylin-jdbc-2.6.x-3.x-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-5.x-6.4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-5.x-6.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>lettuce-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-lettuce-5.x-6.4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-5.x-6.4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-5.x-6.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>lettuce-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-lettuce-5.x-6.4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-6.5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-6.5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>lettuce-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>apm-lettuce-6.5.x-plugin</artifactId>
 

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-6.5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-6.5.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>lettuce-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <artifactId>apm-lettuce-6.5.x-plugin</artifactId>
 

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>lettuce-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-lettuce-common</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/lettuce-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>lettuce-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-lettuce-common</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>lettuce-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/lettuce-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/lettuce-plugins/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>lettuce-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>light4j-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/light4j-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>light4j-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>light4j-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/light4j-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>light4j-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mariadb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mariadb-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mariadb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mariadb-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mariadb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mariadb-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mariadb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mariadb-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-client-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-client-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>micronaut-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-client-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-client-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>micronaut-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-server-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-server-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>micronaut-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-server-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/micronaut-plugins/micronaut-http-server-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>micronaut-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/micronaut-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/micronaut-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/micronaut-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/micronaut-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-mongodb-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mongodb-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mongodb-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-mongodb-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-5.x-plugin/pom.xml
@@ -17,15 +17,13 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-mongodb-5.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/mongodb-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mongodb-5.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mongodb-5.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/motan-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mssql-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mssql-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mssql-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mssql-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mssql-jdbc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mssql-jdbc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mssql-jdbc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mssql-jdbc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mssql-jtds-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mssql-jtds-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mssql-jtds-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mssql-jtds-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-5.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/mysql-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nats-2.14.x-2.16.5-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nats-2.14.x-2.16.5-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/apm-sniffer/apm-sdk-plugin/nats-2.14.x-2.16.5-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nats-2.14.x-2.16.5-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/apm-sniffer/apm-sdk-plugin/neo4j-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/neo4j-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/neo4j-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/neo4j-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/netty-socketio-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/http-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/mvc-annotation-1.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>nutz-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>nutz-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/nutz-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nutz-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/okhttp-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/okhttp-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/okhttp-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/play-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/play-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-play-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/play-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/play-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-play-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-sdk-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-sdk-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/postgresql-8.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-2.2-2.7-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-2.2-2.7-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-2.2-2.7-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-2.2-2.7-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-2.8.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-2.8.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/pulsar-common/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/pulsar-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/quasar-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/quasar-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-quasar-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/quasar-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/quasar-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-quasar-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rabbitmq-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-redisson-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/redisson-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-redisson-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>resteasy-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>resteasy-server-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-server-3.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>resteasy-server-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-server-4.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>resteasy-server-6.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/resteasy-plugin/resteasy-server-6.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>resteasy-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>resteasy-server-6.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>apm-sdk-plugin</artifactId>
 		<groupId>org.apache.skywalking</groupId>
-		<version>9.7.0-SNAPSHOT</version>
+		<version>9.7.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>apm-sdk-plugin</artifactId>
 		<groupId>org.apache.skywalking</groupId>
-		<version>9.7.0</version>
+		<version>9.8.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-client-java-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-client-java-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/rocketMQ-client-java-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/rocketMQ-client-java-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>servicecomb-plugin</artifactId>
     <groupId>org.apache.skywalking</groupId>
-    <version>9.7.0-SNAPSHOT</version>
+    <version>9.7.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servicecomb-plugin/servicecomb-java-chassis-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>servicecomb-plugin</artifactId>
     <groupId>org.apache.skywalking</groupId>
-    <version>9.7.0</version>
+    <version>9.8.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servlet-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servlet-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/servlet-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/servlet-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.0.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.0.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.0.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.1.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.1.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.1.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-4.1.0-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-5.0.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-5.0.0-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-5.0.0-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/shardingsphere-plugins/sharding-sphere-5.0.0-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>shardingsphere-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/sofarpc-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/solon-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solon-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>solon-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/solon-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solon-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>solon-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/solrj-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/async-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/concurrent-util-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/core-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-5.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/mvc-annotation-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>spring-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/resttemplate-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/scheduled-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/scheduled-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/scheduled-annotation-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/scheduled-annotation-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-ai-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-ai-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-ai-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-ai-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-cloud</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>netflix-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-cloud</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>netflix-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>netflix-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-cloud-feign-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/netflix-plugins/spring-cloud-feign-1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>netflix-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spring-cloud-feign-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-cloud</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>spring-cloud</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/spring-cloud-feign-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/spring-cloud-feign-2.x-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.skywalking</groupId>
     <artifactId>spring-cloud</artifactId>
-    <version>9.7.0</version>
+    <version>9.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>apm-spring-cloud-feign-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/spring-cloud-feign-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-cloud/spring-cloud-feign-2.x-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.skywalking</groupId>
     <artifactId>spring-cloud</artifactId>
-    <version>9.7.0-SNAPSHOT</version>
+    <version>9.7.0</version>
   </parent>
 
   <artifactId>apm-spring-cloud-feign-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spring-kafka-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-1.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-1.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-kafka-1.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spring-kafka-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-kafka-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-kafka-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-rabbitmq-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-rabbitmq-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-rabbitmq-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-rabbitmq-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-rabbitmq-plugin/pom.xml
@@ -16,15 +16,13 @@
   ~ limitations under the License.
   ~
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>spring-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spring-rabbitmq-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-5.x-webclient-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spring-plugins/spring-webflux-6.x-webclient-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spymemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/spymemcached-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spymemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/struts2-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/struts2-7.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/struts2-7.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/thrift-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/thrift-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/thrift-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/thrift-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-thread-pool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/tomcat-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/tomcat-thread-pool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>undertow-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>undertow-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>undertow-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-plugins/undertow-2.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>undertow-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/undertow-worker-thread-pool-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>vertx-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vertx-plugins</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-3.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/vertx-plugins/vertx-core-4.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>vertx-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/websphere-liberty-23.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/websphere-liberty-23.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/websphere-liberty-23.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/websphere-liberty-23.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-xmemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xmemcached-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>apm-sdk-plugin</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-xmemcached-2.x-plugin</artifactId>

--- a/apm-sniffer/apm-sdk-plugin/xxl-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xxl-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-sdk-plugin/xxl-job-2.x-plugin/pom.xml
+++ b/apm-sniffer/apm-sdk-plugin/xxl-job-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-sdk-plugin</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-test-tools/pom.xml
+++ b/apm-sniffer/apm-test-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-test-tools</artifactId>

--- a/apm-sniffer/apm-test-tools/pom.xml
+++ b/apm-sniffer/apm-test-tools/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-test-tools</artifactId>

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-kafka-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-kafka-activation/pom.xml
@@ -21,7 +21,7 @@
 <parent>
     <artifactId>apm-toolkit-activation</artifactId>
     <groupId>org.apache.skywalking</groupId>
-    <version>9.7.0</version>
+    <version>9.8.0-SNAPSHOT</version>
 </parent>
 <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-kafka-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-kafka-activation/pom.xml
@@ -21,7 +21,7 @@
 <parent>
     <artifactId>apm-toolkit-activation</artifactId>
     <groupId>org.apache.skywalking</groupId>
-    <version>9.7.0-SNAPSHOT</version>
+    <version>9.7.0</version>
 </parent>
 <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-log4j-2.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logback-1.x-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logging-common/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logging-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-logging-common/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-logging-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-meter-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-meter-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-meter-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-meter-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-micrometer-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-micrometer-activation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-micrometer-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-micrometer-activation/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-opentracing-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-trace-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/apm-toolkit-webflux-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apm-toolkit-activation</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/apm-toolkit-activation/pom.xml
+++ b/apm-sniffer/apm-toolkit-activation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/bootstrap-plugins/jdk-forkjoinpool-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-forkjoinpool-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-forkjoinpool-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-forkjoinpool-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-http-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-httpclient-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-httpclient-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>bootstrap-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-httpclient-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-httpclient-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>bootstrap-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threading-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>bootstrap-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threadpool-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threadpool-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>bootstrap-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-threadpool-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-threadpool-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>bootstrap-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-virtual-thread-executor-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-virtual-thread-executor-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>bootstrap-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/jdk-virtual-thread-executor-plugin/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/jdk-virtual-thread-executor-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>bootstrap-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bootstrap-plugins/pom.xml
+++ b/apm-sniffer/bootstrap-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bytebuddy-patch/pom.xml
+++ b/apm-sniffer/bytebuddy-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/bytebuddy-patch/pom.xml
+++ b/apm-sniffer/bytebuddy-patch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>java-agent-sniffer</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/expired-plugins/impala-jdbc-2.6.x-plugin/pom.xml
+++ b/apm-sniffer/expired-plugins/impala-jdbc-2.6.x-plugin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>expired-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-impala-jdbc-2.6.x-plugin</artifactId>

--- a/apm-sniffer/expired-plugins/impala-jdbc-2.6.x-plugin/pom.xml
+++ b/apm-sniffer/expired-plugins/impala-jdbc-2.6.x-plugin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>expired-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-impala-jdbc-2.6.x-plugin</artifactId>

--- a/apm-sniffer/expired-plugins/pom.xml
+++ b/apm-sniffer/expired-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/expired-plugins/pom.xml
+++ b/apm-sniffer/expired-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/caffeine-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/caffeine-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-caffeine-3.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/caffeine-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/caffeine-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-caffeine-3.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/customize-enhance-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/ehcache-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/ehcache-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/ehcache-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/ehcache-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/fastjson-1.2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/fastjson-1.2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-fastjson-1.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/fastjson-1.2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/fastjson-1.2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-fastjson-1.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-gson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/gson-2.8.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-gson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/guava-cache-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/guava-cache-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-guava-cache-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/guava-cache-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/guava-cache-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-guava-cache-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/jackson-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/jackson-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jackson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/jackson-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/jackson-2.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-jackson-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/kotlin-coroutine-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/kotlin-coroutine-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-kotlin-coroutine-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/kotlin-coroutine-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/kotlin-coroutine-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-kotlin-coroutine-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/mybatis-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/mybatis-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-mybatis-3.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/mybatis-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/mybatis-3.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mybatis-3.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/nacos-client-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/nacos-client-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/nacos-client-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/nacos-client-2.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/netty-http-4.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/netty-http-4.1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/netty-http-4.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/netty-http-4.1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/mvc-annotation-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/mvc-annotation-6.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/mvc-annotation-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/mvc-annotation-6.x-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.0.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.0.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-cloud</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-cloud-gateway-2.0.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.0.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.0.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-cloud</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spring-cloud-gateway-2.0.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-cloud</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-spring-cloud-gateway-2.1.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-2.1.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-cloud</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-cloud-gateway-2.1.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-cloud</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-3.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-3.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-cloud</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-cloud</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/gateway-4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-cloud</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>optional-spring-cloud</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/optional-spring-cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-spring-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>optional-spring-cloud</artifactId>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/resttemplate-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/resttemplate-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/resttemplate-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/resttemplate-6.x-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-annotation-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-tx-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-5.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/optional-spring-plugins/spring-webflux-6.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-spring-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/pom.xml
+++ b/apm-sniffer/optional-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/quartz-scheduler-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/quartz-scheduler-2.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-quartz-scheduler-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/quartz-scheduler-2.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/quartz-scheduler-2.x-plugin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-quartz-scheduler-2.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/sentinel-1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/sentinel-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/sentinel-1.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/sentinel-1.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/shenyu-2.4.x-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-ignore-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-sampler-cpu-policy-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-sampler-cpu-policy-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/trace-sampler-cpu-policy-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/trace-sampler-cpu-policy-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-zookeeper-3.4.x-plugin</artifactId>

--- a/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
+++ b/apm-sniffer/optional-plugins/zookeeper-3.4.x-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.skywalking</groupId>
         <artifactId>optional-plugins</artifactId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
 
     <artifactId>apm-zookeeper-3.4.x-plugin</artifactId>

--- a/apm-sniffer/optional-reporter-plugins/kafka-config-extension/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/kafka-config-extension/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-reporter-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-reporter-plugins/kafka-config-extension/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/kafka-config-extension/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>optional-reporter-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-reporter-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/kafka-reporter-plugin/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>optional-reporter-plugins</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-reporter-plugins/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/optional-reporter-plugins/pom.xml
+++ b/apm-sniffer/optional-reporter-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent-sniffer</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0-SNAPSHOT</version>
+        <version>9.7.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-sniffer/pom.xml
+++ b/apm-sniffer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>java-agent</artifactId>
         <groupId>org.apache.skywalking</groupId>
-        <version>9.7.0</version>
+        <version>9.8.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/changes/changes-9.7.0.md
+++ b/changes/changes-9.7.0.md
@@ -1,0 +1,38 @@
+Changes by Version
+==================
+Release Notes.
+
+9.7.0
+------------------
+
+* Fix `plugin.http.include_http_headers` not working on Spring Boot 3.x / Jakarta EE (apache/skywalking#13938).
+* Support `plugin.http.include_http_headers` in the Tomcat plugin, collecting the configured request headers as the `http.headers` tag on Tomcat entry spans (e.g. RESTEasy on Tomcat), consistent with the Spring MVC plugin. Honors the shared `plugin.http.http_headers_length_threshold`.
+* Unify the Tomcat plugins into a single `tomcat` plugin (Tomcat 7 - 10) and the Jetty server plugins into a single `jetty-server` plugin (Jetty 9 - 11), each supporting both `javax.servlet` and `jakarta.servlet`. Breaking change: plugin names `tomcat-7.x/8.x` and `tomcat-10.x` are replaced by `tomcat`, and `jetty-server-9.x` and `jetty-server-11.x` by `jetty-server`; update `plugin.exclude_plugins` if you reference the old names.
+* Add a Jetty 12 server plugin (`jetty-server-12.x`). Jetty 12 removed the `HttpChannel` handle target and moved request handling to the async `Server#handle(Request, Response, Callback)` core API, so it needs a separate plugin from the merged `jetty-server`.
+* Add a Struts 7 plugin (`struts2-7.x`) for Jakarta Struts, whose `DefaultActionInvocation` moved to `org.apache.struts2`.
+* Added support for Lettuce reactive Redis commands.
+* Add tracing support for `invokeAll` and `invokeAny` in the JDK thread pool plugin (`jdk-threadpool-plugin`).
+* Add Spring AI 1.x plugin and GenAI layer.
+* Fix httpclient-5.x plugin injecting sw8 propagation headers into ClickHouse HTTP requests (port 8123), causing HTTP 400. Add `PROPAGATION_EXCLUDE_PORTS` config to skip tracing (including header injection) for specified ports in the classic client interceptor.
+* Add Spring RabbitMQ 2.x - 4.x plugin.
+* Extend MySQL plugin to support MySQL Connector/J 8.4.0 and 9.x (9.0 -> 9.6).
+* Extend MariaDB plugin to support MariaDB Connector/J 2.7.x.
+* Extend MongoDB 4.x plugin to support MongoDB Java Driver 4.2 -> 4.10. Fix db.bind_vars extraction for driver 4.9+ where InsertOperation/DeleteOperation/UpdateOperation classes were removed.
+* Fix MongoDB 4.x plugin for driver 4.11+ where Cluster.getDescription() was removed, use getCurrentDescription() instead.
+* Extend Feign plugin to support OpenFeign 10.x, 11.x, 12.1.
+* Add Feign 12.2+ PathVar support (BuildTemplateByResolvingArgs moved to RequestTemplateFactoryResolver).
+* Extend Undertow plugin to support Undertow 2.1.x, 2.2.x, 2.3.x.
+* Extend GraphQL plugin to support graphql-java 18 -> 24 (20+ requires JDK 17).
+* Extend Spring Kafka plugin to support Spring Kafka 2.4 -> 2.9 and 3.0 -> 3.3.
+* Enhance test/plugin/run.sh to support extra Maven properties per version in support-version.list (format: version,key=value).
+* Add MariaDB 3.x plugin (all classes renamed in 3.x).
+* Extend Jedis 4.x plugin to support Jedis 5.x (fix witness method for 5.x compatibility).
+* Add Elasticsearch Java client (co.elastic.clients:elasticsearch-java) plugin for 7.16.x-9.x.
+* Only publish `apm-application-toolkit` modules to Maven Central. Agent and plugins are distributed via download package and Docker images.
+* Add unified release script (`tools/releasing/release.sh`) with two-step flow: `prepare-vote` and `vote-passed`.
+* Fix an issue where `JDBCPluginConfig.Plugin.JDBC.SQL_BODY_MAX_LENGTH` was not honored by clickhouse-0.3.1 and clickhouse-0.3.2.x plugins.
+- Add tracing support for vector-store retrieval operations.
+* Fix agent lifecycle events: the Start event now carries the service instance name, and the Shutdown event is delivered on graceful JVM exit. `ServiceManager` prepares/starts higher-priority `BootService`s first and shuts them down last (matching `BootService#priority()`), and the shutdown event refreshes its gRPC deadline before sending.
+* Fix the `SenderSendInterceptor` in the nutz-plugins/http-1.x-plugin to avoid NPE caused by the Response status.
+
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/249?closed=1)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>java-agent</artifactId>
-    <version>9.7.0</version>
+    <version>9.8.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.apache</groupId>
@@ -46,7 +46,7 @@
         <url>https://github.com/apache/skywalking-java</url>
         <connection>scm:git:https://github.com/apache/skywalking-java.git</connection>
         <developerConnection>scm:git:https://github.com/apache/skywalking-java.git</developerConnection>
-        <tag>v9.7.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.apache.skywalking</groupId>
     <artifactId>java-agent</artifactId>
-    <version>9.7.0-SNAPSHOT</version>
+    <version>9.7.0</version>
 
     <parent>
         <groupId>org.apache</groupId>
@@ -46,7 +46,7 @@
         <url>https://github.com/apache/skywalking-java</url>
         <connection>scm:git:https://github.com/apache/skywalking-java.git</connection>
         <developerConnection>scm:git:https://github.com/apache/skywalking-java.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v9.7.0</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Release Apache SkyWalking Java Agent 9.7.0.

- Maven release:prepare completed (tag `v9.7.0` created)
- CHANGES.md archived to `changes/changes-9.7.0.md`
- Next development version: 9.8.0-SNAPSHOT