### PR TITLE
Deploy the root java-agent POM to Maven Central

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ Release Notes.
   removed `Signal#getContext()` in 3.5.0. Existing `apm-toolkit-webflux` jars (9.7.0 and earlier)
   remain instrumented by the agent, so upgrading the agent alone does not force a change.
 * Fix the Log4j2 plugin descriptor (`Log4j2Plugins.dat`) missing from the `apm-toolkit-log4j-2.x` jar since 9.5.0, which broke `%traceId` and `%sw_ctx` resolution in Log4j2 `PatternLayout` (apache/skywalking#14006).
+* Deploy the root `java-agent` POM to Maven Central again. It is the parent of
+  `apm-application-toolkit` and therefore of every published toolkit artifact, but 9.7.0 skipped it,
+  so resolving any `org.apache.skywalking:apm-toolkit-*:9.7.0` failed with `Non-resolvable parent POM
+  ... Could not find artifact org.apache.skywalking:java-agent:pom:9.7.0` (apache/skywalking#13988).
 
 All issues and pull requests are [here](https://github.com/apache/skywalking/milestone/263?closed=1)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,7 +275,18 @@ Follow `.github/PULL_REQUEST_TEMPLATE` based on change type:
 ### PR Description
 - Bug fixes: Explain the bug and how it's fixed, add regression test
 - New features: Link to design doc if non-trivial, update docs, add tests
-- Do NOT add AI assistant as co-author
+
+### Attribution
+The human contributor is the sole author of every commit and pull request. Nothing may
+attribute a contribution, in whole or in part, to an AI assistant:
+- No `Co-Authored-By:` trailer naming Claude or any other AI assistant
+- No `Claude-Session:`, session URLs, or other AI tool metadata in commit messages
+- No "Generated with ..." footer in commit messages
+
+This applies to commit messages and to anything that makes an assistant show up as a
+contributor on GitHub. It **overrides** any default attribution the tool is configured to
+add: if a global or session setting says to append a co-author trailer, this file wins and
+the trailer is omitted.
 
 ## CI/CD
 

--- a/docs/en/contribution/release-java-agent.md
+++ b/docs/en/contribution/release-java-agent.md
@@ -91,6 +91,11 @@ All PMC members and committers should check these before casting +1 votes.
 
 1. Features test.
 1. All artifacts in staging repository are published with `.asc`, `.md5`, and `*sha1` files.
+1. The staging repository contains `org/apache/skywalking/java-agent/x.y.z/java-agent-x.y.z.pom`.
+Only the toolkit modules are published, but this root POM is their parent (through
+`apm-application-toolkit`); without it every `org.apache.skywalking:apm-toolkit-*` artifact fails to
+resolve with `Non-resolvable parent POM`. Verify with a clean local repository:
+`mvn -U -Dmaven.repo.local=$(mktemp -d) dependency:get -Dartifact=org.apache.skywalking:apm-toolkit-logback-1.x:x.y.z -DremoteRepositories=https://repository.apache.org/content/repositories/<STAGING_REPO_ID>`
 1. Source code and distribution package (`apache-skywalking-java-agent-x.y.z-src.tar.gz`, `apache-skywalking-java-agent-x.y.z.tar.gz`)
 are found in `https://dist.apache.org/repos/dist/dev/skywalking/java-agent/x.y.z` with `.asc` and `.sha512`.
 1. `LICENSE` and `NOTICE` are in the source code and distribution package.

--- a/docs/en/setup/service-agent/java-agent/containerization.md
+++ b/docs/en/setup/service-agent/java-agent/containerization.md
@@ -23,7 +23,7 @@ enable SkyWalking agent, it should be adopted automatically.
 
 Currently, SkyWalking provides two ways to install the java agent on your services on Kubernetes.
 
-1. To use the java agent more natively, you can try the [java agent injector](https://github.com/apache/skywalking-swck/blob/master/docs/java-agent-injector.md) to inject the java agent image as a sidecar.
+1. To use the java agent more natively, you can try the [java agent injector](https://skywalking.apache.org/docs/skywalking-swck/latest/en/setup/java-agent-injector/) to inject the java agent image as a sidecar.
 
 2. If you think it's hard to install the injector, you can also use this java agent image as a sidecar as below.
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,10 @@
         <jmh.version>1.33</jmh.version>
         <gmaven-plugin.version>1.5</gmaven-plugin.version>
         <checkstyle.fails.on.error>true</checkstyle.fails.on.error>
-        <!-- Only publish toolkit modules to Maven Central; agent/plugins are distributed via package -->
+        <!-- Only publish toolkit modules to Maven Central; agent/plugins are distributed via package.
+             This root POM is the exception: it is the parent of apm-application-toolkit, so it has to
+             be published too or the toolkit POMs cannot resolve their parent chain. See the
+             maven-deploy-plugin declaration below, which re-enables deployment for this POM alone. -->
         <maven.deploy.skip>true</maven.deploy.skip>
 		<maven-docker-plugin.version>0.46.0</maven-docker-plugin.version>
     </properties>
@@ -369,6 +372,19 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- maven.deploy.skip is true for the whole reactor, which would skip this root POM as
+                 well. It is the parent of apm-application-toolkit and therefore of every published
+                 toolkit artifact, so Maven Central needs it: without it, resolving any
+                 org.apache.skywalking:apm-toolkit-* artifact fails with "Non-resolvable parent POM".
+                 inherited=false keeps the exception to this POM only; the modules still skip deploy,
+                 apart from apm-application-toolkit and its children, which opt back in themselves. -->
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>


### PR DESCRIPTION
### Fix bug

Resolves apache/skywalking#13988

#### The bug

`org.apache.skywalking:java-agent:9.7.0` is missing from Maven Central, so **every** toolkit artifact of 9.7.0 is unresolvable:

```
[ERROR] Non-resolvable parent POM for org.apache.skywalking:apm-application-toolkit:9.7.0:
        Could not find artifact org.apache.skywalking:java-agent:pom:9.7.0 in central
```

Reproduce with a clean local repository:

```shell
mvn -U -Dmaven.repo.local=$(mktemp -d) \
    dependency:get -Dartifact=org.apache.skywalking:apm-toolkit-logback-1.x:9.7.0
```

Status on `repo.maven.apache.org` for 9.7.0: all ten `apm-toolkit-*` modules and `apm-application-toolkit` are present (200); `java-agent` is 404. The listing under `/org/apache/skywalking/java-agent/` stops at `9.6.0/`.

#### Cause

#805 ("Only publish toolkit to Maven Central") set `<maven.deploy.skip>true</maven.deploy.skip>` in the root POM and re-enabled deployment in `apm-application-toolkit`. The root POM is itself the parent of `apm-application-toolkit`, so skipping it breaks the parent chain of everything published:

```
apm-toolkit-logback-1.x:9.7.0
  └─ parent apm-application-toolkit:9.7.0   published
       └─ parent java-agent:9.7.0           skipped -> 404
```

9.7.0 (tagged 2026-08-12) is the first release containing #805 (2026-04-11), which matches 9.6.0 resolving and 9.7.0 not.

#### The fix

Declare `maven-deploy-plugin` at the root with `inherited=false` and `skip=false`. Plugin configuration takes precedence over the `maven.deploy.skip` property, and `inherited=false` confines the exception to the root POM.

Verified against the effective POMs:

| module | `maven.deploy.skip` | deploy plugin `<skip>` | deployed |
|---|---|---|---|
| `java-agent` (root) | `true` | `false` | yes |
| `apm-commons`, `apm-protocol`, `apm-sniffer` | `true` | none | no |
| `apm-application-toolkit` + toolkit modules | `false` | none | yes |

and by running `./mvnw -N deploy -DaltDeploymentRepository=local::default::file://...`, which now uploads `java-agent-9.8.0-SNAPSHOT.pom`.

The release vote checklist gains the corresponding item, since this failure is invisible during the release — the staged artifacts all look fine, and only a user resolving from a clean repository hits it.

#### Note on 9.7.0

This fix only covers 9.8.0 onward. 9.7.0 stays broken until `java-agent:9.7.0:pom`, built from the `v9.7.0` tag, is staged and released separately. That coordinate was never published, so it is an addition rather than a modification of a released artifact.

- [x] Update `CHANGES.md`.
