### PR TITLE
fix: restore Log4j2Plugins.dat in apm-toolkit-log4j-2.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Release Notes.
 ------------------
 
 * Add Spring LDAP 3.3.x-4.x plugin.
+* Fix the Log4j2 plugin descriptor (`Log4j2Plugins.dat`) missing from the `apm-toolkit-log4j-2.x` jar since 9.5.0, which broke `%traceId` and `%sw_ctx` resolution in Log4j2 `PatternLayout` (apache/skywalking#14006).
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/263?closed=1)
 

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -39,4 +39,34 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!--
+                      When annotationProcessorPaths is declared explicitly,
+                      javac stops discovering processors from the classpath.
+                      log4j-core's PluginProcessor (which generates
+                      Log4j2Plugins.dat) must be listed here explicitly,
+                      otherwise %traceId / %sw_ctx resolve to built-in patterns.
+                    -->
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-core</artifactId>
+                            <version>${log4j-core.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
+++ b/apm-application-toolkit/apm-toolkit-log4j-2.x/pom.xml
@@ -47,18 +47,15 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <!--
-                      When annotationProcessorPaths is declared explicitly,
-                      javac stops discovering processors from the classpath.
-                      log4j-core's PluginProcessor (which generates
-                      Log4j2Plugins.dat) must be listed here explicitly,
-                      otherwise %traceId / %sw_ctx resolve to built-in patterns.
+                      The root POM declares annotationProcessorPaths, which makes
+                      javac stop discovering processors from the classpath.
+                      Append log4j-core's PluginProcessor (which generates
+                      Log4j2Plugins.dat) so that %traceId / %sw_ctx resolve to the
+                      toolkit converters instead of built-in Log4j2 patterns.
+                      combine.children="append" keeps the Lombok entry inherited
+                      from the root POM.
                     -->
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
+                    <annotationProcessorPaths combine.children="append">
                         <path>
                             <groupId>org.apache.logging.log4j</groupId>
                             <artifactId>log4j-core</artifactId>


### PR DESCRIPTION
### Problem

Since **9.5.0**, the released `apm-toolkit-log4j-2.x` jar no longer contains the Log4j2 plugin descriptor:

```
META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat
```

Without that descriptor Log4j2 cannot discover `TraceIdConverter`, so `%traceId` and `%sw_ctx` in a `PatternLayout` silently break — they are greedily matched as the built-in `%t` (thread name) followed by literal text.

Verified against Maven Central:

| Version | `Log4j2Plugins.dat` |
|---------|---------------------|
| 9.0.0 – 9.4.0 | present |
| 9.5.0 – 9.7.0 | **missing** |

### Root Cause

9.5.0 added an `annotationProcessorPaths` block to `maven-compiler-plugin` in the root `pom.xml`, listing only Lombok. Once `annotationProcessorPaths` is declared explicitly, javac stops discovering annotation processors from the compile classpath. The `log4j-core` jar is declared as `provided` in this module, and Log4j2's `PluginProcessor` — previously picked up from that classpath — is what generates `Log4j2Plugins.dat`. With the processor list narrowed to Lombok only, `PluginProcessor` never runs and the descriptor is silently dropped.

### Fix

Declare the compiler plugin in this module with `annotationProcessorPaths` containing both Lombok (preserving parent behaviour) and `log4j-core` (restoring the `PluginProcessor`).

### Verification

The module's Java source files (`TraceIdConverter`, `SkyWalkingContextConverter`, `Log4j2OutputAppender`, `Log4j2SkyWalkingContextOutputAppender`) do not use Lombok annotations, so adding it to the path is safe but optional.

### References

- Reported upstream: apache/skywalking#14006
