### PR TITLE
Prompt for the next milestone ID when resetting CHANGES.md

### DIFF
--- a/docs/en/contribution/release-java-agent.md
+++ b/docs/en/contribution/release-java-agent.md
@@ -76,6 +76,14 @@ Then run `gpgconf --kill gpg-agent` and `gpg --sign /dev/null` to cache it.
 4. **upload** — upload to Apache SVN `dist/dev` (prompts for SVN credentials)
 5. **email vote** — print vote email template with pre-filled version, commit ID, submodule commit, and checksums
 
+Before the long build starts, **prepare** asks for the GitHub milestone ID of the next
+development version, which it writes into the reset `CHANGES.md`. Look up the
+`Java - <next_version>` milestone at https://github.com/apache/skywalking/milestones and
+enter its number. The ID is checked against that milestone's title, and you are warned if
+they disagree. Set `NEXT_MILESTONE=<id>` to answer non-interactively; leave the prompt
+blank to keep the `milestone/xxx` placeholder and edit it by hand before merging the
+release PR.
+
 Copy the generated email and send it to `dev@skywalking.apache.org`. Voting remains open for at least 72 hours. At least 3 (+1 binding) PMC votes with more +1 than -1 are required.
 
 ## Vote Check

--- a/tools/releasing/release.sh
+++ b/tools/releasing/release.sh
@@ -161,6 +161,40 @@ cmd_prepare() {
     echo "  Next dev version: ${next_version}-SNAPSHOT"
     echo "  Branch: ${branch_name}"
     echo ""
+
+    # At the end of this step CHANGES.md is reset for the next development
+    # version, and its milestone link needs that version's GitHub milestone ID.
+    # Ask for it here, up front, so the release does not stop for input after
+    # the long release:prepare build. Set NEXT_MILESTONE=<id> to skip the prompt.
+    local next_milestone="${NEXT_MILESTONE:-}"
+    if [ -z "$next_milestone" ]; then
+        echo "  CHANGES.md will be reset for ${next_version}, and its milestone link needs an ID."
+        echo "  Find 'Java - ${next_version}' at https://github.com/apache/skywalking/milestones"
+        read -rp "  Milestone ID for ${next_version} (number, or blank to fill in manually later): " next_milestone
+    fi
+    if [ -n "$next_milestone" ]; then
+        case "$next_milestone" in
+            *[!0-9]*) error "Milestone ID must be a number, got: ${next_milestone}" ;;
+        esac
+        # gh api writes the error body to stdout on failure, so gate on its
+        # exit status rather than letting a 404 payload become the title.
+        local milestone_title
+        if ! milestone_title=$(gh api "repos/apache/skywalking/milestones/${next_milestone}" -q .title 2>/dev/null); then
+            milestone_title=""
+        fi
+        if [ -z "$milestone_title" ]; then
+            warn "  Could not verify milestone ${next_milestone} on apache/skywalking; using it as given."
+        elif [ "$milestone_title" != "Java - ${next_version}" ]; then
+            warn "  Milestone ${next_milestone} is '${milestone_title}', expected 'Java - ${next_version}'. Double-check it."
+        else
+            info "  Next milestone: ${next_milestone} (${milestone_title})"
+        fi
+    else
+        next_milestone="xxx"
+        warn "  No milestone ID given; CHANGES.md will keep 'milestone/xxx' - edit it before merging the release PR."
+    fi
+
+    echo ""
     read -rp "Continue? [y/N] " confirm
     if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
         info "Aborted."
@@ -208,7 +242,7 @@ ${next_version}
 ------------------
 
 
-All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/xxx?closed=1)
+All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/${next_milestone}?closed=1)
 
 ------------------
 Find change logs of all versions [here](changes).


### PR DESCRIPTION
### Problem

When `cmd_prepare` resets `CHANGES.md` for the next development version, it writes a
literal placeholder that nothing ever fills in:

```
All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/xxx?closed=1)
```

The release flow has no step that resolves `xxx`, so unless the release manager
spots it and edits by hand, the placeholder rides the release PR straight into
`main` and the next version's change log ships pointing at a dead milestone link.

This was hit while preparing 9.7.0 and had to be corrected manually on the release
branch.

### Fix

Ask for the milestone ID and substitute it.

- **Asked up front**, next to the version confirmation, rather than after
  `release:prepare` — so the release doesn't stop for input in the middle of a
  multi-minute build.
- **Validated as numeric**, and cross-checked against the milestone's title on
  `apache/skywalking`. Entering last release's ID by mistake is reported before
  anything is committed:
  ```
  [WARN]   Milestone 249 is 'Java - 9.7.0', expected 'Java - 9.8.0'. Double-check it.
  ```
- **`NEXT_MILESTONE=<id>`** answers non-interactively for scripted runs.
- **A blank answer** keeps the previous placeholder behaviour, but now warns rather
  than doing it silently.

`gh api` writes its error body to *stdout* on failure, so the title lookup gates on
gh's exit status — otherwise a 404 JSON payload would be reported as the milestone
name.

### Testing

`bash -n` passes. All five input paths exercised against the live GitHub API:

| Input | Result |
|---|---|
| `263` (correct) | `[INFO] Next milestone: 263 (Java - 9.8.0)` |
| `249` (last release's) | `[WARN] Milestone 249 is 'Java - 9.7.0', expected 'Java - 9.8.0'` |
| `999999` (nonexistent) | `[WARN] Could not verify milestone 999999; using it as given` |
| `26x3` (non-numeric) | `[ERROR] Milestone ID must be a number` — aborts |
| blank | `[WARN] ... will keep 'milestone/xxx'` |

The generated `CHANGES.md` is byte-identical to the hand-written correction made on
the 9.7.0 release branch (`diff` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)